### PR TITLE
Fixes Windows error message due to incorrect type comparison.

### DIFF
--- a/poethepoet/task/shell.py
+++ b/poethepoet/task/shell.py
@@ -48,7 +48,7 @@ class ShellTask(PoeTask):
                 f"Couldn't locate interpreter executable for {config_value!r} to run "
                 "shell task. "
             )
-            if self._is_windows and config_value in ("posix", "bash"):
+            if self._is_windows and set(config_value).issubset({"posix", "bash"}):
                 message += "Installing Git Bash or using WSL should fix this."
             else:
                 message += "Some dependencies may be missing from your system."


### PR DESCRIPTION
On Windows, I only see `Some dependencies may be missing from your system.` even though the value of `config_value` is `('posix',)`. This is because the type comparison is wrong, it checks that the tuple `('posix',)` is in `('posix', 'bash')`, instead of checking the string `posix`.

This PR fixes it by doing a set subset check.