### PR TITLE
Allow poetry plugin with empty command prefix to run tasks included from another file

### DIFF
--- a/poethepoet/config.py
+++ b/poethepoet/config.py
@@ -9,6 +9,7 @@ except ImportError:
 
 from typing import (
     Any,
+    Dict,
     Iterator,
     List,
     Mapping,
@@ -280,9 +281,7 @@ class PoeConfig:
             Path().resolve() if cwd is None else Path(cwd)
         )
         self._project_config = ProjectConfig(
-            {"tool.poe": table or {}},
-            path=self._project_dir.joinpath(config_name),
-            strict=False,
+            {"tool.poe": table or {}}, path=self._project_dir, strict=False
         )
         self._included_config = []
 
@@ -322,7 +321,7 @@ class PoeConfig:
         yield from result
 
     @property
-    def tasks(self) -> Mapping[str, Any]:
+    def tasks(self) -> Dict[str, Any]:
         result = dict(self._project_config.get("tasks", {}))
         for config in self._included_config:
             for task_name, task_def in config.get("tasks", {}).items():
@@ -356,7 +355,7 @@ class PoeConfig:
 
     @property
     def is_poetry_project(self) -> bool:
-        return "poetry" in self._project_config.full_config
+        return "poetry" in self._project_config.full_config.get("tool", {})
 
     @property
     def project_dir(self) -> Path:

--- a/poethepoet/plugin.py
+++ b/poethepoet/plugin.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from cleo.commands.command import Command
 from cleo.events.console_command_event import ConsoleCommandEvent
@@ -10,6 +10,9 @@ from poetry.console.application import COMMANDS, Application
 from poetry.plugins.application_plugin import ApplicationPlugin
 
 from .exceptions import PoePluginException
+
+if TYPE_CHECKING:
+    from .config import PoeConfig
 
 
 class PoeCommand(Command):
@@ -87,7 +90,7 @@ class PoetryPlugin(ApplicationPlugin):
 
             debug = bool(int(os.environ.get("DEBUG_POE_PLUGIN", "0")))
             print(
-                "error: poethepoet plugin failed to activate."
+                "error: poethepoet plugin encountered an error."
                 + ("" if debug else " Set DEBUG_POE_PLUGIN=1 for details."),
                 file=sys.stderr,
             )
@@ -104,10 +107,10 @@ class PoetryPlugin(ApplicationPlugin):
             # If there's no pyproject.toml then probably that's OK, don't freak out
             return
 
-        command_prefix = poe_config.get("poetry_command", "poe").strip()
+        command_prefix = poe_config._project_config.get("poetry_command").strip()
         PoeCommand.command_prefix = command_prefix
 
-        poe_tasks = poe_config.get("tasks", {})
+        poe_tasks = poe_config.tasks
         self._validate_command_prefix(command_prefix)
 
         if command_prefix in COMMANDS:
@@ -117,22 +120,12 @@ class PoetryPlugin(ApplicationPlugin):
             )
 
         if command_prefix == "":
-            # Register a dummy command prefix
-            # to allow cleo to identify commands coming from poe
-            self._register_command(
-                application,
-                "",
-                {"help": "Run poe tasks defined for this project"},
-                "poe",
-            )
             for task_name, task in poe_tasks.items():
                 if task_name in COMMANDS:
                     raise PoePluginException(
                         f"Poe task {task_name!r} conflicts with a poetry command. "
                         "Please rename the task or the configure a command prefix."
                     )
-                # Don't register tasks under the dummy command prefix,
-                # we still want no prefix here
                 self._register_command(application, task_name, task)
         else:
             self._register_command(
@@ -151,33 +144,22 @@ class PoetryPlugin(ApplicationPlugin):
         self._monkey_patch_cleo(command_prefix, list(poe_tasks.keys()))
 
         self._register_command_event_handler(
-            application, poe_config.get("poetry_hooks", {})
+            application, poe_config._project_config.get("poetry_hooks", {})
         )
 
     @classmethod
-    def _get_config(cls, application: Application) -> Dict[str, Any]:
+    def _get_config(cls, application: Application) -> "PoeConfig":
+        from .config import PoeConfig
+
+        # Try respect poetry's '--directory' if set
         try:
-            pyproject = application.poetry.pyproject.data
-        except:  # noqa: E722
-            # Fallback to loading the config again in case of future failure of the
-            # above undocumented API
-            import tomlkit
+            pyproject_dir = application.poetry.pyproject_path.parent
+        except AttributeError:
+            pyproject_dir = None
 
-            from .config import PoeConfig
-
-            # Try respect poetry's '--directory' if set
-            try:
-                pyproject_path = Path(application.poetry.pyproject_path)
-            except AttributeError:
-                pyproject_path = None
-
-            pyproject = tomlkit.loads(
-                Path(
-                    PoeConfig().find_config_file(target_path=pyproject_path)
-                ).read_text()
-            )
-
-        return pyproject.get("tool", {}).get("poe", {})
+        poe_config = PoeConfig(cwd=pyproject_dir)
+        poe_config.load(strict=False)
+        return poe_config
 
     def _validate_command_prefix(self, command_prefix: str):
         if command_prefix and not command_prefix.isalnum():
@@ -284,16 +266,7 @@ class PoetryPlugin(ApplicationPlugin):
             tokens = io.input._tokens
             task_name_index = _index_of_first_non_option(tokens)
             poe_commands = (prefix,) if prefix else task_names
-            # If the prefix is an empty string, and it's not a poetry command
-            # We need to add the dummy prefix to the command so cleo can identify it
             if (
-                prefix == ""
-                and 0 <= task_name_index < len(tokens)
-                and tokens[task_name_index] not in COMMANDS
-            ):
-                tokens.insert(task_name_index, "poe")
-                tokens.insert(task_name_index, "--")
-            elif (
                 0 <= task_name_index < len(tokens)
                 and tokens[task_name_index] in poe_commands
             ):

--- a/tests/fixtures/poetry_plugin_project/empty_prefix/pyproject.toml
+++ b/tests/fixtures/poetry_plugin_project/empty_prefix/pyproject.toml
@@ -13,6 +13,7 @@ poe_test_helpers = { path = "../../packages/poe_test_helpers" }
 
 [tool.poe]
 poetry_command = ""
+include = "tasks.toml"
 
 [tool.poe.tasks]
 echo = { cmd = "poe_test_echo", help = "It's like echo"}

--- a/tests/fixtures/poetry_plugin_project/empty_prefix/tasks.toml
+++ b/tests/fixtures/poetry_plugin_project/empty_prefix/tasks.toml
@@ -1,0 +1,2 @@
+[tool.poe.tasks]
+included-greeting = "echo 'Greetings from another file!'"

--- a/tests/test_poetry_plugin.py
+++ b/tests/test_poetry_plugin.py
@@ -106,6 +106,17 @@ def test_running_tasks_without_poe_command_prefix(run_poetry, projects):
 
 @pytest.mark.slow()
 @pytest.mark.usefixtures("_setup_poetry_project_empty_prefix")
+def test_poetry_command_from_included_file_with_empty_prefix(run_poetry, projects):
+    result = run_poetry(
+        ["included-greeting"],
+        cwd=projects["poetry_plugin/empty_prefix"].parent,
+    )
+    assert result.stdout.startswith("Poe => echo 'Greetings from another file!'")
+    # assert result.stderr == ""
+
+
+@pytest.mark.slow()
+@pytest.mark.usefixtures("_setup_poetry_project_empty_prefix")
 def test_poetry_help_with_poe_command_prefix(run_poetry, projects):
     result = run_poetry([], cwd=projects["poetry_plugin/with_prefix"].parent)
     assert result.stdout.startswith("Poetry (version ")


### PR DESCRIPTION
Fixes https://github.com/nat-n/poethepoet/issues/199 by making the poetry plugin load tasks using PoeConfig to ensure included task files are loaded as usual.

Replaces #200