### PR TITLE
Use sys.argv[0] for help message USAGE line in ui.print_help().

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,10 @@ rst_prolog = """
 
 """
 
+linkcheck_ignore = [
+    # link checker chokes on GitHub source code links with hashes: https://github.com/sphinx-doc/sphinx/issues/9016
+    "https://github.com/nat-n/poethepoet/blob/main/poethepoet/helpers/python.py#L13"
+]
 
 # -- Options for HTML output ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/poethepoet/app.py
+++ b/poethepoet/app.py
@@ -34,6 +34,8 @@ class PoeThePoet:
         config: Optional[Union[Mapping[str, Any], "PoeConfig"]] = None,
         output: IO = sys.stdout,
         poetry_env_path: Optional[str] = None,
+        config_name: str = "pyproject.toml",
+        program_name: str = "poe",
     ):
         from .config import PoeConfig
         from .ui import PoeUi
@@ -42,10 +44,10 @@ class PoeThePoet:
         self.config = (
             config
             if isinstance(config, PoeConfig)
-            else PoeConfig(cwd=cwd, table=config)
+            else PoeConfig(cwd=cwd, table=config, config_name=config_name)
         )
-        self.ui = PoeUi(output=output)
-        self.poetry_env_path = poetry_env_path
+        self.ui = PoeUi(output=output, program_name=program_name)
+        self._poetry_env_path = poetry_env_path
 
     def __call__(self, cli_args: Sequence[str], internal: bool = False) -> int:
         """
@@ -165,9 +167,9 @@ class PoeThePoet:
             poe_active=os.environ.get("POE_ACTIVE"),
             multistage=multistage,
         )
-        if self.poetry_env_path:
+        if self._poetry_env_path:
             # This allows the PoetryExecutor to use the venv from poetry directly
-            result.exec_cache["poetry_virtualenv"] = self.poetry_env_path
+            result.exec_cache["poetry_virtualenv"] = self._poetry_env_path
         return result
 
     def print_help(

--- a/poethepoet/task/args.py
+++ b/poethepoet/task/args.py
@@ -41,8 +41,15 @@ arg_types: Dict[str, Type] = {
 class PoeTaskArgs:
     _args: Tuple[ArgParams, ...]
 
-    def __init__(self, args_def: ArgsDef, task_name: str, env: "EnvVarsManager"):
+    def __init__(
+        self,
+        args_def: ArgsDef,
+        task_name: str,
+        program_name: str,
+        env: "EnvVarsManager",
+    ):
         self._args = self._normalize_args_def(args_def)
+        self._program_name = program_name
         self._task_name = task_name
         self._env = env
 
@@ -245,7 +252,9 @@ class PoeTaskArgs:
         import argparse
 
         parser = argparse.ArgumentParser(
-            prog=f"poe {self._task_name}", add_help=False, allow_abbrev=False
+            prog=f"{self._program_name} {self._task_name}",
+            add_help=False,
+            allow_abbrev=False,
         )
         for arg in self._args:
             parser.add_argument(

--- a/poethepoet/task/base.py
+++ b/poethepoet/task/base.py
@@ -214,11 +214,13 @@ class PoeTask(metaclass=MetaPoeTask):
     def _parse_named_args(
         self, extra_args: Sequence[str], env: "EnvVarsManager"
     ) -> Optional[Dict[str, str]]:
-        from .args import PoeTaskArgs
+        if args_def := self.options.get("args"):
+            from .args import PoeTaskArgs
 
-        args_def = self.options.get("args")
-        if args_def:
-            return PoeTaskArgs(args_def, self.name, env).parse(extra_args)
+            return PoeTaskArgs(args_def, self.name, self._ui.program_name, env).parse(
+                extra_args
+            )
+
         return None
 
     def run(

--- a/poethepoet/ui.py
+++ b/poethepoet/ui.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from pathlib import Path
 from typing import IO, TYPE_CHECKING, List, Mapping, Optional, Sequence, Tuple, Union
 
 from .__version__ import __version__
@@ -174,10 +175,12 @@ class PoeUi:
 
         if verbosity >= 0:
             # Use argparse for usage summary
+            program = Path(sys.argv[0] if sys.argv else "poe").name
+            program = "poe" if program in ("poetry", "__main__.py") else program
             result.append(
                 (
                     "<h2>USAGE</h2>",
-                    "  <u>poe</u> [-h] [-v | -q] [--root PATH] [--ansi | --no-ansi] task [task arguments]",
+                    f"  <u>{program}</u> [-h] [-v | -q] [--root PATH] [--ansi | --no-ansi] task [task arguments]",
                 )
             )
 

--- a/poethepoet/ui.py
+++ b/poethepoet/ui.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from pathlib import Path
 from typing import IO, TYPE_CHECKING, List, Mapping, Optional, Sequence, Tuple, Union
 
 from .__version__ import __version__
@@ -27,8 +26,9 @@ class PoeUi:
     args: "Namespace"
     _color: "Pastel"
 
-    def __init__(self, output: IO):  # TODO: make IO wrapper
+    def __init__(self, output: IO, program_name: str = "poe"):
         self.output = output
+        self.program_name = program_name
         self._init_colors()
 
     def _init_colors(self):
@@ -53,7 +53,7 @@ class PoeUi:
         import argparse
 
         parser = argparse.ArgumentParser(
-            prog="poe",
+            prog=self.program_name,
             description="Poe the Poet: A task runner that works well with poetry.",
             add_help=False,
             allow_abbrev=False,
@@ -174,13 +174,10 @@ class PoeUi:
             result.append(error_line)
 
         if verbosity >= 0:
-            # Use argparse for usage summary
-            program = Path(sys.argv[0] if sys.argv else "poe").name
-            program = "poe" if program in ("poetry", "__main__.py") else program
             result.append(
                 (
                     "<h2>USAGE</h2>",
-                    f"  <u>{program}</u> [-h] [-v | -q] [--root PATH] [--ansi | --no-ansi] task [task arguments]",
+                    f"  <u>{self.program_name}</u> [-h] [-v | -q] [--root PATH] [--ansi | --no-ansi] task [task arguments]",
                 )
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ poe = "poethepoet:main"
 [tool.poetry.plugins."poetry.application.plugin"]
 poethepoet = "poethepoet.plugin:PoetryPlugin"
 
+
 [tool.poe.tasks]
 
 _clean_docs.script = "shutil:rmtree('docs/_build', ignore_errors=1)"
@@ -128,6 +129,14 @@ _clean_docs.script = "shutil:rmtree('docs/_build', ignore_errors=1)"
   [tool.poe.tasks.check]
   help     = "Run all checks on the code base"
   sequence = ["docs-check", "style", "types", "lint", "test"]
+
+  [tool.poe.tasks.install-poetry-plugin]
+  help = "Install or update this project as a plugin in poetry"
+  sequence = [
+    { cmd = "poetry self remove poethepoet"},
+    { cmd = "poetry self add \"${POE_ROOT}[poetry_plugin]\""}
+  ]
+  ignore_fail = true
 
   [tool.poe.tasks.poe]
   help   = "Execute poe from this repo (useful for testing)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,10 +177,18 @@ def run_poe(capsys, projects):
         cwd: str = projects["example"],
         config: Optional[Mapping[str, Any]] = None,
         project: Optional[str] = None,
+        config_name="pyproject.toml",
+        program_name="poe",
     ) -> PoeRunResult:
         cwd = projects.get(project, cwd)
         output_capture = StringIO()
-        poe = PoeThePoet(cwd=cwd, config=config, output=output_capture)
+        poe = PoeThePoet(
+            cwd=cwd,
+            config=config,
+            output=output_capture,
+            config_name=config_name,
+            program_name=program_name,
+        )
         result = poe(run_args)
         output_capture.seek(0)
         return PoeRunResult(result, cwd, output_capture.read(), *capsys.readouterr())

--- a/tests/fixtures/custom_config_project/tasks.json
+++ b/tests/fixtures/custom_config_project/tasks.json
@@ -1,0 +1,9 @@
+{
+  "tool": {
+    "poe": {
+      "tasks": {
+        "hello": "poe_test_echo hello from tasks.json"
+      }
+    }
+  }
+}

--- a/tests/fixtures/custom_config_project/tasks.toml
+++ b/tests/fixtures/custom_config_project/tasks.toml
@@ -1,0 +1,4 @@
+
+
+[tool.poe.tasks.hello]
+cmd = "poe_test_echo hello from tasks.toml"

--- a/tests/fixtures/poetry_plugin_project/with_prefix/poetry.lock
+++ b/tests/fixtures/poetry_plugin_project/with_prefix/poetry.lock
@@ -1,0 +1,35 @@
+[[package]]
+name = "cowpy"
+version = "1.1.5"
+description = ""
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.source]
+type = "file"
+url = "../../packages/cowpy-1.1.5-py3-none-any.whl"
+
+[[package]]
+name = "poe-test-helpers"
+version = "0.2.0"
+description = "Provides cross platform executables to help with testing"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+develop = false
+
+[package.source]
+type = "directory"
+url = "../../packages/poe_test_helpers"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.7"
+content-hash = "94002636f413787b5c4816f3f896ec98cd57abc7c8a9bb8e084a4af1eb6d551c"
+
+[metadata.files]
+cowpy = [
+    {file = "cowpy-1.1.5-py3-none-any.whl", hash = "sha256:de5ae7646dd30b4936013666c6bd019af9cf411cc3b377c8538cfd8414262921"},
+]
+poe-test-helpers = []

--- a/tests/fixtures/poetry_plugin_project/with_prefix/poetry.toml
+++ b/tests/fixtures/poetry_plugin_project/with_prefix/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true

--- a/tests/fixtures/poetry_plugin_project/with_prefix/pyproject.toml
+++ b/tests/fixtures/poetry_plugin_project/with_prefix/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.poetry]
+name        = "poethepoet_plugin"
+version     = "0.1.0"
+description = "A project that uses poetry as a plugin."
+authors     = ["Nat Noordanus <n@natn.me>"]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+
+[tool.poetry.dev-dependencies]
+cowpy = { path = "../../packages/cowpy-1.1.5-py3-none-any.whl" }
+poe_test_helpers = { path = "../../packages/poe_test_helpers" }
+
+[tool.poe]
+poetry_command = "foo"
+
+[tool.poe.tasks]
+echo = { cmd = "poe_test_echo", help = "It's like echo"}
+cow-greet = "cowpy 'good day sir!'"
+
+[build-system]
+requires      = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,45 @@
+import re
+
+import pytest
+
+
+def test_customize_program_name(run_poe, projects):
+    result = run_poe(program_name="boop")
+    assert "USAGE\n  boop [-h]" in result.capture
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_bad_args_doc_with_custom_program_name(run_poe, projects, capsys):
+    with pytest.raises(SystemExit):
+        result = run_poe("async-task", "--fail", program_name="boop", project="scripts")
+    result = capsys.readouterr()
+    assert result.out == ""
+    assert result.err == (
+        "usage: boop async-task [--a A] [--b B]\n"
+        "boop async-task: error: unrecognized arguments: --fail\n"
+    )
+
+
+def test_customize_config_name(run_poe, projects, capsys):
+    result = run_poe("hello", config_name="tasks.toml", project="custom_config")
+    assert result.capture == "Poe => poe_test_echo hello from tasks.toml\n"
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_customize_config_name_with_json(run_poe, projects, capsys):
+    result = run_poe("hello", config_name="tasks.json", project="custom_config")
+    assert result.capture == "Poe => poe_test_echo hello from tasks.json\n"
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+    result = run_poe(
+        "--root",
+        str(projects["custom_config"]),
+        "hello",
+        config_name="tasks.json",
+    )
+    assert result.capture == "Poe => poe_test_echo hello from tasks.json\n"
+    assert result.stdout == ""
+    assert result.stderr == ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 import re
 
+import pytest
+
 from poethepoet import __version__
 
 

--- a/tests/test_poetry_plugin.py
+++ b/tests/test_poetry_plugin.py
@@ -14,8 +14,12 @@ def setup_poetry_project_empty_prefix(run_poetry, projects):
     run_poetry(["install"], cwd=projects["poetry_plugin/empty_prefix"].parent)
 
 
+@pytest.fixture(scope="session")
+def setup_poetry_project_with_prefix(run_poetry, projects):
+    run_poetry(["install"], cwd=projects["poetry_plugin/with_prefix"].parent)
+
+
 @pytest.mark.slow
-@pytest.mark.skipif(version_info < (3, 8), reason="dependencies require python>=3.8")
 def test_poetry_help(run_poetry, projects):
     result = run_poetry([], cwd=projects["poetry_plugin"])
     assert result.stdout.startswith("Poetry (version ")
@@ -25,7 +29,6 @@ def test_poetry_help(run_poetry, projects):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(version_info < (3, 8), reason="dependencies require python>=3.8")
 def test_task_with_cli_dependency(
     run_poetry, projects, setup_poetry_project, is_windows
 ):
@@ -47,7 +50,6 @@ def test_task_with_cli_dependency(
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(version_info < (3, 8), reason="dependencies require python>=3.8")
 def test_task_with_lib_dependency(
     run_poetry, projects, setup_poetry_project, is_windows
 ):
@@ -59,7 +61,6 @@ def test_task_with_lib_dependency(
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(version_info < (3, 8), reason="dependencies require python>=3.8")
 def test_task_accepts_any_args(run_poetry, projects, setup_poetry_project):
     result = run_poetry(
         ["poe", "echo", "--lol=:D", "--version", "--help"],
@@ -72,7 +73,6 @@ def test_task_accepts_any_args(run_poetry, projects, setup_poetry_project):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(version_info < (3, 8), reason="dependencies require python>=3.8")
 def test_poetry_help_without_poe_command_prefix(
     run_poetry, projects, setup_poetry_project_empty_prefix
 ):
@@ -84,7 +84,6 @@ def test_poetry_help_without_poe_command_prefix(
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(version_info < (3, 8), reason="dependencies require python>=3.8")
 def test_running_tasks_without_poe_command_prefix(
     run_poetry, projects, setup_poetry_project_empty_prefix
 ):
@@ -99,7 +98,43 @@ def test_running_tasks_without_poe_command_prefix(
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(version_info < (3, 8), reason="dependencies require python>=3.8")
+def test_poetry_help_with_poe_command_prefix(
+    run_poetry, projects, setup_poetry_project_empty_prefix
+):
+    result = run_poetry([], cwd=projects["poetry_plugin/with_prefix"].parent)
+    assert result.stdout.startswith("Poetry (version ")
+    assert "\n  foo cow-greet" in result.stdout
+    assert "\n  foo echo           It's like echo\n" in result.stdout
+    # assert result.stderr == ""
+
+
+@pytest.mark.slow
+def test_running_tasks_with_poe_command_prefix(
+    run_poetry, projects, setup_poetry_project_with_prefix
+):
+    result = run_poetry(
+        ["foo", "echo", "--lol=:D", "--version", "--help"],
+        cwd=projects["poetry_plugin/with_prefix"].parent,
+    )
+    assert result.stdout == (
+        "Poe => poe_test_echo --lol=:D --version --help\n--lol=:D --version --help\n"
+    )
+    # assert result.stderr == ""
+
+
+@pytest.mark.slow
+def test_running_tasks_with_poe_command_prefix(
+    run_poetry, projects, setup_poetry_project_with_prefix
+):
+    result = run_poetry(
+        ["foo"],
+        cwd=projects["poetry_plugin/with_prefix"].parent,
+    )
+    assert "USAGE\n  poetry foo [-h]" in result.stdout
+    # assert result.stderr == ""
+
+
+@pytest.mark.slow
 def test_running_poetry_command_with_hooks(run_poetry, projects, setup_poetry_project):
     result = run_poetry(["env", "info"], cwd=projects["poetry_plugin"])
     assert "THIS IS YOUR ENV!" in result.stdout


### PR DESCRIPTION
# Use case
I have a `pyproject.toml` within a packaged folder (with others in dynamic locations), and provide a global script which transparently runs `poe` inside a target folder to provide its tasks.

With this change, programs such as mine that wrap `poe` by using its main application class will automatically produce an accurate `USAGE` line.

Normal usage of `poe` will not see any change in the help message - regardless of whether it is running globally, via poetry, as a module, or as a poetry plugin.

## Possible improvements to this change

`PoeThePoet.__call__` could pass its `internal` flag down to `ui.print_help()` in order to control this behavior, or an optional program name field could be added to the class instead.
