### PR TITLE
SIGINT forwarding to a running subprocess

### DIFF
--- a/poethepoet/executor/base.py
+++ b/poethepoet/executor/base.py
@@ -1,6 +1,6 @@
+import signal
 from subprocess import Popen, PIPE
 import sys
-import signal
 from typing import Any, Dict, MutableMapping, Optional, Sequence, Type, TYPE_CHECKING
 from ..exceptions import PoeException
 from ..virtualenv import Virtualenv


### PR DESCRIPTION
When the running task is something infinite, let's say a web server, we should
be able to terminate it cleanly. To do that, we must forward the stop signal
to the subprocess. Previously the signal was caught by Poe, which is not desirable.

----

This PR makes sure, that you can stop poe tasks by Ctrl+C. I run into it when runnning a web server. I got a poe stacktrace instead of my projects stacktrace. This should fix it. Hope you like it. :slightly_smiling_face: 