### PR TITLE
Remove the upper bound on Python 4.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -934,8 +934,8 @@ poetry_plugin = ["poetry"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6.2"
-content-hash = "4821e9308710bb60ef0b532861e5808f024d5bf26e59efa53689eb939c2b478a"
+python-versions = ">=3.6.2"
+content-hash = "efabe7286c79ff1d1cca3615573df9b7446660189577b952dc09b8926dc5f17d"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository  = "https://github.com/nat-n/poethepoet"
 homepage    = "https://github.com/nat-n/poethepoet"
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
+python = ">=3.6.2"
 pastel = "^0.2.1"
 tomli  = "^1.2.2"
 poetry = {version = "^1.0", allow-prereleases = true, optional = true}


### PR DESCRIPTION
Now that both pylint and astroid no longer have the cap on the python version it can be removed from poe as well.

Closes #43 