### PR TITLE
cmd task: Strip quotes from token on Windows

### DIFF
--- a/poethepoet/task/cmd.py
+++ b/poethepoet/task/cmd.py
@@ -88,6 +88,11 @@ class CmdTask(PoeTask):
             if not is_quoted and _GLOBCHARS_PATTERN.match(cmd_token):
                 # looks like a glob path so resolve it
                 result.extend(glob(cmd_token, recursive=True))
+            elif is_quoted and self._is_windows:
+                # In this case, the cmd_token will still be wrapped in double or single
+                # quotes. We need to remove those otherwise they'll be pass into the
+                # command.
+                result.append(cmd_token[1:-1])
             else:
                 result.append(cmd_token)
         return result

--- a/tests/test_cmd_tasks.py
+++ b/tests/test_cmd_tasks.py
@@ -50,12 +50,8 @@ def test_cmd_alias_env_var(run_poe_subproc):
 
 def test_cmd_task_with_multiple_value_arg(run_poe_subproc, is_windows):
     result = run_poe_subproc("multiple-value-arg", "hey", "1", "2", "3", project="cmds")
-    if is_windows:
-        assert result.capture == 'Poe => poe_test_echo "first: hey second: 1 2 3"\n'
-        assert result.stdout == '"first: hey second: 1 2 3"\n'
-    else:
-        assert result.capture == "Poe => poe_test_echo first: hey second: 1 2 3\n"
-        assert result.stdout == "first: hey second: 1 2 3\n"
+    assert result.capture == "Poe => poe_test_echo first: hey second: 1 2 3\n"
+    assert result.stdout == "first: hey second: 1 2 3\n"
     assert result.stderr == ""
 
 

--- a/tests/test_envfile.py
+++ b/tests/test_envfile.py
@@ -5,39 +5,22 @@ from pathlib import Path
 
 def test_global_envfile_and_default(run_poe_subproc, is_windows):
     result = run_poe_subproc("deploy-dev", project="envfile")
-    if is_windows:
-        # On windows shlex works in non-POSIX mode which results in  quotes
-        assert (
-            'Poe => poe_test_echo "deploying to admin:12345@dev.example.com:8080"\n'
-            in result.capture
-        )
-        assert result.stdout == '"deploying to admin:12345@dev.example.com:8080"\n'
-        assert result.stderr == ""
-    else:
-        assert (
-            "Poe => poe_test_echo deploying to admin:12345@dev.example.com:8080\n"
-            in result.capture
-        )
-        assert result.stdout == "deploying to admin:12345@dev.example.com:8080\n"
-        assert result.stderr == ""
+    assert (
+        "Poe => poe_test_echo deploying to admin:12345@dev.example.com:8080\n"
+        in result.capture
+    )
+    assert result.stdout == "deploying to admin:12345@dev.example.com:8080\n"
+    assert result.stderr == ""
 
 
 def test_task_envfile_and_default(run_poe_subproc, is_windows):
     result = run_poe_subproc("deploy-prod", project="envfile")
-    if is_windows:
-        assert (
-            'Poe => poe_test_echo "deploying to admin:12345@prod.example.com/app"\n'
-            in result.capture
-        )
-        assert result.stdout == '"deploying to admin:12345@prod.example.com/app"\n'
-        assert result.stderr == ""
-    else:
-        assert (
-            "Poe => poe_test_echo deploying to admin:12345@prod.example.com/app\n"
-            in result.capture
-        )
-        assert result.stdout == "deploying to admin:12345@prod.example.com/app\n"
-        assert result.stderr == ""
+    assert (
+        "Poe => poe_test_echo deploying to admin:12345@prod.example.com/app\n"
+        in result.capture
+    )
+    assert result.stdout == "deploying to admin:12345@prod.example.com/app\n"
+    assert result.stderr == ""
 
 
 def test_multiple_envfiles(run_poe_subproc, projects, is_windows):
@@ -45,17 +28,8 @@ def test_multiple_envfiles(run_poe_subproc, projects, is_windows):
         f'--root={projects["envfile/multiple_envfiles"]}', "show_me_the_vals"
     )
 
-    if is_windows:
-        assert (
-            'Poe => poe_test_echo "VAL_A-VAL_B-VAL_C-VAL_D-VAL_E-VAL_F!!"\n'
-            in result.capture
-        )
-        assert result.stdout == '"VAL_A-VAL_B-VAL_C-VAL_D-VAL_E-VAL_F!!"\n'
-        assert result.stderr == ""
-    else:
-        assert (
-            "Poe => poe_test_echo VAL_A-VAL_B-VAL_C-VAL_D-VAL_E-VAL_F!!\n"
-            in result.capture
-        )
-        assert result.stdout == "VAL_A-VAL_B-VAL_C-VAL_D-VAL_E-VAL_F!!\n"
-        assert result.stderr == ""
+    assert (
+        "Poe => poe_test_echo VAL_A-VAL_B-VAL_C-VAL_D-VAL_E-VAL_F!!\n" in result.capture
+    )
+    assert result.stdout == "VAL_A-VAL_B-VAL_C-VAL_D-VAL_E-VAL_F!!\n"
+    assert result.stderr == ""

--- a/tests/test_poe_config.py
+++ b/tests/test_poe_config.py
@@ -35,17 +35,8 @@ def test_setting_default_array_item_task_type(run_poe_subproc):
 
 def test_setting_global_env_vars(run_poe_subproc, is_windows):
     result = run_poe_subproc("travel", env=no_venv)
-    if is_windows:
-        assert (
-            result.capture
-            == f"Poe => poe_test_echo 'from EARTH to'\nPoe => travel[1]\n"
-        )
-        assert result.stdout == f"'from EARTH to'\nMARS\n"
-    else:
-        assert (
-            result.capture == f"Poe => poe_test_echo from EARTH to\nPoe => travel[1]\n"
-        )
-        assert result.stdout == f"from EARTH to\nMARS\n"
+    assert result.capture == f"Poe => poe_test_echo from EARTH to\nPoe => travel[1]\n"
+    assert result.stdout == f"from EARTH to\nMARS\n"
     assert result.stderr == ""
 
 
@@ -90,9 +81,4 @@ def test_decrease_verbosity(run_poe_subproc, is_windows):
     )
     assert result.capture == ""
     assert result.stderr == ""
-    if is_windows:
-        # On Windows, "echo 'Hello'" results in "'Hello'".
-        assert result.stdout == "'Hello'\n"
-    else:
-        # On UNIX, "echo 'Hello'" results in just "Hello".
-        assert result.stdout == "Hello\n"
+    assert result.stdout == "Hello\n"

--- a/tests/test_sequence_tasks.py
+++ b/tests/test_sequence_tasks.py
@@ -1,37 +1,21 @@
 def test_sequence_task(run_poe_subproc, esc_prefix, is_windows):
     result = run_poe_subproc("composite_task", project="sequences")
-    if is_windows:
-        # On windows shlex works in non-POSIX mode which results in  quotes
-        assert (
-            result.capture
-            == f"Poe => poe_test_echo 'Hello'\nPoe => poe_test_echo 'World!'\nPoe => poe_test_echo ':)!'\n"
-        )
-        assert result.stdout == f"'Hello'\n'World!'\n':)!'\n"
-    else:
-        assert (
-            result.capture
-            == f"Poe => poe_test_echo Hello\nPoe => poe_test_echo World!\nPoe => poe_test_echo :)!\n"
-        )
-        assert result.stdout == f"Hello\nWorld!\n:)!\n"
+    assert (
+        result.capture
+        == f"Poe => poe_test_echo Hello\nPoe => poe_test_echo World!\nPoe => poe_test_echo :)!\n"
+    )
+    assert result.stdout == f"Hello\nWorld!\n:)!\n"
     assert result.stderr == ""
 
 
 def test_another_sequence_task(run_poe_subproc, esc_prefix, is_windows):
     # This should be exactly the same as calling the composite_task task directly
     result = run_poe_subproc("also_composite_task", project="sequences")
-    if is_windows:
-        # On windows shlex works in non-POSIX mode which results in  quotes
-        assert (
-            result.capture
-            == f"Poe => poe_test_echo 'Hello'\nPoe => poe_test_echo 'World!'\nPoe => poe_test_echo ':)!'\n"
-        )
-        assert result.stdout == f"'Hello'\n'World!'\n':)!'\n"
-    else:
-        assert (
-            result.capture
-            == f"Poe => poe_test_echo Hello\nPoe => poe_test_echo World!\nPoe => poe_test_echo :)!\n"
-        )
-        assert result.stdout == f"Hello\nWorld!\n:)!\n"
+    assert (
+        result.capture
+        == f"Poe => poe_test_echo Hello\nPoe => poe_test_echo World!\nPoe => poe_test_echo :)!\n"
+    )
+    assert result.stdout == f"Hello\nWorld!\n:)!\n"
     assert result.stderr == ""
 
 


### PR DESCRIPTION
I found an issue related to #16 where, on Windows, a quoted token is being passed to the command still wrapped in quotes. This only happens on Windows because the `shelx.split(posix=False)` preserves them. You can verify this issue on Windows with the poethepoety `test-quick` task, which passes a quotes string to pytest and fails because the marker contains an invalid quote character:

```
Poe => pytest --cov=poethepoet -m "not slow"
# ... cut ...
ERROR: Wrong expression passed to '-m': "not slow": at column 1: unexpected character ""
```

I initially was seeing this with a call to cspell and have reproduced it with a small script / task.

```python
# args.py
import sys
print(sys.argv)
```

```toml
# pyproject.toml
[tool.poe.tasks.args]
cmd = "python args.py \"hello world\" \"some/glob/**/*.py\""
```

The results of running the `args` task show that, on Windows, the quotes are preserved when they should be stripped.

```
$ poetry poe args
Poe => python args.py "hello world" "some/glob/**/*.py"
['args.py', '"hello world"', '"some/glob/**/*.py"']
```

I tried using some of the examples from #16 but I couldn't get them to work in my case, either the glob was being expanded by poe or the quote characters were being passed to the subprocess.