### PR TITLE
win32: Resolve Executable to Absolute Path if not found in venv

### DIFF
--- a/poethepoet/virtualenv.py
+++ b/poethepoet/virtualenv.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import sys
 from pathlib import Path
 from typing import Dict, Mapping
@@ -38,6 +39,7 @@ class Virtualenv:
                 return str(bin_dir.joinpath(f"{executable}.exe"))
             if bin_dir.joinpath(f"{executable}.bat").is_file():
                 return str(bin_dir.joinpath(f"{executable}.bat"))
+            return shutil.which(executable) or executable
         return executable
 
     @staticmethod


### PR DESCRIPTION
This PR addresses  #119 for `cmd`  tasks that use the poetry executor. I found that, on Windows, a task like the following wasn't working:

```toml
[tool.poe.tasks]
"check-spelling" = "npx cspell README.md CHANGELOG.md"
```

Running the task on Windows is failing because `npx` does not exist, it's actually `npx.cmd`:

```
poetry run poe check-spelling
# ..snip..
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

The problem seems to be that the fix for #119 was done in [`PoeExecutor.execute`](https://github.com/nat-n/poethepoet/blob/main/poethepoet/executor/base.py#L135), however this isn't called by the poetry executor since it calls `PoeExecutor._execute_cmd()` directly, bypassing the fix. I've confirmed that this PR works for my case.