### PR TITLE
Add ability to configure which type of shell to use for executing shell tasks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -251,8 +251,6 @@ scripts *(shell)*, and sequence tasks *(sequence)*.
       Uses whatever version of zsh can be found.
   fish
       Uses whatever version of fish can be found.
-  pwsh7
-      Uses powershell version 7 or higher.
   pwsh
       Uses powershell version 6 or higher.
   powershell

--- a/README.rst
+++ b/README.rst
@@ -211,10 +211,7 @@ scripts *(shell)*, and sequence tasks *(sequence)*.
 
   **Using different types of shell/interpreter**
 
-  Is also possible to specify an alternative interpreter (or hierarchy of interpreters) to be invoked to execute shell taks content. For example if you only expect the task to be executed on windows or other environments with powershell installed then you can specify a powershell based task like so:
-
-  .. warning::
-    A current limitation of the powershell integration is that the resulting shell does not inherit environment variables from poe. Therefore environment variables (including task arguments) configured by poe won't work as expected!
+  It is also possible to specify an alternative interpreter (or list of compatible interpreters ordered by preference) to be invoked to execute shell task content. For example if you only expect the task to be executed on windows or other environments with powershell installed then you can specify a powershell based task like so:
 
   .. code-block:: toml
 
@@ -228,19 +225,38 @@ scripts *(shell)*, and sequence tasks *(sequence)*.
 
   .. code-block:: toml
 
-    interpreter = ["posix", pwsh"]
+    interpreter = ["posix", "pwsh"]
 
   It is also possible to specify python code as the shell task code as in the following example. However it is recommended to use a *script* task rather than writing complex code inline within your pyproject.toml.
 
   .. code-block:: toml
 
-    [tool.poe.tasks.install-poetry]
+    [tool.poe.tasks.time]
     shell = """
-    print("hello!")
+    from datetime import datetime
+
+    print(datetime.now())
     """
     interpreter = "python"
 
-  The full set of valid interpreter identifiers is :code:`{"posix", "sh", "bash", "zsh", "fish", "pwsh", "python"}`. The default value is :code:`"posix"` which is actually an alias for :code:`["sh", "bash", "zsh"]`, meaning that it will attempt to use sh, then bash, then zsh.
+  The following interpreter values may be used:
+
+  posix
+      This is the default behavoir, equivalent to ["sh", "bash", "zsh"], meaning that poe will try to find sh, and fallback to bash, then zsh.
+  sh
+      Use the basic posix shell. This is often an alias for bash or dash depending on the operating system.
+  bash
+      Uses whatever version of bash can be found. This is usually the most portable option.
+  zsh
+      Uses whatever version of zsh can be found.
+  fish
+      Uses whatever version of fish can be found.
+  pwsh7
+      Uses powershell version 7 or higher.
+  pwsh
+      Uses powershell version 6 or higher.
+  powershell
+      Uses the newest version of powershell that can be found.
 
   The default value can be changed with the global *shell_interpreter* option as described below.
 

--- a/README.rst
+++ b/README.rst
@@ -213,6 +213,9 @@ scripts *(shell)*, and sequence tasks *(sequence)*.
 
   Is also possible to specify an alternative interpreter (or hierarchy of interpreters) to be invoked to execute shell taks content. For example if you only expect the task to be executed on windows or other environments with powershell installed then you can specify a powershell based task like so:
 
+  .. warning::
+    A current limitation of the powershell integration is that the resulting shell does not inherit environment variables from poe. Therefore environment variables (including task arguments) configured by poe won't work as expected!
+
   .. code-block:: toml
 
     [tool.poe.tasks.install-poetry]

--- a/poethepoet/config.py
+++ b/poethepoet/config.py
@@ -14,7 +14,6 @@ class PoeConfig:
         "bash",
         "zsh",
         "fish",
-        "pwsh7",  # powershell >= 7
         "pwsh",  # powershell >= 6
         "powershell",  # any version of powershell
         "python",

--- a/poethepoet/config.py
+++ b/poethepoet/config.py
@@ -8,7 +8,17 @@ class PoeConfig:
     _table: Mapping[str, Any]
 
     TOML_NAME = "pyproject.toml"
-    KNOWN_SHELL_INTERPRETERS = ("posix", "sh", "bash", "zsh", "fish", "pwsh", "python")
+    KNOWN_SHELL_INTERPRETERS = (
+        "posix",
+        "sh",
+        "bash",
+        "zsh",
+        "fish",
+        "pwsh7",  # powershell >= 7
+        "pwsh",  # powershell >= 6
+        "powershell",  # any version of powershell
+        "python",
+    )
 
     # Options allowed directly under tool.poe in pyproject.toml
     __options__ = {

--- a/poethepoet/task/shell.py
+++ b/poethepoet/task/shell.py
@@ -1,3 +1,4 @@
+from os import environ
 from shutil import which
 import sys
 from typing import (
@@ -71,7 +72,12 @@ class ShellTask(PoeTask):
     def _locate_interpreter(self, interpreter: str) -> Optional[str]:
         result = None
 
-        if interpreter == "posix":
+        # Try use $SHELL from the environment as a hint
+        shell_var = environ.get("SHELL", "")
+        if shell_var.endswith(f"/{interpreter}") and which(shell_var) == shell_var:
+            result = shell_var
+
+        elif interpreter == "posix":
             # look for any known posix shell
             result = (
                 self._locate_interpreter("sh")

--- a/poethepoet/task/shell.py
+++ b/poethepoet/task/shell.py
@@ -1,9 +1,12 @@
+import json
 from os import environ
 from shutil import which
+from subprocess import Popen, PIPE
 import sys
 from typing import (
     Any,
     Dict,
+    List,
     Mapping,
     Optional,
     Sequence,
@@ -41,8 +44,8 @@ class ShellTask(PoeTask):
         if not has_named_args and any(arg.strip() for arg in extra_args):
             raise PoeException(f"Shell task {self.name!r} does not accept arguments")
 
-        interpreter = self.resolve_interpreter()
-        if not interpreter:
+        interpreter_cmd = self.resolve_interpreter_cmd()
+        if not interpreter_cmd:
             config_value = self._get_interpreter_config()
             message = f"Couldn't locate interpreter executable for {config_value!r} to run shell task. "
             if self._is_windows and config_value in ("posix", "bash"):
@@ -53,7 +56,7 @@ class ShellTask(PoeTask):
 
         self._print_action(self.content, context.dry)
         return context.get_executor(self.invocation, env, self.options).execute(
-            [interpreter], input=self.content.encode()
+            interpreter_cmd, input=self.content.encode()
         )
 
     def _get_interpreter_config(self) -> Tuple[str, ...]:
@@ -64,13 +67,23 @@ class ShellTask(PoeTask):
             return (result,)
         return tuple(result)
 
-    def resolve_interpreter(self) -> Optional[str]:
+    def resolve_interpreter_cmd(self) -> Optional[List[str]]:
+        """
+        Return a formatted command for the first specified interpreter that can be
+        located.
+        """
         for item in self._get_interpreter_config():
-            return self._locate_interpreter(item)
+            executable = self._locate_interpreter(item)
+            if executable is None:
+                return None
+            if item in ("pwsh7", "pwsh", "powershell"):
+                return [executable, "-NoLogo", "-Command", "-"]
+            return [executable]
         return None
 
     def _locate_interpreter(self, interpreter: str) -> Optional[str]:
         result = None
+        prog_files = environ.get("PROGRAMFILES", "C:\\Program Files")
 
         # Try use $SHELL from the environment as a hint
         shell_var = environ.get("SHELL", "")
@@ -93,7 +106,7 @@ class ShellTask(PoeTask):
 
             # Specifically look for git bash on windows
             if result is None and self._is_windows:
-                result = which("C:\\Program Files\\Git\\bin\\bash.exe")
+                result = which(f"{prog_files}\\Git\\bin\\bash.exe")
 
         elif interpreter == "zsh":
             result = which("zsh") or which("/bin/zsh")
@@ -101,14 +114,27 @@ class ShellTask(PoeTask):
         elif interpreter == "fish":
             result = which("fish") or which("/bin/fish")
 
-        elif interpreter == "pwsh":
-            result = which("pwsh") or which("powershell")
+        elif interpreter in ("pwsh7", "pwsh", "powershell"):
+            # Look for the pwsh executable and verify the version matches
+            pwsh = which("pwsh")
+            if pwsh:
+                pwsh_version = self._get_powershell_version(pwsh)
+                if pwsh_version >= 7 or (pwsh_version == 6 and interpreter == "pwsh"):
+                    result = pwsh
 
-            # Specifically look in a known location on windows
-            if result is None and self._is_windows:
-                result = which(
-                    "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.EXE"
-                )
+            if result is None:
+                result = which(f"{prog_files}\\PowerShell\\7\\pwsh.exe")
+
+            if result is None:
+                if interpreter == "pwsh":
+                    result = which(f"{prog_files}\\PowerShell\\6\\pwsh.exe")
+
+                elif interpreter == "powershell" and self._is_windows:
+                    # Look for older versions of powershell
+                    result = which("powershell") or which(
+                        environ.get("WINDIR", "C:\\Windows")
+                        + "\\System32\\WindowsPowerShell\\v1.0\\powershell.EXE"
+                    )
 
         elif interpreter == "python":
             result = which("python") or which("python3") or sys.executable
@@ -142,3 +168,15 @@ class ShellTask(PoeTask):
                     )
 
         return None
+
+    def _get_powershell_version(self, executable: str):
+        subproc = Popen(
+            [executable, "-NoLogo", "-Command", "-"],
+            stdin=PIPE,
+            stdout=PIPE,
+        )
+        stdout = subproc.communicate(b"$PSVersionTable | ConvertTo-Json")[0].decode()
+        # Junk before or after the json content
+        i0 = stdout.find("{")
+        i1 = stdout.rfind("}")
+        return json.loads(stdout[i0 : i1 + 1])["PSVersion"]["Major"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def is_windows():
 
 @pytest.fixture
 def pyproject():
-    with PROJECT_TOML.open("r") as toml_file:
+    with PROJECT_TOML.open("rb") as toml_file:
         return tomli.load(toml_file)
 
 
@@ -121,7 +121,7 @@ def run_poe_subproc(projects, temp_file, tmp_path, is_windows):
             with config_path.open("w+") as config_file:
                 toml.dump(config, config_file)
                 config_file.seek(0)
-            config_arg = fr"tomli.load(open(r\"{config_path}\", \"r\"))"
+            config_arg = fr"tomli.load(open(r\"{config_path}\", \"rb\"))"
         else:
             config_arg = "None"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import shutil
 from subprocess import PIPE, Popen
 import sys
 from tempfile import TemporaryDirectory
+import time
 import tomli
 from typing import Any, Dict, List, Mapping, Optional
 import venv
@@ -245,7 +246,7 @@ def use_venv(install_into_virtualenv):
         yield
         # Only cleanup if we actually created it to avoid this fixture being a bit dangerous
         if not did_exist:
-            shutil.rmtree(location)
+            try_rm_dir(location)
 
     return use_venv
 
@@ -273,9 +274,20 @@ def use_virtualenv(install_into_virtualenv):
         yield
         # Only cleanup if we actually created it to avoid this fixture being a bit dangerous
         if not did_exist:
-            shutil.rmtree(location)
+            try_rm_dir(location)
 
     return use_virtualenv
+
+
+def try_rm_dir(location: Path):
+    try:
+        shutil.rmtree(location)
+    except:
+        # The above sometimes files with a Permissions error in CI for Windows
+        # No idea why, but maybe this will help
+        print("Retrying venv cleanup")
+        time.sleep(1)
+        shutil.rmtree(location)
 
 
 @pytest.fixture

--- a/tests/fixtures/shells_project/bad_interpreter.toml
+++ b/tests/fixtures/shells_project/bad_interpreter.toml
@@ -1,0 +1,8 @@
+[tool.poe.tasks.bad-interpreter]
+interpreter = "gosh"
+shell = """
+import "fmt"
+func main() {
+  fmt.Println("hello")
+}
+"""

--- a/tests/fixtures/shells_project/pyproject.toml
+++ b/tests/fixtures/shells_project/pyproject.toml
@@ -19,22 +19,26 @@ args = ["formal-greeting", "subject"]
 
 [tool.poe.tasks.echo_sh]
 interpreter = ["sh"]
-shell = "echo $0"
+shell = "echo $0 $test_var"
+env = { test_var =  "roflcopter"}
 
 
 [tool.poe.tasks.echo_bash]
 interpreter = "bash"
-shell = "echo $0"
+shell = "echo $0 $test_var"
+env = { test_var =  "roflcopter"}
 
 
 [tool.poe.tasks.echo_pwsh]
 interpreter = "pwsh"
-shell = "echo $0"
+shell = "echo $0 $test_var"
+env = { test_var =  "roflcopter"}
 
 
 [tool.poe.tasks.echo_python]
 interpreter = "python"
 shell = """
-import sys
-print(sys.version_info)
+import sys, os
+print(sys.version_info, os.environ.get("test_var"))
 """
+env = { test_var =  "roflcopter"}

--- a/tests/fixtures/shells_project/pyproject.toml
+++ b/tests/fixtures/shells_project/pyproject.toml
@@ -31,8 +31,7 @@ env = { test_var =  "roflcopter"}
 
 [tool.poe.tasks.echo_pwsh]
 interpreter = "pwsh"
-shell = "echo $0 $test_var"
-env = { test_var =  "roflcopter"}
+shell = "echo 'I wonder how one would make powershell inherit env vars?'"
 
 
 [tool.poe.tasks.echo_python]

--- a/tests/fixtures/shells_project/pyproject.toml
+++ b/tests/fixtures/shells_project/pyproject.toml
@@ -31,7 +31,8 @@ env = { test_var =  "roflcopter"}
 
 [tool.poe.tasks.echo_pwsh]
 interpreter = "pwsh"
-shell = "echo 'I wonder how one would make powershell inherit env vars?'"
+shell = "echo $ENV:test_var"
+env = { test_var =  "roflcopter"}
 
 
 [tool.poe.tasks.echo_python]

--- a/tests/fixtures/shells_project/pyproject.toml
+++ b/tests/fixtures/shells_project/pyproject.toml
@@ -15,3 +15,26 @@ echo "bam bam baaam bam"
 [tool.poe.tasks.greet]
 shell = "echo $formal_greeting $subject"
 args = ["formal-greeting", "subject"]
+
+
+[tool.poe.tasks.echo_sh]
+interpreter = ["sh"]
+shell = "echo $0"
+
+
+[tool.poe.tasks.echo_bash]
+interpreter = "bash"
+shell = "echo $0"
+
+
+[tool.poe.tasks.echo_pwsh]
+interpreter = "pwsh"
+shell = "echo $0"
+
+
+[tool.poe.tasks.echo_python]
+interpreter = "python"
+shell = """
+import sys
+print(sys.version_info)
+"""

--- a/tests/fixtures/shells_project/shell_interpreter_config.toml
+++ b/tests/fixtures/shells_project/shell_interpreter_config.toml
@@ -1,0 +1,8 @@
+
+tool.poe.shell_interpreter = ["python"]
+
+[tool.poe.tasks.echo_python]
+shell = """
+import sys
+print(sys.version_info)
+"""

--- a/tests/test_script_tasks.py
+++ b/tests/test_script_tasks.py
@@ -192,7 +192,7 @@ def test_script_task_bad_type(run_poe_subproc, projects):
 
 def test_script_task_bad_content(run_poe_subproc, projects):
     result = run_poe_subproc(
-        f'--root={projects["scripts/bad_type"]}',
+        f'--root={projects["scripts/bad_content"]}',
         "bad-content",
         "--greeting=hello",
     )
@@ -200,7 +200,7 @@ def test_script_task_bad_content(run_poe_subproc, projects):
         "Error: Task 'bad-type' contains invalid callable reference "
         "'dummy_package:main[greeting]' "
         "(expected something like `module:callable` or `module:callable()`)"
-    )
+    ) in result.capture
     assert result.stdout == ""
     assert result.stderr == ""
 

--- a/tests/test_shell_task.py
+++ b/tests/test_shell_task.py
@@ -48,30 +48,35 @@ def test_shell_task_with_dash_case_arg(run_poe_subproc):
 
 def test_interpreter_sh(run_poe_subproc):
     result = run_poe_subproc("echo_sh", project="shells")
-    assert result.capture == (f"Poe => echo $0\n")
-    # assert result.stdout == ... hard to know what this should be!
+    assert result.capture == (f"Poe => echo $0 $test_var\n")
+    assert "roflcopter" in result.stdout
     assert result.stderr == ""
 
 
 def test_interpreter_bash(run_poe_subproc):
     result = run_poe_subproc("echo_bash", project="shells")
-    assert result.capture == (f"Poe => echo $0\n")
+    assert result.capture == (f"Poe => echo $0 $test_var\n")
     assert "bash" in result.stdout
+    assert "roflcopter" in result.stdout
     assert result.stderr == ""
 
 
 @pytest.mark.skipif(not shutil.which("powershell"), reason="No powershell available")
 def test_interpreter_pwsh(run_poe_subproc, is_windows):
     result = run_poe_subproc("echo_pwsh", project="shells")
-    assert result.capture == (f"Poe => echo $0\n")
+    assert result.capture == (f"Poe => echo $0 $test_var\n")
     assert "PowerShell" in result.stdout
+    assert "roflcopter" in result.stdout
     assert result.stderr == ""
 
 
 def test_interpreter_python(run_poe_subproc):
     result = run_poe_subproc("echo_python", project="shells")
-    assert result.capture == (f"Poe => import sys\nprint(sys.version_info)\n")
+    assert result.capture == (
+        f'Poe => import sys, os\nprint(sys.version_info, os.environ.get("test_var"))\n'
+    )
     assert result.stdout.startswith("sys.version_info(major=3,")
+    assert "roflcopter" in result.stdout
     assert result.stderr == ""
 
 

--- a/tests/test_shell_task.py
+++ b/tests/test_shell_task.py
@@ -90,7 +90,7 @@ def test_bad_interpreter_config(run_poe_subproc, projects):
     assert (
         "Error: Unsupported value for option `interpreter` for task 'bad-interpreter'."
         " Expected one of ("
-        "'posix', 'sh', 'bash', 'zsh', 'fish', 'pwsh7', 'pwsh', 'powershell', 'python')"
+        "'posix', 'sh', 'bash', 'zsh', 'fish', 'pwsh', 'powershell', 'python')"
     ) in result.capture
     assert result.stdout == ""
     assert result.stderr == ""

--- a/tests/test_shell_task.py
+++ b/tests/test_shell_task.py
@@ -64,12 +64,35 @@ def test_interpreter_bash(run_poe_subproc):
 def test_interpreter_pwsh(run_poe_subproc, is_windows):
     result = run_poe_subproc("echo_pwsh", project="shells")
     assert result.capture == (f"Poe => echo $0\n")
-    assert "pwsh" in result.stdout
+    assert "PowerShell" in result.stdout
     assert result.stderr == ""
 
 
 def test_interpreter_python(run_poe_subproc):
     result = run_poe_subproc("echo_python", project="shells")
+    assert result.capture == (f"Poe => import sys\nprint(sys.version_info)\n")
+    assert result.stdout.startswith("sys.version_info(major=3,")
+    assert result.stderr == ""
+
+
+def test_bad_interpreter_config(run_poe_subproc, projects):
+    result = run_poe_subproc(
+        f'--root={projects["shells/bad_interpreter"]}',
+        "bad-interpreter",
+    )
+    assert (
+        "Error: Unsupported value for option `interpreter` for task 'bad-interpreter'."
+        " Expected one of ('posix', 'sh', 'bash', 'zsh', 'fish', 'pwsh', 'python')"
+    ) in result.capture
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_global_interpreter_config(run_poe_subproc, projects):
+    result = run_poe_subproc(
+        f'--root={projects["shells/shell_interpreter_config"]}',
+        "echo_python",
+    )
     assert result.capture == (f"Poe => import sys\nprint(sys.version_info)\n")
     assert result.stdout.startswith("sys.version_info(major=3,")
     assert result.stderr == ""

--- a/tests/test_shell_task.py
+++ b/tests/test_shell_task.py
@@ -67,11 +67,8 @@ def test_interpreter_bash(run_poe_subproc):
 )
 def test_interpreter_pwsh(run_poe_subproc, is_windows):
     result = run_poe_subproc("echo_pwsh", project="shells")
-    assert result.capture == (
-        f"Poe => echo 'I wonder how one would make powershell inherit env vars?'\n"
-    )
-    assert "PowerShell" in result.stdout
-    assert "I wonder how one would make powershell inherit env vars?" in result.stdout
+    assert result.capture == (f"Poe => echo $ENV:test_var\n")
+    assert "roflcopter" in result.stdout
     assert result.stderr == ""
 
 
@@ -92,7 +89,8 @@ def test_bad_interpreter_config(run_poe_subproc, projects):
     )
     assert (
         "Error: Unsupported value for option `interpreter` for task 'bad-interpreter'."
-        " Expected one of ('posix', 'sh', 'bash', 'zsh', 'fish', 'pwsh', 'python')"
+        " Expected one of ("
+        "'posix', 'sh', 'bash', 'zsh', 'fish', 'pwsh7', 'pwsh', 'powershell', 'python')"
     ) in result.capture
     assert result.stdout == ""
     assert result.stderr == ""

--- a/tests/test_shell_task.py
+++ b/tests/test_shell_task.py
@@ -1,3 +1,7 @@
+import pytest
+import shutil
+
+
 def test_shell_task(run_poe_subproc):
     result = run_poe_subproc("count", project="shells")
     assert (
@@ -39,4 +43,33 @@ def test_shell_task_with_dash_case_arg(run_poe_subproc):
     )
     assert result.capture == (f"Poe => echo $formal_greeting $subject\n")
     assert result.stdout == "hey you\n"
+    assert result.stderr == ""
+
+
+def test_interpreter_sh(run_poe_subproc):
+    result = run_poe_subproc("echo_sh", project="shells")
+    assert result.capture == (f"Poe => echo $0\n")
+    # assert result.stdout == ... hard to know what this should be!
+    assert result.stderr == ""
+
+
+def test_interpreter_bash(run_poe_subproc):
+    result = run_poe_subproc("echo_bash", project="shells")
+    assert result.capture == (f"Poe => echo $0\n")
+    assert "bash" in result.stdout
+    assert result.stderr == ""
+
+
+@pytest.mark.skipif(not shutil.which("powershell"), reason="No powershell available")
+def test_interpreter_pwsh(run_poe_subproc, is_windows):
+    result = run_poe_subproc("echo_pwsh", project="shells")
+    assert result.capture == (f"Poe => echo $0\n")
+    assert "pwsh" in result.stdout
+    assert result.stderr == ""
+
+
+def test_interpreter_python(run_poe_subproc):
+    result = run_poe_subproc("echo_python", project="shells")
+    assert result.capture == (f"Poe => import sys\nprint(sys.version_info)\n")
+    assert result.stdout.startswith("sys.version_info(major=3,")
     assert result.stderr == ""

--- a/tests/test_shell_task.py
+++ b/tests/test_shell_task.py
@@ -61,12 +61,17 @@ def test_interpreter_bash(run_poe_subproc):
     assert result.stderr == ""
 
 
-@pytest.mark.skipif(not shutil.which("powershell"), reason="No powershell available")
+@pytest.mark.skipif(
+    not (shutil.which("powershell") or shutil.which("pwsh")),
+    reason="No powershell available",
+)
 def test_interpreter_pwsh(run_poe_subproc, is_windows):
     result = run_poe_subproc("echo_pwsh", project="shells")
-    assert result.capture == (f"Poe => echo $0 $test_var\n")
+    assert result.capture == (
+        f"Poe => echo 'I wonder how one would make powershell inherit env vars?'\n"
+    )
     assert "PowerShell" in result.stdout
-    assert "roflcopter" in result.stdout
+    assert "I wonder how one would make powershell inherit env vars?" in result.stdout
     assert result.stderr == ""
 
 


### PR DESCRIPTION
Addresses #15 and #27 

The new shell executable resolution logic only considers the $SHELL env var as a hint (if it appears to match the target shell type), and never explicitly looks for WSL on windows. See included updates to documentation for more details.

Example of a shell task using fish shell:

```toml
  [tool.poe.tasks.fibonacci]
  help = "Output the fibonacci sequence up to 89"
  interpreter = "fish"
  shell = """
    function fib --argument-names max n0 n1
      if test $max -ge $n0
        echo $n0
        fib $max $n1 (math $n0 + $n1)
      end
    end

    fib 89 1 1
  """
```

Note that there are a couple of significant limitations with the powershell integration that I don't know how to solve. Firstly when powershell starts it always prints some copyright boilerplate which is not really desirable for this use case, and secondly it doesn't propagate environment variables from the parent process which is quite a limitation (e.g. named args won't work). Suggestions are welcome from anyone more knowledgable about powershell.