### PR TITLE
Skip PoetryExecutor if poetry is not found

### DIFF
--- a/poethepoet/executor/base.py
+++ b/poethepoet/executor/base.py
@@ -70,6 +70,10 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         self._is_windows = sys.platform == "win32"
 
     @classmethod
+    def fits_in(cls, context: "RunContext") -> bool:
+        return True
+
+    @classmethod
     def get(
         cls,
         invocation: Tuple[str, ...],
@@ -96,7 +100,6 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         by making some reasonable assumptions based on visible features of the
         environment
         """
-        from ..virtualenv import Virtualenv
 
         config_executor_type = context.executor_type
         if executor_config:
@@ -106,13 +109,13 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
                 )
             return cls.__executor_types[executor_config["type"]]
         elif config_executor_type == "auto":
-            if "poetry" in context.config.project["tool"]:
-                # Looks like this is a poetry project!
-                return cls.__executor_types["poetry"]
+            for impl in [
+                cls.__executor_types["poetry"],
+                cls.__executor_types["virtualenv"],
+            ]:
+                if impl.fits_in(context):
+                    return impl
 
-            if Virtualenv.detect(context.project_dir):
-                # Looks like there's a local virtualenv
-                return cls.__executor_types["virtualenv"]
             # Fallback to not using any particular environment
             return cls.__executor_types["simple"]
         else:

--- a/poethepoet/executor/base.py
+++ b/poethepoet/executor/base.py
@@ -70,7 +70,7 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         self._is_windows = sys.platform == "win32"
 
     @classmethod
-    def fits_in(cls, context: "RunContext") -> bool:
+    def works_with_context(cls, context: "RunContext") -> bool:
         return True
 
     @classmethod
@@ -113,7 +113,7 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
                 cls.__executor_types["poetry"],
                 cls.__executor_types["virtualenv"],
             ]:
-                if impl.fits_in(context):
+                if impl.works_with_context(context):
                     return impl
 
             # Fallback to not using any particular environment

--- a/poethepoet/executor/poetry.py
+++ b/poethepoet/executor/poetry.py
@@ -19,7 +19,7 @@ class PoetryExecutor(PoeExecutor):
     __options__: Dict[str, Type] = {}
 
     @classmethod
-    def fits_in(cls, context: "RunContext") -> bool:
+    def works_with_context(cls, context: "RunContext") -> bool:
         if "poetry" not in context.config.project["tool"]:
             return False
         return cls._poetry_cmd_from_path()

--- a/poethepoet/executor/poetry.py
+++ b/poethepoet/executor/poetry.py
@@ -22,7 +22,7 @@ class PoetryExecutor(PoeExecutor):
     def works_with_context(cls, context: "RunContext") -> bool:
         if "poetry" not in context.config.project["tool"]:
             return False
-        return cls._poetry_cmd_from_path()
+        return bool(cls._poetry_cmd_from_path())
 
     def execute(
         self, cmd: Sequence[str], input: Optional[bytes] = None, use_exec: bool = False

--- a/poethepoet/executor/virtualenv.py
+++ b/poethepoet/executor/virtualenv.py
@@ -4,6 +4,7 @@ from ..exceptions import PoeException
 from .base import PoeExecutor
 
 if TYPE_CHECKING:
+    from ..context import RunContext
     from ..virtualenv import Virtualenv
 
 
@@ -14,6 +15,12 @@ class VirtualenvExecutor(PoeExecutor):
 
     __key__ = "virtualenv"
     __options__: Dict[str, Type] = {"location": str}
+
+    @classmethod
+    def fits_in(cls, context: "RunContext") -> bool:
+        from ..virtualenv import Virtualenv
+
+        return Virtualenv.detect(context.project_dir)
 
     def execute(
         self, cmd: Sequence[str], input: Optional[bytes] = None, use_exec: bool = False

--- a/poethepoet/executor/virtualenv.py
+++ b/poethepoet/executor/virtualenv.py
@@ -17,7 +17,7 @@ class VirtualenvExecutor(PoeExecutor):
     __options__: Dict[str, Type] = {"location": str}
 
     @classmethod
-    def fits_in(cls, context: "RunContext") -> bool:
+    def works_with_context(cls, context: "RunContext") -> bool:
         from ..virtualenv import Virtualenv
 
         return Virtualenv.detect(context.project_dir)


### PR DESCRIPTION
poe cannot run `PoetryExecutor` if poetry is set as an alias instead of `$PATH`.

I want to skip `PoetryExecutor` when poetry is not found.