### PR TITLE
Remove the upper bound on tomli 2.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -935,7 +935,7 @@ poetry_plugin = ["poetry"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.2"
-content-hash = "efabe7286c79ff1d1cca3615573df9b7446660189577b952dc09b8926dc5f17d"
+content-hash = "5e063911bf568c9f5ed91a447ecd2b1dd0f22a8edf1ffc2640f0e317e6b64f09"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ homepage    = "https://github.com/nat-n/poethepoet"
 [tool.poetry.dependencies]
 python = ">=3.6.2"
 pastel = "^0.2.1"
-tomli  = "^1.2.2"
+tomli  = ">=1.2.2"
 poetry = {version = "^1.0", allow-prereleases = true, optional = true}
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Besides removing support for python 3.6, the only breaking changes in tomli 2.0 are in the first parameter of `load`/`loads`: it can no longer be passed by keyword, and in the case of `load` it must be a binary file object.  Poe already does that, so no further changes are required.