### PR TITLE
Add ability to declare default values for env vars in pyproject.toml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -269,9 +269,16 @@ You can specify arbitrary environment variables to be set for a task by providin
 
     [tool.poe.tasks]
     serve.script = "myapp:run"
-    serve.env = { PORT = 9001 }
+    serve.env = { PORT = "9001" }
 
 Notice this example uses deep keys which can be more convenient but aren't as well supported by some toml implementations.
+
+The above example can be modified to only set the `PORT` variable if it is not already set by replacing the last line with the following:
+
+  .. code-block:: toml
+
+    serve.env.PORT.default "9001"
+
 
 You can also specify an env file (with bashlike syntax) to load per task like so:
 
@@ -362,6 +369,13 @@ You can configure environment variables to be set for all poe tasks in the pypro
   [tool.poe.env]
   VAR1 = "FOO"
   VAR2 = "BAR"
+
+As for the task level option, you can indicated that a variable should only be set if not already set like so:
+
+.. code-block:: toml
+
+  [tool.poe.env]
+  VAR1.default = "FOO"
 
 You can also specify an env file (with bashlike syntax) to load for all tasks like so:
 

--- a/poethepoet/context.py
+++ b/poethepoet/context.py
@@ -62,7 +62,7 @@ class RunContext:
         return PoeExecutor.get(
             invocation=invocation,
             context=self,
-            env=self.get_env(env),
+            env=env,
             working_dir=self.project_dir,
             dry=self.dry,
             executor_config=task_options.get("executor"),

--- a/poethepoet/task/cmd.py
+++ b/poethepoet/task/cmd.py
@@ -60,7 +60,7 @@ class CmdTask(PoeTask):
             cmd_tokens = (
                 (compat_token, bool(_QUOTED_TOKEN_PATTERN.match(compat_token)))
                 for compat_token in shlex.split(
-                    self._resolve_envvars(self.content, context, env),
+                    self._resolve_envvars(self.content, env),
                     posix=False,
                     comments=True,
                 )
@@ -70,12 +70,12 @@ class CmdTask(PoeTask):
                 (posix_token, bool(_QUOTED_TOKEN_PATTERN.match(compat_token)))
                 for (posix_token, compat_token) in zip(
                     shlex.split(
-                        self._resolve_envvars(self.content, context, env),
+                        self._resolve_envvars(self.content, env),
                         posix=True,
                         comments=True,
                     ),
                     shlex.split(
-                        self._resolve_envvars(self.content, context, env),
+                        self._resolve_envvars(self.content, env),
                         posix=False,
                         comments=True,
                     ),

--- a/poethepoet/task/script.py
+++ b/poethepoet/task/script.py
@@ -48,7 +48,7 @@ class ScriptTask(PoeTask):
 
         argv = [
             self.name,
-            *(self._resolve_envvars(token, context, env) for token in extra_args),
+            *(self._resolve_envvars(token, env) for token in extra_args),
         ]
         cmd = (
             "python",  # TODO: pre-locate python from the target env?

--- a/poetry.lock
+++ b/poetry.lock
@@ -463,12 +463,12 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
-name = "tomlkit"
-version = "0.7.0"
-description = "Style preserving TOML library"
+name = "tomli"
+version = "1.0.0"
+description = "A lil' TOML parser"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "tox"
@@ -573,7 +573,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "e58e5ee40815ee6a32da05425c249c81b960a7a1fa15dca832741b9e6a5dd430"
+content-hash = "88902cb68adfe37c607b57256dcd5d93bf57ea884a01c559fa339c02eb7851ad"
 
 [metadata.files]
 appdirs = [
@@ -900,9 +900,9 @@ toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
-tomlkit = [
-    {file = "tomlkit-0.7.0-py2.py3-none-any.whl", hash = "sha256:6babbd33b17d5c9691896b0e68159215a9387ebfa938aa3ac42f4a4beeb2b831"},
-    {file = "tomlkit-0.7.0.tar.gz", hash = "sha256:ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"},
+tomli = [
+    {file = "tomli-1.0.0-py3-none-any.whl", hash = "sha256:96e8efdf42dd939192a1cfbb89b72801473a87b2b7aa360b6921f187fa7ce5ef"},
+    {file = "tomli-1.0.0.tar.gz", hash = "sha256:09cb4fc761cdda80ae04ff7235320f8f656c30e0ac01754ce0eaa4b485b8254d"},
 ]
 tox = [
     {file = "tox-3.21.2-py2.py3-none-any.whl", hash = "sha256:0aa777ee466f2ef18e6f58428c793c32378779e0a321dbb8934848bc3e78998c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ homepage =  "https://github.com/nat-n/poethepoet"
 [tool.poetry.dependencies]
 python = "^3.6"
 pastel = "^0.2.0"
-tomlkit = ">=0.6.0,<1.0.0"
+tomli = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 black = "^19.10b0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,8 @@ import shutil
 from subprocess import PIPE, Popen
 import sys
 from tempfile import TemporaryDirectory
-import tomlkit
-from typing import Any, List, Mapping, Optional
+import tomli
+from typing import Any, Dict, List, Mapping, Optional
 import venv
 import virtualenv
 
@@ -27,7 +27,7 @@ def is_windows():
 @pytest.fixture
 def pyproject():
     with PROJECT_TOML.open("r") as toml_file:
-        return tomlkit.parse(toml_file.read())
+        return tomli.load(toml_file)
 
 
 @pytest.fixture
@@ -75,7 +75,7 @@ def run_poe_subproc(dummy_project_path, temp_file, tmp_path, is_windows):
     shell_cmd_template = (
         'python -c "'
         "{coverage_setup}"
-        "import tomlkit;"
+        "import tomli;"
         "from poethepoet.app import PoeThePoet;"
         "from pathlib import Path;"
         r"poe = PoeThePoet(cwd=r\"{cwd}\", config={config}, output={output});"
@@ -88,13 +88,14 @@ def run_poe_subproc(dummy_project_path, temp_file, tmp_path, is_windows):
         cwd: str = dummy_project_path,
         config: Optional[Mapping[str, Any]] = None,
         coverage: bool = not is_windows,
+        env: Dict[str, str] = None,
     ) -> str:
         if config is not None:
             config_path = tmp_path.joinpath("tmp_test_config_file")
             with config_path.open("w+") as config_file:
                 toml.dump(config, config_file)
                 config_file.seek(0)
-            config_arg = fr"tomlkit.parse(open(r\"{config_path}\", \"r\").read())"
+            config_arg = fr"tomli.load(open(r\"{config_path}\", \"r\"))"
         else:
             config_arg = "None"
 
@@ -106,7 +107,7 @@ def run_poe_subproc(dummy_project_path, temp_file, tmp_path, is_windows):
             output=fr"open(r\"{temp_file}\", \"w\")",
         )
 
-        env = dict(os.environ)
+        env = dict(os.environ, **(env or {}))
         if coverage:
             env["COVERAGE_PROCESS_START"] = str(PROJECT_TOML)
 

--- a/tests/fixtures/default_value/pyproject.toml
+++ b/tests/fixtures/default_value/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.poe.env]
+ONE = "!one!"
+TWO = "nope"
+THREE = "!three!"
+FOUR.default = "!four!"
+FIVE.default = "nope"
+SIX.default = "!six!"
+
+[tool.poe.tasks.test]
+cmd = "echo $ONE $TWO $THREE $FOUR $FIVE $SIX"
+env.TWO = "!two!"
+env.FIVE = "!five!"
+env.SIX.default = "nope"

--- a/tests/test_default_value.py
+++ b/tests/test_default_value.py
@@ -1,0 +1,24 @@
+def test_global_envfile_and_default(run_poe_subproc, poe_project_path):
+    project_path = poe_project_path.joinpath("tests", "fixtures", "default_value")
+    result = run_poe_subproc("test", cwd=project_path)
+    assert "Poe => echo !one! !two! !three! !four! !five! !six!\n" in result.capture
+    assert result.stdout == "!one! !two! !three! !four! !five! !six!\n"
+    assert result.stderr == ""
+
+
+def test_global_envfile_and_default_with_presets(run_poe_subproc, poe_project_path):
+    project_path = poe_project_path.joinpath("tests", "fixtures", "default_value")
+
+    env = {
+        "ONE": "111",
+        "TWO": "222",
+        "THREE": "333",
+        "FOUR": "444",
+        "FIVE": "555",
+        "SIX": "666",
+    }
+
+    result = run_poe_subproc("test", cwd=project_path, env=env)
+    assert "Poe => echo !one! !two! !three! 444 !five! 666\n" in result.capture
+    assert result.stdout == "!one! !two! !three! 444 !five! 666\n"
+    assert result.stderr == ""

--- a/tests/test_envfile.py
+++ b/tests/test_envfile.py
@@ -1,8 +1,9 @@
+import os
 from pathlib import Path
 import sys
 
 
-def test_global_envfile(run_poe_subproc, poe_project_path, is_windows):
+def test_global_envfile_and_default(run_poe_subproc, poe_project_path, is_windows):
     project_path = poe_project_path.joinpath("tests", "fixtures", "envfile")
     result = run_poe_subproc("deploy-dev", cwd=project_path)
     if is_windows:
@@ -20,7 +21,7 @@ def test_global_envfile(run_poe_subproc, poe_project_path, is_windows):
         assert result.stderr == ""
 
 
-def test_task_envfile(run_poe_subproc, poe_project_path, is_windows):
+def test_task_envfile_and_default(run_poe_subproc, poe_project_path, is_windows):
     project_path = poe_project_path.joinpath("tests", "fixtures", "envfile")
     result = run_poe_subproc("deploy-prod", cwd=project_path)
     if is_windows:


### PR DESCRIPTION
This is something I found necessary for my own use case. It allows similar semantics to `?=` variable assignment in make.

Setting an env var to a table with key default means the variable will only be set if not already provided by a lower precedence source such as the host shell or an env file. e.g.

```toml
[tool.poe.env]
PORT.default = "9001"
```

This PR build on top of #29

Documentation done, feature test TODO.