### PR TITLE
Fix plugin get directory from poetry

### DIFF
--- a/poethepoet/plugin.py
+++ b/poethepoet/plugin.py
@@ -56,7 +56,11 @@ class PoeCommand(Command):
         except:  # noqa: E722
             poetry_env_path = None
 
-        cwd = Path().resolve()
+        # Get the cwd from poetry to ensure '--directory subdir' usage
+        try:
+            cwd = application.poetry.pyproject_path
+        except AttributeError:
+            cwd = Path().resolve()
         config = PoeConfig(cwd=cwd)
 
         if io.output.is_quiet():


### PR DESCRIPTION
https://github.com/nat-n/poethepoet/discussions/209

With a bit of tinkering, I found `application.poetry.pyproject_path`. This contains the path to pyproject.toml

Using the example of #209:
Running `poetry --directory backend install` from the dir `project/` the attribute `application.poetry.pyproject_path` has the value `backend/pyproject.toml`
Running `poetry install` from the dir `project/backend/` the attribute `application.poetry.pyproject_path` has the value `/project/backend/pyproject.toml`

I hope I haven't missed anything essential 😃 