### PR TITLE
Make args work as expected on ref tasks

### DIFF
--- a/docs/tasks/task_types/ref.rst
+++ b/docs/tasks/task_types/ref.rst
@@ -33,3 +33,9 @@ Available task options
 ----------------------
 
 ``ref`` tasks support all of the :doc:`standard task options <../options>` with the exception of ``use_exec``.
+
+
+Passing arguments
+-----------------
+
+By default any arguments passed to a ref task will be forwarded to the referenced task, allowing it to function as a task alias. If named arguments are configured for the ref task then additional arguments can still be passed to the referenced task after ``--`` on the command line.

--- a/poethepoet/app.py
+++ b/poethepoet/app.py
@@ -153,7 +153,7 @@ class PoeThePoet:
         if context is None:
             context = self.get_run_context()
         try:
-            return task.run(context=context, extra_args=task.invocation[1:])
+            return task.run(context=context)
         except PoeException as error:
             self.print_help(error=error)
             return 1
@@ -175,9 +175,7 @@ class PoeThePoet:
                     return self.run_task(stage_task, context)
 
                 try:
-                    task_result = stage_task.run(
-                        context=context, extra_args=stage_task.invocation[1:]
-                    )
+                    task_result = stage_task.run(context=context)
                     if task_result:
                         raise ExecutionError(
                             f"Task graph aborted after failed task {stage_task.name!r}"

--- a/poethepoet/task/args.py
+++ b/poethepoet/task/args.py
@@ -298,13 +298,15 @@ class PoeTaskArgs:
 
         return result
 
-    def parse(self, extra_args: Sequence[str]):
-        parsed_args = vars(self.build_parser().parse_args(extra_args))
+    def parse(self, args: Sequence[str]) -> Dict[str, str]:
+        parsed_args = vars(self.build_parser().parse_args(args))
+
         # Ensure positional args are still exposed by name even if they were parsed with
         # alternate identifiers
         for arg in self._args:
             if isinstance(arg.get("positional"), str):
                 parsed_args[arg["name"]] = parsed_args[arg["positional"]]
                 del parsed_args[arg["positional"]]
+
         # args named with dash case are converted to snake case before being exposed
         return {name.replace("-", "_"): value for name, value in parsed_args.items()}

--- a/poethepoet/task/expr.py
+++ b/poethepoet/task/expr.py
@@ -6,7 +6,6 @@ from typing import (
     Iterable,
     Mapping,
     Optional,
-    Sequence,
     Tuple,
     Type,
     Union,
@@ -38,20 +37,21 @@ class ExprTask(PoeTask):
     def _handle_run(
         self,
         context: "RunContext",
-        extra_args: Sequence[str],
         env: "EnvVarsManager",
     ) -> int:
         from ..helpers.python import format_class
 
-        named_arg_values = self.get_named_arg_values(env)
+        named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.update(named_arg_values)
+
+        # TODO: do something about extra_args, error?
 
         imports = self.options.get("imports", tuple())
 
         expr, env_values = self.parse_content(named_arg_values, env, imports)
         argv = [
             self.name,
-            *(env.fill_template(token) for token in extra_args),
+            *(env.fill_template(token) for token in self.invocation[1:]),
         ]
 
         script = [

--- a/poethepoet/task/script.py
+++ b/poethepoet/task/script.py
@@ -1,6 +1,6 @@
 import re
 import shlex
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, Union
 
 from ..exceptions import ExpressionParseError
 from .base import PoeTask
@@ -27,20 +27,21 @@ class ScriptTask(PoeTask):
     def _handle_run(
         self,
         context: "RunContext",
-        extra_args: Sequence[str],
         env: "EnvVarsManager",
     ) -> int:
         from ..helpers.python import format_class
 
-        named_arg_values = self.get_named_arg_values(env)
+        named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.update(named_arg_values)
+
+        # TODO: do something about extra_args, error?
 
         target_module, function_call = self.parse_content(named_arg_values)
         function_ref = function_call[: function_call.index("(")]
 
         argv = [
             self.name,
-            *(env.fill_template(token) for token in extra_args),
+            *(env.fill_template(token) for token in self.invocation[1:]),
         ]
 
         # TODO: check whether the project really does use src layout, and don't do

--- a/poethepoet/task/shell.py
+++ b/poethepoet/task/shell.py
@@ -6,7 +6,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Sequence,
     Tuple,
     Type,
     Union,
@@ -34,13 +33,12 @@ class ShellTask(PoeTask):
     def _handle_run(
         self,
         context: "RunContext",
-        extra_args: Sequence[str],
         env: "EnvVarsManager",
     ) -> int:
-        named_arg_values = self.get_named_arg_values(env)
+        named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.update(named_arg_values)
 
-        if not named_arg_values and any(arg.strip() for arg in extra_args):
+        if not named_arg_values and any(arg.strip() for arg in self.invocation[1:]):
             raise PoeException(f"Shell task {self.name!r} does not accept arguments")
 
         interpreter_cmd = self.resolve_interpreter_cmd()

--- a/tests/fixtures/refs_project/pyproject.toml
+++ b/tests/fixtures/refs_project/pyproject.toml
@@ -10,3 +10,14 @@ ref = "greet lol!"
 
 [tool.poe.tasks.greet-dave]
 ref = "greet-subject --subject dave"
+
+[tool.poe.tasks.apologize]
+cmd  = "echo \"I'm sorry ${name}, ${explain}\""
+args = ["name", "explain"]
+
+[tool.poe.tasks.say-sorry]
+ref = "apologize"
+
+[tool.poe.tasks.sorry-dave]
+ref  = "apologize --name=Dave --explain='${explain}'"
+args = [{ name = "explain", positional = true, multiple = true }]

--- a/tests/test_ref_task.py
+++ b/tests/test_ref_task.py
@@ -10,3 +10,61 @@ def test_ref_passes_extra_args_in_definition(run_poe_subproc):
     assert result.capture == "Poe => poe_test_echo hi 'lol!'\n"
     assert result.stdout == "hi lol!\n"
     assert result.stderr == ""
+
+
+def test_ref_parses_named_args(run_poe_subproc):
+    result = run_poe_subproc(
+        "apologize", "--name=Davey", "--explain=Ah cannae dae that", project="refs"
+    )
+    assert (
+        result.capture == """Poe => echo 'I'"'"'m sorry Davey, Ah cannae dae that'\n"""
+    )
+    assert result.stdout == "I'm sorry Davey, Ah cannae dae that\n"
+    assert result.stderr == ""
+
+
+def test_ref_forwards_arguments_if_none_defined(run_poe_subproc):
+    result = run_poe_subproc(
+        "say-sorry",
+        "--name=Davey",
+        "--explain=Ah cannae dae that",
+        "--",
+        ",",
+        "anything",
+        "else?",
+        project="refs",
+    )
+    assert result.capture == (
+        """Poe => echo 'I'"'"'m sorry Davey, Ah cannae dae that'"""
+        """ , anything 'else?'\n"""
+    )
+    assert result.stdout == "I'm sorry Davey, Ah cannae dae that , anything else?\n"
+    assert result.stderr == ""
+
+
+def test_ref_forwards_arguments(run_poe_subproc):
+    result = run_poe_subproc(
+        "sorry-dave",
+        "I",
+        "cant",
+        "do",
+        "that",
+        "--",
+        "--",
+        ",",
+        "anything",
+        "else?",
+        project="refs",
+    )
+    assert (
+        result.capture
+        == """Poe => echo 'I'"'"'m sorry Dave, I cant do that' , anything 'else?'\n"""
+    )
+    assert result.stdout == "I'm sorry Dave, I cant do that , anything else?\n"
+    assert result.stderr == ""
+
+    # Pass extra args including -- if no args defined
+    result = run_poe_subproc("greet-funny", "OK", project="refs")
+    assert result.capture == "Poe => poe_test_echo hi 'lol!' OK\n"
+    assert result.stdout == "hi lol! OK\n"
+    assert result.stderr == ""


### PR DESCRIPTION
Ref tasks can now parse named arguments and template the values into the invocation of the referenced task. Extra args (provided after `--` or all args if named arg configured) are appended to the invocation

Additional refactor:
- Add debug logging that is activated by setting the POE_DEBUG environment variable
- consolidate logic for getting extra args passed after `--`
- Remove extra_args argument from methods for task running in favour of always use 
  invocation as the source of truth for CLI args

Related #196