### PR TITLE
Fix docs plugin link

### DIFF
--- a/docs/poetry_plugin.rst
+++ b/docs/poetry_plugin.rst
@@ -125,4 +125,4 @@ Therefore it is generally recommended to use the poe CLI tool directly if you do
 
 .. |poetry_plugin_link| raw:: html
 
-   <a href="https://python-poetry.org/docs/master/plugins/#using-plugins" target="_blank">poetry plugin</a>
+   <a href="https://python-poetry.org/docs/main/plugins/#using-plugins" target="_blank">poetry plugin</a>


### PR DESCRIPTION
Hi there,
I have noticed that the following URL is broken on this page: https://poethepoet.natn.io/poetry_plugin.html
https://python-poetry.org/docs/master/plugins/#using-plugins

I have changed it to:
https://python-poetry.org/docs/main/plugins/#using-plugins

Have a nice day 😃 
Great tool btw!
