### PR TITLE
Make switch task work as expected with 'uses' option

### DIFF
--- a/poethepoet/task/script.py
+++ b/poethepoet/task/script.py
@@ -48,13 +48,13 @@ class ScriptTask(PoeTask):
 
         script = [
             "import asyncio,os,sys;",
-            "from inspect import iscoroutinefunction as ic;",
+            "from inspect import iscoroutinefunction as _c;",
             "from os import environ;",
-            "from importlib import import_module as im;",
+            "from importlib import import_module as _i;",
             f"sys.argv = {argv!r}; sys.path.append('src');",
             f"{format_class(named_arg_values)}",
-            f"_m = im('{target_module}');",
-            f"_r = asyncio.run(_m.{function_call}) if ic(_m.{function_ref})",
+            f"_m = _i('{target_module}');",
+            f"_r = asyncio.run(_m.{function_call}) if _c(_m.{function_ref})",
             f" else _m.{function_call};",
         ]
 

--- a/poethepoet/task/switch.py
+++ b/poethepoet/task/switch.py
@@ -88,6 +88,7 @@ class SwitchTask(PoeTask):
                     config=config,
                     invocation=task_invocation,
                     ui=ui,
+                    capture_stdout=self.options.get("capture_stdout", capture_stdout),
                     inheritance=TaskInheritance.from_task(self),
                 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,13 +145,6 @@ _clean_docs.script = "shutil:rmtree('docs/_build', ignore_errors=1)"
   help   = "Execute poe from this repo (useful for testing)"
   script = "poethepoet:main"
 
-  [tool.poe.tasks.y]
-  cmd = "pwd"
-
-  [tool.poe.tasks.x]
-  sequence = ["y", {cmd = "pwd"}]
-  cwd = "tests"
-
 
 [tool.rstcheck]
 ignore_messages = [

--- a/tests/fixtures/switch_project/pyproject.toml
+++ b/tests/fixtures/switch_project/pyproject.toml
@@ -71,3 +71,18 @@ control = "poe_test_echo ${WHATEVER}"
   [[tool.poe.tasks.multivalue_case.switch]]
   shell = "import sys; print('It is not in 1-6')"
   interpreter = "python"
+
+
+[tool.poe.tasks.switcher]
+control.expr = "42"
+
+  [[tool.poe.tasks.switcher.switch]]
+  case = "42"
+  cmd = "echo 'matched'"
+
+  [[tool.poe.tasks.switcher.switch]]
+  cmd = "echo other"
+
+[tool.poe.tasks.switcher_user]
+uses = { switched = "switcher" }
+cmd = "echo switched=$switched"

--- a/tests/test_switch_task.py
+++ b/tests/test_switch_task.py
@@ -86,6 +86,15 @@ def test_switch_dry_run(run_poe_subproc):
     assert result.stderr == ""
 
 
+def test_switch_in_in_graph(run_poe_subproc):
+    result = run_poe_subproc("switcher_user", project="switch")
+    assert result.capture == (
+        "Poe <= 42\n" "Poe <= echo matched\n" "Poe => echo switched=matched\n"
+    )
+    assert result.stdout == "switched=matched\n"
+    assert result.stderr == ""
+
+
 def test_switch_multivalue_case(run_poe_subproc):
     for num in ("1", "3", "5"):
         result = run_poe_subproc(


### PR DESCRIPTION
Fixes #182 by making a switch task capture the contents of the case task for the next task to use.

Also tweak implementation of script tasks to make variable collisions less likely.