### PR TITLE
📝 add information about referencing vars from PowerShell to docs

### DIFF
--- a/docs/guides/args_guide.rst
+++ b/docs/guides/args_guide.rst
@@ -195,6 +195,9 @@ The resulting task can be run like:
 
   poe passby --planet mars
 
+.. TIP::
+   For PowerShell tasks, the variable needs to be referenced as an environment variable in the shell code, e.g., :code:`$env:planet`.
+
 Arguments for script tasks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
It is not totally obvious how to reference variables passed to a shell that uses a PowerShell interpreter. The trick is you need to access them as environment variables. I added a brief blurb on how to do this to the docs. 

I rebuilt the docs and reviewed my change visually:
![image](https://github.com/nat-n/poethepoet/assets/48703453/5d375c38-4930-4f18-baf5-459c36a4328e)

The tip at the bottom is what I added.