### PR TITLE
Fix error message when the cwd directory does not exist

### DIFF
--- a/poethepoet/executor/base.py
+++ b/poethepoet/executor/base.py
@@ -152,6 +152,10 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         """
 
         try:
+            if self.working_dir and not self.working_dir.is_dir():
+                raise PoeException(
+                    f"Working directory {self.working_dir} could not be found."
+                )
             if use_exec:
                 if input:
                     raise ExecutionError("Cannot exec task that requires input!")


### PR DESCRIPTION
The current implementation outputs an error `executable could not be found` when the cwd directory does not exist.

The error message is confusing, so I added an error when the cwd does not exist.

## Behavior example

```toml
[tool.poe.tasks.cwd-ok]
cwd = ".github"
cmd = "echo ok"

[tool.poe.tasks.cwd-ng]
cwd = "notexist"
cmd = "echo ng"
```

## Current 

**Ubuntu(WSL)**

```
$ poe cwd-ok
Poe => echo ok
ok

$ poe cwd-ng
Poe => echo ng
Poe the Poet - A task runner that works well with poetry.
version 0.24.1

Error: executable 'echo' could not be found using virtualenv '/home/kzrnm/poethepoet/.venv' 

USAGE
  poe [-h] [-v | -q] [--root PATH] [--ansi | --no-ansi] task [task arguments]
....................................
```

**Windows(Git Bash)**

```
$ poe cwd-ok
Poe => echo ok
ok

$ poe cwd-ng
Poe => echo ng
Traceback (most recent call last):
....................................
  File "Z:\poethepoet\poethepoet\executor\base.py", line 164, in _execute_cmd
    return self._exec_via_subproc(cmd, input=input, env=env, shell=shell)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Z:\poethepoet\poethepoet\executor\base.py", line 231, in _exec_via_subproc
    proc = Popen(cmd, **popen_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Z:\Python311\Lib\subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "Z:\Python311\Lib\subprocess.py", line 1538, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
NotADirectoryError: [WinError 267] The directory name is invalid
```


## New 

**Ubuntu(WSL)**

```
$ poe cwd-ok
Poe => echo ok
ok

$ poe cwd-ng
Poe => echo ng
Poe the Poet - A task runner that works well with poetry.
version 0.24.1

Error: Working directory /home/kzrnm/poethepoet/notexist could not be found.

USAGE
  poe [-h] [-v | -q] [--root PATH] [--ansi | --no-ansi] task [task arguments]
....................................
```
