### PR TITLE
Add --executor CLI option to override the executor at runtime.

### DIFF
--- a/docs/global_options.rst
+++ b/docs/global_options.rst
@@ -107,13 +107,17 @@ The default behaviour is **auto**.
 
 For example, the following configuration will cause poe to ignore the poetry environment
 (if present), and instead use the virtualenv at the given location relative to the
-parent directory.
+parent directory. If no location is specified for a virtualenv then the default behavior is to use the virtualenv from ``./venv`` or ``./.venv`` if available.
 
 .. code-block:: toml
 
   [tool.poe.executor]
   type = "virtualenv"
   location = "myvenv"
+
+.. important::
+
+  This global option can be overridden at runtime by providing the ``--executor`` cli option before the task name with the name of the executor type to use.
 
 Change the default shell interpreter
 ------------------------------------

--- a/poethepoet/context.py
+++ b/poethepoet/context.py
@@ -51,10 +51,6 @@ class RunContext:
                 config_working_dir=config_part.cwd,
             )
 
-    @property
-    def executor_type(self) -> Optional[str]:
-        return self.config.executor["type"]
-
     def _get_dep_values(
         self, used_task_invocations: Mapping[str, Tuple[str, ...]]
     ) -> Dict[str, str]:
@@ -99,12 +95,18 @@ class RunContext:
     ) -> "PoeExecutor":
         from .executor import PoeExecutor
 
+        if not executor_config:
+            if self.ui["executor"]:
+                executor_config = {"type": self.ui["executor"]}
+            else:
+                executor_config = self.config.executor
+
         return PoeExecutor.get(
             invocation=invocation,
             context=self,
+            executor_config=executor_config,
             env=env,
             working_dir=working_dir,
-            executor_config=executor_config,
             capture_stdout=capture_stdout,
             dry=self.dry,
         )

--- a/poethepoet/ui.py
+++ b/poethepoet/ui.py
@@ -123,6 +123,16 @@ class PoeUi:
             help="Specify where to find the pyproject.toml",
         )
 
+        parser.add_argument(
+            "-e",
+            "--executor",
+            dest="executor",
+            metavar="EXECUTOR",
+            type=str,
+            default="",
+            help="Override the default task executor",
+        )
+
         # legacy --root parameter, keep for backwards compatibility but help output is
         # suppressed
         parser.add_argument(
@@ -216,9 +226,9 @@ class PoeUi:
         if verbosity >= 0:
             result.append(
                 (
-                    "<h2>USAGE</h2>",
+                    "<h2>Usage:</h2>",
                     f"  <u>{self.program_name}</u>"
-                    " [-h] [-v | -q] [-C PATH] [--ansi | --no-ansi]"
+                    " [global options]"
                     " task [task arguments]",
                 )
             )
@@ -230,7 +240,7 @@ class PoeUi:
             formatter.add_arguments(action_group._group_actions)
             formatter.end_section()
             result.append(
-                ("<h2>GLOBAL OPTIONS</h2>", *formatter.format_help().split("\n")[1:])
+                ("<h2>Global options:</h2>", *formatter.format_help().split("\n")[1:])
             )
 
             if tasks:
@@ -248,9 +258,9 @@ class PoeUi:
                     )
                     for task, (_, args) in tasks.items()
                 )
-                col_width = max(13, min(30, max_task_len))
+                col_width = max(20, min(30, max_task_len))
 
-                tasks_section = ["<h2>CONFIGURED TASKS</h2>"]
+                tasks_section = ["<h2>Configured tasks:</h2>"]
                 for task, (help_text, args_help) in tasks.items():
                     if task.startswith("_"):
                         continue

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@ import pytest
 
 def test_customize_program_name(run_poe, projects):
     result = run_poe(program_name="boop")
-    assert "USAGE\n  boop [-h]" in result.capture
+    assert "Usage:\n  boop [global options] task" in result.capture
     assert result.stdout == ""
     assert result.stderr == ""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ def test_call_no_args(run_poe):
     assert (
         "\nResult: No task specified.\n" in result.capture
     ), "Output should include status message"
-    assert "CONFIGURED TASKS\n  echo" in result.capture, "echo task should be in help"
+    assert "Configured tasks:\n  echo" in result.capture, "echo task should be in help"
 
 
 def test_call_with_directory(run_poe, projects):
@@ -25,8 +25,8 @@ def test_call_with_directory(run_poe, projects):
         "\nResult: No task specified.\n" in result.capture
     ), "Output should include status message"
     assert (
-        "CONFIGURED TASKS\n"
-        "  echo                 It says what you say" in result.capture
+        "Configured tasks:\n"
+        "  echo                  It says what you say" in result.capture
     ), "echo task should be in help"
 
 
@@ -40,8 +40,8 @@ def test_call_with_directory_set_via_env(run_poe_subproc, projects):
         "\nResult: No task specified.\n" in result.capture
     ), "Output should include status message"
     assert (
-        "CONFIGURED TASKS\n"
-        "  echo                 It says what you say" in result.capture
+        "Configured tasks:\n"
+        "  echo                  It says what you say" in result.capture
     ), "echo task should be in help"
 
 
@@ -56,8 +56,8 @@ def test_call_with_root(run_poe, projects):
         "\nResult: No task specified.\n" in result.capture
     ), "Output should include status message"
     assert (
-        "CONFIGURED TASKS\n"
-        "  echo                 It says what you say" in result.capture
+        "Configured tasks:\n"
+        "  echo                  It says what you say" in result.capture
     ), "echo task should be in help"
 
 
@@ -111,7 +111,7 @@ def test_documentation_of_task_named_args(run_poe):
     ), "Output should include status message"
 
     assert re.search(
-        r"CONFIGURED TASKS\n"
+        r"Configured tasks:\n"
         r"  composite_task          \s+\n"
         r"  echo-args               \s+\n"
         r"  static-args-test        \s+\n"

--- a/tests/test_includes.py
+++ b/tests/test_includes.py
@@ -20,11 +20,11 @@ def _init_git_submodule(projects):
 def test_docs_for_include_toml_file(run_poe_subproc):
     result = run_poe_subproc(project="includes")
     assert (
-        "CONFIGURED TASKS\n"
-        "  echo           says what you say\n"
-        "  greet          \n"
-        "  greet1         \n"
-        "  greet2         Issue a greeting from the Iberian Peninsula\n"
+        "Configured tasks:\n"
+        "  echo                  says what you say\n"
+        "  greet                 \n"
+        "  greet1                \n"
+        "  greet2                Issue a greeting from the Iberian Peninsula\n"
     ) in result.capture
     assert result.stdout == ""
     assert result.stderr == ""
@@ -49,7 +49,7 @@ def test_docs_for_multiple_includes(run_poe_subproc, projects):
         f'-C={projects["includes/multiple_includes"]}',
     )
     assert (
-        "CONFIGURED TASKS\n"
+        "Configured tasks:\n"
         "  echo                    says what you say\n"
         "  greet                   \n"
         "  greet1                  \n"
@@ -102,11 +102,11 @@ def test_docs_for_only_includes(run_poe_subproc, projects):
         f'-C={projects["includes/only_includes"]}',
     )
     assert (
-        "CONFIGURED TASKS\n"
-        "  echo           This is ignored because it's already defined!\n"  # or not
-        "  greet          \n"
-        "  greet1         \n"
-        "  greet2         Issue a greeting from the Iberian Peninsula\n"
+        "Configured tasks:\n"
+        "  echo                  This is ignored because it's already defined!\n"
+        "  greet                 \n"
+        "  greet1                \n"
+        "  greet2                Issue a greeting from the Iberian Peninsula\n"
     ) in result.capture
     assert result.stdout == ""
     assert result.stderr == ""
@@ -115,14 +115,14 @@ def test_docs_for_only_includes(run_poe_subproc, projects):
 def test_monorepo_contains_only_expected_tasks(run_poe_subproc, projects):
     result = run_poe_subproc(project="monorepo")
     assert result.capture.endswith(
-        "CONFIGURED TASKS\n"
-        "  get_cwd_0      \n"
-        "  get_cwd_1      \n"
-        "  add            \n"
-        "  get_cwd_2      \n"
-        "  subproj3_env   \n"
-        "  get_cwd_3      \n"
-        "  subproj4_env   \n\n\n"
+        "Configured tasks:\n"
+        "  get_cwd_0             \n"
+        "  get_cwd_1             \n"
+        "  add                   \n"
+        "  get_cwd_2             \n"
+        "  subproj3_env          \n"
+        "  get_cwd_3             \n"
+        "  subproj4_env          \n\n\n"
     )
     assert result.stdout == ""
     assert result.stderr == ""
@@ -131,11 +131,11 @@ def test_monorepo_contains_only_expected_tasks(run_poe_subproc, projects):
 def test_monorepo_can_also_include_parent(run_poe_subproc, projects, is_windows):
     result = run_poe_subproc(cwd=projects["monorepo/subproject_2"])
     assert result.capture.endswith(
-        "CONFIGURED TASKS\n"
-        "  add            \n"
-        "  get_cwd_2      \n"
-        "  extra_task     \n"
-        "  get_cwd_0      \n\n\n"
+        "Configured tasks:\n"
+        "  add                   \n"
+        "  get_cwd_2             \n"
+        "  extra_task            \n"
+        "  get_cwd_0             \n\n\n"
     )
     assert result.stdout == ""
     assert result.stderr == ""

--- a/tests/test_poetry_plugin.py
+++ b/tests/test_poetry_plugin.py
@@ -145,7 +145,7 @@ def test_running_tasks_with_poe_command_prefix_missing_args(run_poetry, projects
         ["foo"],
         cwd=projects["poetry_plugin/with_prefix"].parent,
     )
-    assert "USAGE\n  poetry foo [-h]" in result.stdout
+    assert "Usage:\n  poetry foo [global options]" in result.stdout
     # assert result.stderr == ""
 
 


### PR DESCRIPTION
Also:
- Tweak output style to be more similar to poetry/cleo
- Add debug output when creating an executor
- Streamline executor creation logic to be simpler