### PR TITLE
fix: zsh completion without oh-my-zsh

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,7 +62,7 @@ Zsh
 
   # without oh-my-zsh
   mkdir -p ~/.zfunc/
-  poe _zsh_completion > ~/.zfunc/_poetry
+  poe _zsh_completion > ~/.zfunc/_poe
 
 .. note::
 


### PR DESCRIPTION
I was going through the guide and stumbled upon this. Shouldn't it generate a completion script for `poe` instead of `poetry`?