### PR TITLE
Preserve '--' pseudo argument when passing to tasks

### DIFF
--- a/poethepoet/task/cmd.py
+++ b/poethepoet/task/cmd.py
@@ -39,7 +39,7 @@ class CmdTask(PoeTask):
             # dash token: `--`
             try:
                 split_index = extra_args.index("--")
-                extra_args = extra_args[split_index + 1 :]
+                extra_args = extra_args[split_index:]
             except ValueError:
                 extra_args = tuple()
 

--- a/poethepoet/ui.py
+++ b/poethepoet/ui.py
@@ -133,8 +133,23 @@ class PoeUi:
         return parser
 
     def parse_args(self, cli_args: Sequence[str]):
+        pre_pa_args: Sequence[str]
+        post_pa_args: Optional[Sequence[str]]
+        try:
+            pa_index = cli_args.index("--")
+            pre_pa_args = cli_args[:pa_index]
+            post_pa_args = cli_args[pa_index:]
+        except ValueError:
+            pre_pa_args = cli_args
+            post_pa_args = None
+
         self.parser = self.build_parser()
-        self.args = self.parser.parse_args(cli_args)
+        self.args = self.parser.parse_args(pre_pa_args)
+        if post_pa_args is not None:
+            if "task" in self.args:
+                self.args.task.extend(post_pa_args)
+            else:
+                self.args.task = post_pa_args
         self.verbosity: int = self["increase_verbosity"] - self["decrease_verbosity"]
         self._color.with_colors(self.args.ansi)
 

--- a/tests/test_cmd_tasks.py
+++ b/tests/test_cmd_tasks.py
@@ -37,8 +37,8 @@ def test_cmd_task_with_args_and_extra_args(run_poe_subproc):
         "!",
         project="cmds",
     )
-    assert result.capture == f"Poe => poe_test_echo hey you guy !\n"
-    assert result.stdout == "hey you guy !\n"
+    assert result.capture == f"Poe => poe_test_echo hey you -- guy !\n"
+    assert result.stdout == "hey you -- guy !\n"
     assert result.stderr == ""
 
 

--- a/tests/test_script_tasks.py
+++ b/tests/test_script_tasks.py
@@ -152,6 +152,29 @@ def test_script_task_with_short_args(run_poe_subproc):
     assert result.stderr == ""
 
 
+def test_script_task_with_short_args_extra(run_poe_subproc):
+    result = run_poe_subproc(
+        "greet-full-args",
+        "-g=Ciao",
+        "--user=toni",
+        "-a",
+        "109",
+        "-h=1.09",
+        "--",
+        "extra",
+        "arg",
+        "-h",
+        "x",
+        project="scripts",
+        env=no_venv,
+    )
+    assert result.capture == (
+        "Poe => greet-full-args -g=Ciao --user=toni -a 109 -h=1.09 -- extra arg -h x\n"
+    )
+    assert result.stdout == "Ciao toni 1.09 109\n"
+    assert result.stderr == ""
+
+
 def test_wrong_args_passed(run_poe_subproc):
     base_error = (
         "usage: poe greet-full-args [--greeting GREETING] [--user USER] [--upper]\n"


### PR DESCRIPTION
This commit makes it so that when a user passes the `--` pseudo-argument to a task, it is preserved for further processing by the task itself. Various commands may use `--` to e.g. pass arguments to another subprogram, or (e.g. in the case of `argparse`) to differentiate positional arguments from options.
    
Note that this change potentially breaks compatibility, as some already implemented tasks may rely on the `--` pseudo-argument being dropped, in fact, one of the tests was written that way. However, I strongly believe this is actually a bug and I decided to update the test as well.