### PR TITLE
Modernize types with `ruff check --select=FA,UP`

### DIFF
--- a/poethepoet/app.py
+++ b/poethepoet/app.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path
@@ -54,18 +56,18 @@ class PoeThePoet:
     """
 
     cwd: Path
-    ui: "PoeUi"
-    config: "PoeConfig"
+    ui: PoeUi
+    config: PoeConfig
 
-    _task_specs: Optional[Dict[str, "PoeTask.TaskSpec"]] = None
+    _task_specs: dict[str, PoeTask.TaskSpec] | None = None
 
     def __init__(
         self,
-        cwd: Optional[Union[Path, str]] = None,
-        config: Optional[Union[Mapping[str, Any], "PoeConfig"]] = None,
+        cwd: Path | str | None = None,
+        config: Mapping[str, Any] | PoeConfig | None = None,
         output: IO = sys.stdout,
-        poetry_env_path: Optional[str] = None,
-        config_name: Optional[str] = None,
+        poetry_env_path: str | None = None,
+        config_name: str | None = None,
         program_name: str = "poe",
     ):
         from .config import PoeConfig
@@ -134,7 +136,7 @@ class PoeThePoet:
             self._task_specs = TaskSpecFactory(self.config)
         return self._task_specs
 
-    def resolve_task(self, allow_hidden: bool = False) -> Optional["PoeTask"]:
+    def resolve_task(self, allow_hidden: bool = False) -> PoeTask | None:
         from .task.base import TaskContext
 
         task = tuple(self.ui["task"])
@@ -167,8 +169,8 @@ class PoeThePoet:
         )
 
     def run_task(
-        self, task: "PoeTask", context: Optional["RunContext"] = None
-    ) -> Optional[int]:
+        self, task: PoeTask, context: RunContext | None = None
+    ) -> int | None:
         if context is None:
             context = self.get_run_context()
         try:
@@ -180,7 +182,7 @@ class PoeThePoet:
             self.print_help(error=error)
             return 1
 
-    def run_task_graph(self, task: "PoeTask") -> Optional[int]:
+    def run_task_graph(self, task: PoeTask) -> int | None:
         from .task.graph import TaskExecutionGraph
 
         context = self.get_run_context(multistage=True)
@@ -207,7 +209,7 @@ class PoeThePoet:
                     return 1
         return 0
 
-    def get_run_context(self, multistage: bool = False) -> "RunContext":
+    def get_run_context(self, multistage: bool = False) -> RunContext:
         from .context import RunContext
 
         result = RunContext(
@@ -226,16 +228,16 @@ class PoeThePoet:
 
     def print_help(
         self,
-        info: Optional[str] = None,
-        error: Optional[Union[str, PoeException]] = None,
+        info: str | None = None,
+        error: str | PoeException | None = None,
     ):
         from .task.args import PoeTaskArgs
 
         if isinstance(error, str):
             error = PoeException(error)
 
-        tasks_help: Dict[
-            str, Tuple[str, Sequence[Tuple[Tuple[str, ...], str, str]]]
+        tasks_help: dict[
+            str, tuple[str, Sequence[tuple[tuple[str, ...], str, str]]]
         ] = {
             task_name: (
                 (

--- a/poethepoet/completion/zsh.py
+++ b/poethepoet/completion/zsh.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Iterable, Set
 
 
@@ -50,7 +52,7 @@ def get_zsh_completion_script(name: str = "") -> str:
             tuple(),
         )
         # collect all option strings that are exclusive with this one
-        excl_option_strings: Set[str] = {
+        excl_option_strings: set[str] = {
             option_string
             for excl_option in excl_options
             for option_string in excl_option.option_strings

--- a/poethepoet/context.py
+++ b/poethepoet/context.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Tuple, Union
@@ -10,25 +12,25 @@ if TYPE_CHECKING:
 
 
 class RunContext:
-    config: "PoeConfig"
-    ui: "PoeUi"
-    env: "EnvVarsManager"
+    config: PoeConfig
+    ui: PoeUi
+    env: EnvVarsManager
     dry: bool
-    poe_active: Optional[str]
+    poe_active: str | None
     project_dir: Path
     multistage: bool = False
-    exec_cache: Dict[str, Any]
-    captured_stdout: Dict[Tuple[str, ...], str]
+    exec_cache: dict[str, Any]
+    captured_stdout: dict[tuple[str, ...], str]
 
     def __init__(
         self,
-        config: "PoeConfig",
-        ui: "PoeUi",
+        config: PoeConfig,
+        ui: PoeUi,
         env: Mapping[str, str],
         dry: bool,
-        poe_active: Optional[str],
+        poe_active: str | None,
         multistage: bool = False,
-        cwd: Optional[Union[Path, str]] = None,
+        cwd: Path | str | None = None,
     ):
         from .env.manager import EnvVarsManager
 
@@ -52,8 +54,8 @@ class RunContext:
             )
 
     def _get_dep_values(
-        self, used_task_invocations: Mapping[str, Tuple[str, ...]]
-    ) -> Dict[str, str]:
+        self, used_task_invocations: Mapping[str, tuple[str, ...]]
+    ) -> dict[str, str]:
         """
         Get env vars from upstream tasks declared via the uses option.
         """
@@ -62,7 +64,7 @@ class RunContext:
             for var_name, invocation in used_task_invocations.items()
         }
 
-    def save_task_output(self, invocation: Tuple[str, ...], captured_stdout: bytes):
+    def save_task_output(self, invocation: tuple[str, ...], captured_stdout: bytes):
         """
         Store the stdout data from a task so that it can be reused by other tasks
         """
@@ -76,7 +78,7 @@ class RunContext:
             else:
                 raise
 
-    def get_task_output(self, invocation: Tuple[str, ...]):
+    def get_task_output(self, invocation: tuple[str, ...]):
         """
         Get the stored stdout data from a task so that it can be reused by other tasks
 
@@ -87,12 +89,12 @@ class RunContext:
 
     def get_executor(
         self,
-        invocation: Tuple[str, ...],
-        env: "EnvVarsManager",
+        invocation: tuple[str, ...],
+        env: EnvVarsManager,
         working_dir: Path,
-        executor_config: Optional[Mapping[str, str]] = None,
-        capture_stdout: Union[str, bool] = False,
-    ) -> "PoeExecutor":
+        executor_config: Mapping[str, str] | None = None,
+        capture_stdout: str | bool = False,
+    ) -> PoeExecutor:
         from .executor import PoeExecutor
 
         if not executor_config:

--- a/poethepoet/env/cache.py
+++ b/poethepoet/env/cache.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional, Union
@@ -11,15 +13,15 @@ POE_DEBUG = environ.get("POE_DEBUG", "0") == 1
 
 
 class EnvFileCache:
-    _cache: Dict[str, Dict[str, str]] = {}
-    _ui: Optional["PoeUi"]
+    _cache: dict[str, dict[str, str]] = {}
+    _ui: PoeUi | None
     _project_dir: Path
 
-    def __init__(self, project_dir: Path, ui: Optional["PoeUi"]):
+    def __init__(self, project_dir: Path, ui: PoeUi | None):
         self._project_dir = project_dir
         self._ui = ui
 
-    def get(self, envfile: Union[str, Path]) -> Dict[str, str]:
+    def get(self, envfile: str | Path) -> dict[str, str]:
         from .parse import parse_env_file
 
         envfile_path_str = str(envfile)

--- a/poethepoet/env/manager.py
+++ b/poethepoet/env/manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Union
@@ -11,18 +13,18 @@ if TYPE_CHECKING:
 
 
 class EnvVarsManager(Mapping):
-    _config: "PoeConfig"
-    _ui: Optional["PoeUi"]
-    _vars: Dict[str, str]
-    envfiles: "EnvFileCache"
+    _config: PoeConfig
+    _ui: PoeUi | None
+    _vars: dict[str, str]
+    envfiles: EnvFileCache
 
     def __init__(  # TODO: check if we still need all these args!
         self,
-        config: "PoeConfig",
-        ui: Optional["PoeUi"],
-        parent_env: Optional["EnvVarsManager"] = None,
-        base_env: Optional[Mapping[str, str]] = None,
-        cwd: Optional[Union[Path, str]] = None,
+        config: PoeConfig,
+        ui: PoeUi | None,
+        parent_env: EnvVarsManager | None = None,
+        base_env: Mapping[str, str] | None = None,
+        cwd: Path | str | None = None,
     ):
         from ..helpers.git import GitRepo
         from .cache import EnvFileCache
@@ -58,7 +60,7 @@ class EnvVarsManager(Mapping):
     def __len__(self):
         return len(self._vars)
 
-    def get(self, key: Any, /, default: Any = None) -> Optional[str]:
+    def get(self, key: Any, /, default: Any = None) -> str | None:
         if key == "POE_GIT_DIR":
             # This is a special case environment variable that is only set if requested
             self._vars["POE_GIT_DIR"] = str(self._git_repo.path or "")
@@ -74,8 +76,8 @@ class EnvVarsManager(Mapping):
 
     def apply_env_config(
         self,
-        envfile: Optional[Union[str, List[str]]],
-        config_env: Optional[Mapping[str, Union[str, Mapping[str, str]]]],
+        envfile: str | list[str] | None,
+        config_env: Mapping[str, str | Mapping[str, str]] | None,
         config_dir: Path,
         config_working_dir: Path,
     ):
@@ -120,7 +122,7 @@ class EnvVarsManager(Mapping):
 
     def update(self, env_vars: Mapping[str, Any]):
         # ensure all values are strings
-        str_vars: Dict[str, str] = {}
+        str_vars: dict[str, str] = {}
         for key, value in env_vars.items():
             if isinstance(value, list):
                 str_vars[key] = " ".join(str(item) for item in value)

--- a/poethepoet/env/parse.py
+++ b/poethepoet/env/parse.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from enum import Enum
 from typing import Iterable, Optional, Sequence
@@ -63,7 +65,7 @@ def parse_env_file(content_lines: Sequence[str]):
     result = {}
     cursor = 0
     state = ParserState.SCAN_VAR_NAME
-    var_name: Optional[str] = ""
+    var_name: str | None = ""
     var_content = []
 
     while cursor < len(content):

--- a/poethepoet/exceptions.py
+++ b/poethepoet/exceptions.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from typing import Optional
 
 
 # ruff: noqa: N818
 class PoeException(RuntimeError):
-    cause: Optional[str]
+    cause: str | None
 
     def __init__(self, msg, *args):
         self.msg = msg
@@ -20,21 +22,21 @@ class ExpressionParseError(PoeException):
 
 
 class ConfigValidationError(PoeException):
-    context: Optional[str]
-    task_name: Optional[str]
-    index: Optional[int]
-    global_option: Optional[str]
-    filename: Optional[str]
+    context: str | None
+    task_name: str | None
+    index: int | None
+    global_option: str | None
+    filename: str | None
 
     def __init__(
         self,
         msg,
         *args,
-        context: Optional[str] = None,
-        task_name: Optional[str] = None,
-        index: Optional[int] = None,
-        global_option: Optional[str] = None,
-        filename: Optional[str] = None
+        context: str | None = None,
+        task_name: str | None = None,
+        index: int | None = None,
+        global_option: str | None = None,
+        filename: str | None = None
     ):
         super().__init__(msg, *args)
         self.context = context
@@ -45,7 +47,7 @@ class ConfigValidationError(PoeException):
 
 
 class ExecutionError(RuntimeError):
-    cause: Optional[str]
+    cause: str | None
 
     def __init__(self, msg, *args):
         self.msg = msg

--- a/poethepoet/executor/base.py
+++ b/poethepoet/executor/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 import sys
@@ -48,19 +50,19 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
     A base class for poe task executors
     """
 
-    working_dir: Optional[Path]
+    working_dir: Path | None
 
-    __executor_types: ClassVar[Dict[str, Type["PoeExecutor"]]] = {}
-    __key__: ClassVar[Optional[str]] = None
+    __executor_types: ClassVar[dict[str, type[PoeExecutor]]] = {}
+    __key__: ClassVar[str | None] = None
 
     def __init__(
         self,
-        invocation: Tuple[str, ...],
-        context: "RunContext",
+        invocation: tuple[str, ...],
+        context: RunContext,
         options: Mapping[str, str],
-        env: "EnvVarsManager",
-        working_dir: Optional[Path] = None,
-        capture_stdout: Union[str, bool] = False,
+        env: EnvVarsManager,
+        working_dir: Path | None = None,
+        capture_stdout: str | bool = False,
         dry: bool = False,
     ):
         self.invocation = invocation
@@ -82,20 +84,20 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
             print(f" . Initalizing {self.__class__.__name__}")
 
     @classmethod
-    def works_with_context(cls, context: "RunContext") -> bool:
+    def works_with_context(cls, context: RunContext) -> bool:
         return True
 
     @classmethod
     def get(
         cls,
-        invocation: Tuple[str, ...],
-        context: "RunContext",
+        invocation: tuple[str, ...],
+        context: RunContext,
         executor_config: Mapping[str, str],
-        env: "EnvVarsManager",
-        working_dir: Optional[Path] = None,
-        capture_stdout: Union[str, bool] = False,
+        env: EnvVarsManager,
+        working_dir: Path | None = None,
+        capture_stdout: str | bool = False,
         dry: bool = False,
-    ) -> "PoeExecutor":
+    ) -> PoeExecutor:
         """
         Create an executor.
         """
@@ -104,7 +106,7 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         )
 
     @classmethod
-    def _resolve_implementation(cls, context: "RunContext", executor_type: str):
+    def _resolve_implementation(cls, context: RunContext, executor_type: str):
         """
         Resolve to an executor class, either as specified in the available config or
         by making some reasonable assumptions based on visible features of the
@@ -130,7 +132,7 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
             return cls.__executor_types[executor_type]
 
     def execute(
-        self, cmd: Sequence[str], input: Optional[bytes] = None, use_exec: bool = False
+        self, cmd: Sequence[str], input: bytes | None = None, use_exec: bool = False
     ) -> int:
         """
         Execute the given cmd.
@@ -148,8 +150,8 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         self,
         cmd: Sequence[str],
         *,
-        input: Optional[bytes] = None,
-        env: Optional[Mapping[str, str]] = None,
+        input: bytes | None = None,
+        env: Mapping[str, str] | None = None,
         shell: bool = False,
         use_exec: bool = False,
     ) -> int:
@@ -192,7 +194,7 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         self,
         cmd: Sequence[str],
         *,
-        env: Optional[Mapping[str, str]] = None,
+        env: Mapping[str, str] | None = None,
     ):
         if self.dry:
             return 0
@@ -215,8 +217,8 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         self,
         cmd: Sequence[str],
         *,
-        input: Optional[bytes] = None,
-        env: Optional[Mapping[str, str]] = None,
+        input: bytes | None = None,
+        env: Mapping[str, str] | None = None,
         shell: bool = False,
     ) -> int:
         import signal
@@ -268,7 +270,7 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         return proc.returncode
 
     @classmethod
-    def validate_config(cls, config: Dict[str, Any]):
+    def validate_config(cls, config: dict[str, Any]):
         if "type" not in config:
             raise ConfigValidationError(
                 "Missing required key 'type' from executor option",
@@ -294,7 +296,7 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
             cls.__executor_types[executor_type].validate_executor_config(config)
 
     @classmethod
-    def validate_executor_config(cls, config: Dict[str, Any]):
+    def validate_executor_config(cls, config: dict[str, Any]):
         """To be overridden by subclasses if they accept options"""
         extra_options = set(config.keys()) - {"type"}
         if extra_options:

--- a/poethepoet/executor/poetry.py
+++ b/poethepoet/executor/poetry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional, Sequence, Type
@@ -16,16 +18,16 @@ class PoetryExecutor(PoeExecutor):
     """
 
     __key__ = "poetry"
-    __options__: Dict[str, Type] = {}
+    __options__: dict[str, type] = {}
 
     @classmethod
-    def works_with_context(cls, context: "RunContext") -> bool:
+    def works_with_context(cls, context: RunContext) -> bool:
         if not context.config.is_poetry_project:
             return False
         return bool(cls._poetry_cmd_from_path())
 
     def execute(
-        self, cmd: Sequence[str], input: Optional[bytes] = None, use_exec: bool = False
+        self, cmd: Sequence[str], input: bytes | None = None, use_exec: bool = False
     ) -> int:
         """
         Execute the given cmd as a subprocess inside the poetry managed dev environment

--- a/poethepoet/executor/simple.py
+++ b/poethepoet/executor/simple.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, Type
 
 from .base import PoeExecutor
@@ -9,4 +11,4 @@ class SimpleExecutor(PoeExecutor):
     """
 
     __key__ = "simple"
-    __options__: Dict[str, Type] = {}
+    __options__: dict[str, type] = {}

--- a/poethepoet/executor/virtualenv.py
+++ b/poethepoet/executor/virtualenv.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Type
 
 from ..exceptions import ConfigValidationError, ExecutionError
@@ -14,16 +16,16 @@ class VirtualenvExecutor(PoeExecutor):
     """
 
     __key__ = "virtualenv"
-    __options__: Dict[str, Type] = {"location": str}
+    __options__: dict[str, type] = {"location": str}
 
     @classmethod
-    def works_with_context(cls, context: "RunContext") -> bool:
+    def works_with_context(cls, context: RunContext) -> bool:
         from ..virtualenv import Virtualenv
 
         return Virtualenv.detect(context.project_dir)
 
     def execute(
-        self, cmd: Sequence[str], input: Optional[bytes] = None, use_exec: bool = False
+        self, cmd: Sequence[str], input: bytes | None = None, use_exec: bool = False
     ) -> int:
         """
         Execute the given cmd as a subprocess inside the configured virtualenv
@@ -46,7 +48,7 @@ class VirtualenvExecutor(PoeExecutor):
             f"executable {cmd[0]!r} could not be found{error_context}"
         ) from error
 
-    def _resolve_virtualenv(self) -> "Virtualenv":
+    def _resolve_virtualenv(self) -> Virtualenv:
         from ..virtualenv import Virtualenv
 
         if "location" in self.options:
@@ -74,7 +76,7 @@ class VirtualenvExecutor(PoeExecutor):
         )
 
     @classmethod
-    def validate_executor_config(cls, config: Dict[str, Any]):
+    def validate_executor_config(cls, config: dict[str, Any]):
         """
         Validate that location is a string if given and no other options are given.
         """

--- a/poethepoet/helpers/command/__init__.py
+++ b/poethepoet/helpers/command/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from glob import escape
 from typing import (
@@ -17,7 +19,7 @@ if TYPE_CHECKING:
     from .ast import Line, ParseConfig
 
 
-def parse_poe_cmd(source: str, config: Optional["ParseConfig"] = None):
+def parse_poe_cmd(source: str, config: ParseConfig | None = None):
     from .ast import Glob, ParseConfig, ParseCursor, PythonGlob, Script
 
     if not config:
@@ -30,10 +32,10 @@ def parse_poe_cmd(source: str, config: Optional["ParseConfig"] = None):
 
 
 def resolve_command_tokens(
-    lines: Iterable["Line"],
+    lines: Iterable[Line],
     env: Mapping[str, str],
-    config: Optional["ParseConfig"] = None,
-) -> Iterator[Tuple[str, bool]]:
+    config: ParseConfig | None = None,
+) -> Iterator[tuple[str, bool]]:
     """
     Generates a sequence of tokens, and indicates for each whether it includes glob
     patterns that are not escaped or quoted. In case there are glob patterns in the
@@ -72,7 +74,7 @@ def resolve_command_tokens(
                 continue
 
             # For each token part indicate whether it is a glob
-            token_parts: List[Tuple[str, bool]] = []
+            token_parts: list[tuple[str, bool]] = []
             for segment in word:
                 for element in segment:
                     if isinstance(element, ParamExpansion):

--- a/poethepoet/helpers/command/ast.py
+++ b/poethepoet/helpers/command/ast.py
@@ -20,6 +20,8 @@ SINGLE_QUOTED_CONTENT : /[^']+/
 DOUBLE_QUOTED_CONTENT : /([^\$"]|\[\$"])+/
 """
 
+from __future__ import annotations
+
 from typing import Iterable, List, Literal, Optional, Tuple, Union, cast
 
 from .ast_core import ContentNode, ParseConfig, ParseCursor, ParseError, SyntaxNode
@@ -32,7 +34,7 @@ LINE_SEP_CHARS = LINE_BREAK_CHARS + ";"
 
 class SingleQuotedText(ContentNode):
     def _parse(self, chars: ParseCursor):
-        content: List[str] = []
+        content: list[str] = []
         for char in chars:
             if char == "'":
                 self._content = "".join(content)
@@ -44,7 +46,7 @@ class SingleQuotedText(ContentNode):
 
 class DoubleQuotedText(ContentNode):
     def _parse(self, chars: ParseCursor):
-        content: List[str] = []
+        content: list[str] = []
         for char in chars:
             if char == "\\":
                 # backslash is only special if escape is necessary
@@ -63,7 +65,7 @@ class DoubleQuotedText(ContentNode):
 
 class UnquotedText(ContentNode):
     def _parse(self, chars: ParseCursor):
-        content: List[str] = []
+        content: list[str] = []
         for char in chars:
             if char == "\\":
                 # Backslash is always an escape when outside of quotes
@@ -171,7 +173,7 @@ class PythonGlob(Glob):
 
         if char == "[":
             # Match pattern [groups]
-            group_chars: List[str] = []
+            group_chars: list[str] = []
             chars.take()
             for char in chars:
                 if char == "]":
@@ -205,7 +207,7 @@ class ParamExpansion(ContentNode):
     def _parse(self, chars: ParseCursor):
         assert chars.take() == "$"
 
-        param: List[str] = []
+        param: list[str] = []
         if chars.peek() == "{":
             chars.take()
             for char in chars:
@@ -271,7 +273,7 @@ class Comment(ContentNode):
 
 
 class Segment(SyntaxNode[ContentNode]):
-    _quote_char: Optional[Literal['"', "'"]]
+    _quote_char: Literal['"', "'"] | None
 
     @property
     def is_quoted(self) -> bool:
@@ -356,7 +358,7 @@ class Segment(SyntaxNode[ContentNode]):
 
 class Word(SyntaxNode[Segment]):
     @property
-    def segments(self) -> Tuple[Segment, ...]:
+    def segments(self) -> tuple[Segment, ...]:
         return tuple(self._children)
 
     def _parse(self, chars: ParseCursor):
@@ -378,7 +380,7 @@ class Line(SyntaxNode[Union[Word, Comment]]):
     _terminator: str
 
     @property
-    def words(self) -> Tuple[Word, ...]:
+    def words(self) -> tuple[Word, ...]:
         if self._children and isinstance(self._children[-1], Comment):
             return tuple(cast(Iterable[Word], self._children[:-1]))
         return tuple(cast(Iterable[Word], self._children))

--- a/poethepoet/helpers/command/ast_core.py
+++ b/poethepoet/helpers/command/ast_core.py
@@ -3,6 +3,8 @@ This module core a framework for defining hierarchical parser and ASTs.
 See sibling ast module for an example usage.
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import (
     IO,
@@ -30,7 +32,7 @@ class ParseCursor:
     _line: int
     _position: int
     _source: Iterator[str]
-    _pushback_stack: List[str]
+    _pushback_stack: list[str]
 
     def __init__(self, source: Iterator[str]):
         self._source = source
@@ -88,18 +90,18 @@ class ParseCursor:
 
 
 class ParseConfig:
-    substitute_nodes: Dict[Type["AstNode"], Type["AstNode"]]
+    substitute_nodes: dict[type[AstNode], type[AstNode]]
     line_separators: str
 
     def __init__(
         self,
-        substitute_nodes: Optional[Dict[Type["AstNode"], Type["AstNode"]]] = None,
+        substitute_nodes: dict[type[AstNode], type[AstNode]] | None = None,
         line_separators="",
     ):
         self.substitute_nodes = substitute_nodes or {}
         self.line_separators = line_separators
 
-    def resolve_node_cls(self, klass: Type["AstNode"]) -> Type["AstNode"]:
+    def resolve_node_cls(self, klass: type[AstNode]) -> type[AstNode]:
         return self.substitute_nodes.get(klass, klass)
 
 
@@ -130,9 +132,9 @@ T = TypeVar("T")
 
 
 class SyntaxNode(AstNode, Generic[T]):
-    _children: List[T]
+    _children: list[T]
 
-    def get_child_node_cls(self, node_type: Type[AstNode]) -> Type[T]:
+    def get_child_node_cls(self, node_type: type[AstNode]) -> type[T]:
         """
         Apply Node class substitution for the given node AstNode if specified in
         the ParseConfig.
@@ -140,7 +142,7 @@ class SyntaxNode(AstNode, Generic[T]):
         return cast(Type[T], self.config.resolve_node_cls(node_type))
 
     @property
-    def children(self) -> Tuple["SyntaxNode", ...]:
+    def children(self) -> tuple[SyntaxNode, ...]:
         return tuple(getattr(self, "_children", tuple()))
 
     def pretty(self, indent: int = 0, increment: int = 4):

--- a/poethepoet/helpers/git.py
+++ b/poethepoet/helpers/git.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shutil
 from pathlib import Path
 from subprocess import PIPE, Popen
@@ -7,17 +9,17 @@ from typing import Optional, Tuple
 class GitRepo:
     def __init__(self, seed_path: Path):
         self._seed_path = seed_path
-        self._path: Optional[Path] = None
-        self._main_path: Optional[Path] = None
+        self._path: Path | None = None
+        self._main_path: Path | None = None
 
     @property
-    def path(self) -> Optional[Path]:
+    def path(self) -> Path | None:
         if self._path is None:
             self._path = self._resolve_path()
         return self._path
 
     @property
-    def main_path(self) -> Optional[Path]:
+    def main_path(self) -> Path | None:
         if self._main_path is None:
             self._main_path = self._resolve_main_path()
         return self._main_path
@@ -28,7 +30,7 @@ class GitRepo:
     def delete_git_dir(self):
         shutil.rmtree(self._seed_path.joinpath(".git"))
 
-    def _resolve_path(self) -> Optional[Path]:
+    def _resolve_path(self) -> Path | None:
         """
         Resolve the path of this git repo
         """
@@ -43,7 +45,7 @@ class GitRepo:
             return Path(longest_line)
         return None
 
-    def _resolve_main_path(self) -> Optional[Path]:
+    def _resolve_main_path(self) -> Path | None:
         """
         Resolve the path of this git repo, unless this repo is a git submodule,
         then resolve the path of the main git repo.
@@ -55,7 +57,7 @@ class GitRepo:
             return Path(captured_stdout.decode().strip().split("\n")[0])
         return None
 
-    def _exec(self, *args: str) -> Tuple[Popen, bytes]:
+    def _exec(self, *args: str) -> tuple[Popen, bytes]:
         proc = Popen(
             ["git", *args],
             cwd=self._seed_path,

--- a/poethepoet/helpers/python.py
+++ b/poethepoet/helpers/python.py
@@ -3,6 +3,8 @@ Helper functions for parsing and manipulating python code, as required by Script
 ExprTask.
 """
 
+from __future__ import annotations
+
 import ast
 import re
 import sys
@@ -84,7 +86,7 @@ def resolve_expression(
     root_node = parse_and_validate(source, call_only, task_type)
     name_nodes = _validate_nodes_and_get_names(root_node, source)
 
-    substitutions: List[Substitution] = []
+    substitutions: list[Substitution] = []
     for node in name_nodes:
         if node.id in arguments:
             substitutions.append(
@@ -137,7 +139,7 @@ def parse_and_validate(
     return root_node
 
 
-def format_class(attrs: Optional[Dict[str, Any]], classname: str = "__args") -> str:
+def format_class(attrs: dict[str, Any] | None, classname: str = "__args") -> str:
     """
     Generates source for a python class with the entries of the given dictionary
     represented as class attributes. Output is a one-liner.
@@ -246,13 +248,13 @@ def _validate_nodes_and_get_names(
             )
 
 
-def _apply_substitutions(content: str, subs: List[Substitution]):
+def _apply_substitutions(content: str, subs: list[Substitution]):
     """
     Returns a copy of content with all of the substitutions applied.
     Uses a single pass for efficiency.
     """
     cursor = 0
-    segments: List[str] = []
+    segments: list[str] = []
 
     for (start, end), replacement in sorted(subs, key=lambda x: x[0][0]):
         in_between = content[cursor:start]
@@ -300,8 +302,7 @@ def _get_name_source_segment(source: str, node: ast.Name):
     and must be valid identifiers. It is expected to be correct in all cases, and
     performant in common cases.
     """
-    if sys.version_info >= (3, 8):
-        return ast.get_source_segment(source, node)
+    return ast.get_source_segment(source, node)
 
     partial_result = (
         re.split(r"(?:\r\n|\r|\n)", source)[node.lineno - 1]

--- a/poethepoet/options.py
+++ b/poethepoet/options.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 from keyword import iskeyword
 from typing import (
@@ -26,7 +28,7 @@ class PoeOptions:
     A special kind of config object that parses options ...
     """
 
-    __annotations: Dict[str, Type]
+    __annotations: dict[str, type]
 
     def __init__(self, **options: Any):
         for key in self.get_fields():
@@ -61,7 +63,7 @@ class PoeOptions:
     @classmethod
     def parse(
         cls,
-        source: Union[Mapping[str, Any], list],
+        source: Mapping[str, Any] | list,
         strict: bool = True,
         extra_keys: Sequence[str] = tuple(),
     ):
@@ -110,7 +112,7 @@ class PoeOptions:
             return value_type.parse(value, strict=strict)
 
         if strict:
-            expected_type: Union[Type, Tuple[Type, ...]] = cls._type_of(value_type)
+            expected_type: type | tuple[type, ...] = cls._type_of(value_type)
             if not isinstance(value, expected_type):
                 # Try format expected_type nicely in the error message
                 if not isinstance(expected_type, tuple):
@@ -192,7 +194,7 @@ class PoeOptions:
             return type(None) in type_of_attr
         return False
 
-    def update(self, options_dict: Dict[str, Any]):
+    def update(self, options_dict: dict[str, Any]):
         new_options_dict = {}
         for key in self.get_fields().keys():
             if key in options_dict:
@@ -201,11 +203,11 @@ class PoeOptions:
                 new_options_dict[key] = getattr(self, key)
 
     @classmethod
-    def type_of(cls, key: str) -> Optional[Union[Type, Tuple[Type, ...]]]:
+    def type_of(cls, key: str) -> type | tuple[type, ...] | None:
         return cls._type_of(cls.get_annotation(key))
 
     @classmethod
-    def get_annotation(cls, key: str) -> Optional[Type]:
+    def get_annotation(cls, key: str) -> type | None:
         return cls.get_fields().get(cls._resolve_key(key))
 
     @classmethod
@@ -219,9 +221,9 @@ class PoeOptions:
         return key
 
     @classmethod
-    def _type_of(cls, annotation: Any) -> Union[Type, Tuple[Type, ...]]:
+    def _type_of(cls, annotation: Any) -> type | tuple[type, ...]:
         if get_origin(annotation) is Union:
-            result: List[Type] = []
+            result: list[type] = []
             for component in get_args(annotation):
                 component_type = cls._type_of(component)
                 if isinstance(component_type, tuple):
@@ -252,7 +254,7 @@ class PoeOptions:
         return annotation
 
     @classmethod
-    def get_fields(cls) -> Dict[str, Any]:
+    def get_fields(cls) -> dict[str, Any]:
         """
         Recent python versions removed inheritance for __annotations__
         so we have to implement it explicitly

--- a/poethepoet/plugin.py
+++ b/poethepoet/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List
 
@@ -148,7 +150,7 @@ class PoetryPlugin(ApplicationPlugin):
         )
 
     @classmethod
-    def _get_config(cls, application: Application) -> "PoeConfig":
+    def _get_config(cls, application: Application) -> PoeConfig:
         from .config import PoeConfig
 
         # Try respect poetry's '--directory' if set
@@ -183,7 +185,7 @@ class PoetryPlugin(ApplicationPlugin):
         )
 
     def _register_command_event_handler(
-        self, application: Application, hooks: Dict[str, str]
+        self, application: Application, hooks: dict[str, str]
     ):
         if not hooks:
             return
@@ -210,7 +212,7 @@ class PoetryPlugin(ApplicationPlugin):
             )
 
     def _get_command_event_handler(
-        self, hooks: Dict[str, str], application: Application
+        self, hooks: dict[str, str], application: Application
     ):
         def command_event_handler(
             event: ConsoleCommandEvent,
@@ -235,7 +237,7 @@ class PoetryPlugin(ApplicationPlugin):
 
         return command_event_handler
 
-    def _monkey_patch_cleo(self, prefix: str, task_names: List[str]):
+    def _monkey_patch_cleo(self, prefix: str, task_names: list[str]):
         """
         Cleo is quite opinionated about CLI structure and loose about how options are
         used, and so doesn't currently support individual commands having their own way
@@ -279,7 +281,7 @@ class PoetryPlugin(ApplicationPlugin):
         cleo.application.Application._run = _run
 
 
-def _index_of_first_non_option(tokens: List[str]):
+def _index_of_first_non_option(tokens: list[str]):
     """
     Find the index of the first token that doesn't start with `-`
     Returns len(tokens) if none is found.

--- a/poethepoet/task/args.py
+++ b/poethepoet/task/args.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -23,7 +25,7 @@ from ..options import PoeOptions
 ArgParams = Dict[str, Any]
 ArgsDef = Union[List[str], List[ArgParams], Dict[str, ArgParams]]
 
-arg_param_schema: Dict[str, Union[Type, Tuple[Type, ...]]] = {
+arg_param_schema: dict[str, type | tuple[type, ...]] = {
     "default": (str, int, float, bool),
     "help": str,
     "name": str,
@@ -33,7 +35,7 @@ arg_param_schema: Dict[str, Union[Type, Tuple[Type, ...]]] = {
     "type": str,
     "multiple": (bool, int),
 }
-arg_types: Dict[str, Type] = {
+arg_types: dict[str, type] = {
     "string": str,
     "float": float,
     "integer": int,
@@ -42,14 +44,14 @@ arg_types: Dict[str, Type] = {
 
 
 class ArgSpec(PoeOptions):
-    default: Optional[Union[str, int, float, bool]] = None
+    default: str | int | float | bool | None = None
     help: str = ""
     name: str
-    options: Union[list, tuple]
-    positional: Union[bool, str] = False
+    options: list | tuple
+    positional: bool | str = False
     required: bool = False
     type: Literal["string", "float", "integer", "boolean"] = "string"
-    multiple: Union[bool, int] = False
+    multiple: bool | int = False
 
     @classmethod
     def normalize(cls, args_def: ArgsDef, strict: bool = True):
@@ -91,7 +93,7 @@ class ArgSpec(PoeOptions):
     @classmethod
     def parse(
         cls,
-        source: Union[Mapping[str, Any], list],
+        source: Mapping[str, Any] | list,
         strict: bool = True,
         extra_keys: Sequence[str] = tuple(),
     ):
@@ -122,7 +124,7 @@ class ArgSpec(PoeOptions):
 
     @staticmethod
     def _get_arg_options_list(
-        arg: ArgParams, name: Optional[str] = None, strict: bool = True
+        arg: ArgParams, name: str | None = None, strict: bool = True
     ):
         position = arg.get("positional", False)
         name = name or arg.get("name")
@@ -182,7 +184,7 @@ class ArgSpec(PoeOptions):
 
 
 class PoeTaskArgs:
-    _args: Tuple[ArgSpec, ...]
+    _args: tuple[ArgSpec, ...]
 
     def __init__(self, args_def: ArgsDef, task_name: str):
         self._task_name = task_name
@@ -207,8 +209,8 @@ class PoeTaskArgs:
 
     @classmethod
     def get_help_content(
-        cls, args_def: Optional[ArgsDef]
-    ) -> List[Tuple[Tuple[str, ...], str, str]]:
+        cls, args_def: ArgsDef | None
+    ) -> list[tuple[tuple[str, ...], str, str]]:
         if args_def is None:
             return []
 
@@ -224,8 +226,8 @@ class PoeTaskArgs:
         ]
 
     def build_parser(
-        self, env: "EnvVarsManager", program_name: str
-    ) -> "ArgumentParser":
+        self, env: EnvVarsManager, program_name: str
+    ) -> ArgumentParser:
         import argparse
 
         parser = argparse.ArgumentParser(
@@ -240,7 +242,7 @@ class PoeTaskArgs:
             )
         return parser
 
-    def _get_argument_params(self, arg: ArgSpec, env: "EnvVarsManager"):
+    def _get_argument_params(self, arg: ArgSpec, env: EnvVarsManager):
         default = arg.get("default")
         if isinstance(default, str):
             default = env.fill_template(default)
@@ -276,7 +278,7 @@ class PoeTaskArgs:
 
         return result
 
-    def parse(self, args: Sequence[str], env: "EnvVarsManager", program_name: str):
+    def parse(self, args: Sequence[str], env: EnvVarsManager, program_name: str):
         parsed_args = vars(self.build_parser(env, program_name).parse_args(args))
         # Ensure positional args are still exposed by name even if they were parsed with
         # alternate identifiers

--- a/poethepoet/task/expr.py
+++ b/poethepoet/task/expr.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from typing import (
     TYPE_CHECKING,
@@ -32,7 +34,7 @@ class ExprTask(PoeTask):
 
     class TaskOptions(PoeTask.TaskOptions):
         imports: Sequence[str] = tuple()
-        assert_: Union[bool, int] = False
+        assert_: bool | int = False
         use_exec: bool = False
 
         def validate(self):
@@ -45,9 +47,9 @@ class ExprTask(PoeTask):
 
     class TaskSpec(PoeTask.TaskSpec):
         content: str
-        options: "ExprTask.TaskOptions"
+        options: ExprTask.TaskOptions
 
-        def _task_validations(self, config: "PoeConfig", task_specs: "TaskSpecFactory"):
+        def _task_validations(self, config: PoeConfig, task_specs: TaskSpecFactory):
             """
             Perform validations on this TaskSpec that apply to a specific task type
             """
@@ -61,8 +63,8 @@ class ExprTask(PoeTask):
 
     def _handle_run(
         self,
-        context: "RunContext",
-        env: "EnvVarsManager",
+        context: RunContext,
+        env: EnvVarsManager,
     ) -> int:
         from ..helpers.python import format_class
 
@@ -102,10 +104,10 @@ class ExprTask(PoeTask):
 
     def parse_content(
         self,
-        args: Optional[Dict[str, Any]],
-        env: "EnvVarsManager",
+        args: dict[str, Any] | None,
+        env: EnvVarsManager,
         imports=Iterable[str],
-    ) -> Tuple[str, Dict[str, str]]:
+    ) -> tuple[str, dict[str, str]]:
         """
         Returns the expression to evaluate and the subset of env vars that it references
 
@@ -146,7 +148,7 @@ class ExprTask(PoeTask):
         # Spy on access to the env, so that instead of replacing template ${keys} with
         # the corresponding value, replace them with a python name and keep track of
         # referenced env vars.
-        accessed_vars: Dict[str, str] = {}
+        accessed_vars: dict[str, str] = {}
 
         def getitem_spy(obj: SpyDict, key: str, value: str):
             accessed_vars[key] = value

--- a/poethepoet/task/graph.py
+++ b/poethepoet/task/graph.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Dict, List, Set, Tuple
 
 from ..exceptions import CyclicDependencyError
@@ -8,17 +10,17 @@ if TYPE_CHECKING:
 
 
 class TaskExecutionNode:
-    task: "PoeTask"
-    direct_dependants: List["TaskExecutionNode"]
-    direct_dependencies: Set[Tuple[str, ...]]
-    path_dependants: Tuple[str, ...]
+    task: PoeTask
+    direct_dependants: list[TaskExecutionNode]
+    direct_dependencies: set[tuple[str, ...]]
+    path_dependants: tuple[str, ...]
     capture_stdout: bool
 
     def __init__(
         self,
-        task: "PoeTask",
-        direct_dependants: List["TaskExecutionNode"],
-        path_dependants: Tuple[str, ...],
+        task: PoeTask,
+        direct_dependants: list[TaskExecutionNode],
+        path_dependants: tuple[str, ...],
         capture_stdout: bool = False,
     ):
         self.task = task
@@ -31,7 +33,7 @@ class TaskExecutionNode:
         return not self.task.has_deps()
 
     @property
-    def identifier(self) -> Tuple[str, ...]:
+    def identifier(self) -> tuple[str, ...]:
         return self.task.invocation
 
 
@@ -45,16 +47,16 @@ class TaskExecutionGraph:
     one does not. Nodes are deduplicated to enforce this.
     """
 
-    _context: "RunContext"
+    _context: RunContext
     sink: TaskExecutionNode
-    sources: List[TaskExecutionNode]
-    captured_tasks: Dict[Tuple[str, ...], TaskExecutionNode]
-    uncaptured_tasks: Dict[Tuple[str, ...], TaskExecutionNode]
+    sources: list[TaskExecutionNode]
+    captured_tasks: dict[tuple[str, ...], TaskExecutionNode]
+    uncaptured_tasks: dict[tuple[str, ...], TaskExecutionNode]
 
     def __init__(
         self,
-        sink_task: "PoeTask",
-        context: "RunContext",
+        sink_task: PoeTask,
+        context: RunContext,
     ):
         self._context = context
         self.sink = TaskExecutionNode(sink_task, [], tuple())
@@ -65,7 +67,7 @@ class TaskExecutionGraph:
         # Build graph
         self._resolve_node_deps(self.sink)
 
-    def get_execution_plan(self) -> List[List["PoeTask"]]:
+    def get_execution_plan(self) -> list[list[PoeTask]]:
         """
         Derive an execution plan from the DAG in terms of stages consisting of tasks
         that could theoretically be parallelized.
@@ -73,7 +75,7 @@ class TaskExecutionGraph:
         # TODO: if we parallelize tasks then this should be modified to support lazy
         #       scheduling
 
-        stages: List[List[TaskExecutionNode]] = [self.sources]
+        stages: list[list[TaskExecutionNode]] = [self.sources]
         visited = {source.identifier for source in self.sources}
 
         while True:

--- a/poethepoet/task/script.py
+++ b/poethepoet/task/script.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import shlex
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
@@ -35,9 +37,9 @@ class ScriptTask(PoeTask):
 
     class TaskSpec(PoeTask.TaskSpec):
         content: str
-        options: "ScriptTask.TaskOptions"
+        options: ScriptTask.TaskOptions
 
-        def _task_validations(self, config: "PoeConfig", task_specs: "TaskSpecFactory"):
+        def _task_validations(self, config: PoeConfig, task_specs: TaskSpecFactory):
             """
             Perform validations on this TaskSpec that apply to a specific task type
             """
@@ -57,8 +59,8 @@ class ScriptTask(PoeTask):
 
     def _handle_run(
         self,
-        context: "RunContext",
-        env: "EnvVarsManager",
+        context: RunContext,
+        env: EnvVarsManager,
     ) -> int:
         from ..helpers.python import format_class
 
@@ -103,7 +105,7 @@ class ScriptTask(PoeTask):
             cmd, use_exec=self.spec.options.get("use_exec", False)
         )
 
-    def parse_content(self, args: Optional[Dict[str, Any]]) -> Tuple[str, str]:
+    def parse_content(self, args: dict[str, Any] | None) -> tuple[str, str]:
         """
         Returns the module to load, and the function call to execute.
 

--- a/poethepoet/task/sequence.py
+++ b/poethepoet/task/sequence.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -27,14 +29,14 @@ class SequenceTask(PoeTask):
     A task consisting of a sequence of other tasks
     """
 
-    content: List[Union[str, Dict[str, Any]]]
+    content: list[str | dict[str, Any]]
 
     __key__ = "sequence"
-    __content_type__: ClassVar[Type] = list
+    __content_type__: ClassVar[type] = list
 
     class TaskOptions(PoeTask.TaskOptions):
         ignore_fail: Literal[True, False, "return_zero", "return_non_zero"] = False
-        default_item_type: Optional[str] = None
+        default_item_type: str | None = None
 
         def validate(self):
             """
@@ -51,16 +53,16 @@ class SequenceTask(PoeTask):
 
     class TaskSpec(PoeTask.TaskSpec):
         content: list
-        options: "SequenceTask.TaskOptions"
+        options: SequenceTask.TaskOptions
         subtasks: Sequence[PoeTask.TaskSpec]
 
         def __init__(
             self,
             name: str,
-            task_def: Dict[str, Any],
-            factory: "TaskSpecFactory",
-            source: "ConfigPartition",
-            parent: Optional["PoeTask.TaskSpec"] = None,
+            task_def: dict[str, Any],
+            factory: TaskSpecFactory,
+            source: ConfigPartition,
+            parent: PoeTask.TaskSpec | None = None,
         ):
             super().__init__(name, task_def, factory, source, parent)
 
@@ -99,7 +101,7 @@ class SequenceTask(PoeTask):
                         task_name=self.name,
                     )
 
-        def _task_validations(self, config: "PoeConfig", task_specs: "TaskSpecFactory"):
+        def _task_validations(self, config: PoeConfig, task_specs: TaskSpecFactory):
             """
             Perform validations on this TaskSpec that apply to a specific task type
             """
@@ -116,7 +118,7 @@ class SequenceTask(PoeTask):
     def __init__(
         self,
         spec: TaskSpec,
-        invocation: Tuple[str, ...],
+        invocation: tuple[str, ...],
         ctx: TaskContext,
         capture_stdout: bool = False,
     ):
@@ -132,8 +134,8 @@ class SequenceTask(PoeTask):
 
     def _handle_run(
         self,
-        context: "RunContext",
-        env: "EnvVarsManager",
+        context: RunContext,
+        env: EnvVarsManager,
     ) -> int:
         named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.update(named_arg_values)
@@ -146,7 +148,7 @@ class SequenceTask(PoeTask):
             context.multistage = True
 
         ignore_fail = self.spec.options.ignore_fail
-        non_zero_subtasks: List[str] = list()
+        non_zero_subtasks: list[str] = list()
         for subtask in self.subtasks:
             task_result = subtask.run(context=context, parent_env=env)
             if task_result and not ignore_fail:

--- a/poethepoet/task/shell.py
+++ b/poethepoet/task/shell.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from os import environ
 from typing import (
@@ -26,7 +28,7 @@ class ShellTask(PoeTask):
     __key__ = "shell"
 
     class TaskOptions(PoeTask.TaskOptions):
-        interpreter: Optional[Union[str, list]] = None
+        interpreter: str | list | None = None
 
         def validate(self):
             super().validate()
@@ -57,14 +59,14 @@ class ShellTask(PoeTask):
 
     class TaskSpec(PoeTask.TaskSpec):
         content: str
-        options: "ShellTask.TaskOptions"
+        options: ShellTask.TaskOptions
 
     spec: TaskSpec
 
     def _handle_run(
         self,
-        context: "RunContext",
-        env: "EnvVarsManager",
+        context: RunContext,
+        env: EnvVarsManager,
     ) -> int:
         named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.update(named_arg_values)
@@ -95,15 +97,15 @@ class ShellTask(PoeTask):
             interpreter_cmd, input=content.encode()
         )
 
-    def _get_interpreter_config(self) -> Tuple[str, ...]:
-        result: Union[str, Tuple[str, ...]] = self.spec.options.get(
+    def _get_interpreter_config(self) -> tuple[str, ...]:
+        result: str | tuple[str, ...] = self.spec.options.get(
             "interpreter", self.ctx.config.shell_interpreter
         )
         if isinstance(result, str):
             return (result,)
         return tuple(result)
 
-    def resolve_interpreter_cmd(self) -> Optional[List[str]]:
+    def resolve_interpreter_cmd(self) -> list[str] | None:
         """
         Return a formatted command for the first specified interpreter that can be
         located.
@@ -120,7 +122,7 @@ class ShellTask(PoeTask):
 
         return None
 
-    def _locate_interpreter(self, interpreter: str) -> Optional[str]:
+    def _locate_interpreter(self, interpreter: str) -> str | None:
         from shutil import which
 
         result = None

--- a/poethepoet/task/switch.py
+++ b/poethepoet/task/switch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -32,10 +34,10 @@ class SwitchTask(PoeTask):
     """
 
     __key__ = "switch"
-    __content_type__: ClassVar[Type] = list
+    __content_type__: ClassVar[type] = list
 
     class TaskOptions(PoeTask.TaskOptions):
-        control: Union[str, dict]
+        control: str | dict
         default: Literal["pass", "fail"] = "fail"
 
         @classmethod
@@ -66,16 +68,16 @@ class SwitchTask(PoeTask):
 
     class TaskSpec(PoeTask.TaskSpec):
         control_task_spec: PoeTask.TaskSpec
-        case_task_specs: Tuple[Tuple[Tuple[Any, ...], PoeTask.TaskSpec], ...]
-        options: "SwitchTask.TaskOptions"
+        case_task_specs: tuple[tuple[tuple[Any, ...], PoeTask.TaskSpec], ...]
+        options: SwitchTask.TaskOptions
 
         def __init__(
             self,
             name: str,
-            task_def: Dict[str, Any],
-            factory: "TaskSpecFactory",
-            source: "ConfigPartition",
-            parent: Optional["PoeTask.TaskSpec"] = None,
+            task_def: dict[str, Any],
+            factory: TaskSpecFactory,
+            source: ConfigPartition,
+            parent: PoeTask.TaskSpec | None = None,
         ):
             super().__init__(name, task_def, factory, source, parent)
 
@@ -112,7 +114,7 @@ class SwitchTask(PoeTask):
 
             self.case_task_specs = tuple(case_task_specs)
 
-        def _task_validations(self, config: "PoeConfig", task_specs: "TaskSpecFactory"):
+        def _task_validations(self, config: PoeConfig, task_specs: TaskSpecFactory):
             from collections import defaultdict
 
             allowed_control_task_types = ("expr", "cmd", "script")
@@ -154,19 +156,19 @@ class SwitchTask(PoeTask):
 
     spec: TaskSpec
     control_task: PoeTask
-    switch_tasks: Dict[str, PoeTask]
+    switch_tasks: dict[str, PoeTask]
 
     def __init__(
         self,
         spec: TaskSpec,
-        invocation: Tuple[str, ...],
+        invocation: tuple[str, ...],
         ctx: TaskContext,
         capture_stdout: bool = False,
     ):
         super().__init__(spec, invocation, ctx, capture_stdout)
 
         control_task_name = f"{spec.name}[__control__]"
-        control_invocation: Tuple[str, ...] = (control_task_name,)
+        control_invocation: tuple[str, ...] = (control_task_name,)
         options = self.spec.options
         if options.get("args"):
             control_invocation = (*control_invocation, *invocation[1:])
@@ -179,7 +181,7 @@ class SwitchTask(PoeTask):
 
         self.switch_tasks = {}
         for case_keys, case_spec in spec.case_task_specs:
-            task_invocation: Tuple[str, ...] = (f"{spec.name}[{','.join(case_keys)}]",)
+            task_invocation: tuple[str, ...] = (f"{spec.name}[{','.join(case_keys)}]",)
             if options.get("args"):
                 task_invocation = (*task_invocation, *invocation[1:])
 
@@ -193,8 +195,8 @@ class SwitchTask(PoeTask):
 
     def _handle_run(
         self,
-        context: "RunContext",
-        env: "EnvVarsManager",
+        context: RunContext,
+        env: EnvVarsManager,
     ) -> int:
         named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.update(named_arg_values)

--- a/poethepoet/ui.py
+++ b/poethepoet/ui.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from typing import IO, TYPE_CHECKING, List, Mapping, Optional, Sequence, Tuple, Union
@@ -33,8 +35,8 @@ STDOUT_ANSI_SUPPORT = guess_ansi_support(sys.stdout)
 
 
 class PoeUi:
-    args: "Namespace"
-    _color: "Pastel"
+    args: Namespace
+    _color: Pastel
 
     def __init__(self, output: IO, program_name: str = "poe"):
         self.output = output
@@ -59,7 +61,7 @@ class PoeUi:
         """Provide easy access to arguments"""
         return getattr(self.args, key, None)
 
-    def build_parser(self) -> "ArgumentParser":
+    def build_parser(self) -> ArgumentParser:
         import argparse
 
         parser = argparse.ArgumentParser(
@@ -175,18 +177,16 @@ class PoeUi:
 
     def print_help(
         self,
-        tasks: Optional[
-            Mapping[str, Tuple[str, Sequence[Tuple[Tuple[str, ...], str, str]]]]
-        ] = None,
-        info: Optional[str] = None,
-        error: Optional[PoeException] = None,
+        tasks: Mapping[str, tuple[str, Sequence[tuple[tuple[str, ...], str, str]]]] | None = None,
+        info: str | None = None,
+        error: PoeException | None = None,
     ):
         # TODO: See if this can be done nicely with a custom HelpFormatter
 
         # Ignore verbosity mode if help flag is set
         verbosity = 0 if self["help"] else self.verbosity
 
-        result: List[Union[str, Sequence[str]]] = []
+        result: list[str | Sequence[str]] = []
         if verbosity >= 0:
             result.append(
                 (
@@ -319,7 +319,7 @@ class PoeUi:
         if verbosity <= self.verbosity:
             self._print(message, end=end)
 
-    def print_error(self, error: Union[PoeException, ExecutionError]):
+    def print_error(self, error: PoeException | ExecutionError):
         error_lines = error.msg.split("\n")
         if error.cause:
             error_lines.append(f"From: {error.cause}")

--- a/poethepoet/virtualenv.py
+++ b/poethepoet/virtualenv.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 import sys
@@ -80,7 +82,7 @@ class Virtualenv:
             )
         )
 
-    def get_env_vars(self, base_env: Mapping[str, str]) -> Dict[str, str]:
+    def get_env_vars(self, base_env: Mapping[str, str]) -> dict[str, str]:
         bin_dir = str(self.bin_dir())
         # Revert path update from existing virtualenv if applicable
         path_var = os.environ.get("_OLD_VIRTUAL_PATH", "") or os.environ.get("PATH", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,9 @@ markers = [
 
 
 [tool.ruff]
+target-version = "py38"
+
+[tool.ruff.lint]
 select  = [
   "E",     # error
   "F",     # pyflakes
@@ -196,7 +199,7 @@ ignore  = [
   "PTH123", # builtin-open
   "RUF012", # mutable-class-default
 ]
-fixable = ["E", "F", "I"]
+fixable = ["E", "F", "FA", "I", "UP"]
 
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import shutil
@@ -127,11 +129,11 @@ def run_poe_subproc(projects, temp_file, tmp_path, is_windows):
 
     def run_poe_subproc(
         *run_args: str,
-        cwd: Optional[str] = None,
-        config: Optional[Mapping[str, Any]] = None,
+        cwd: str | None = None,
+        config: Mapping[str, Any] | None = None,
         coverage: bool = not is_windows,
-        env: Optional[Dict[str, str]] = None,
-        project: Optional[str] = None,
+        env: dict[str, str] | None = None,
+        project: str | None = None,
     ) -> PoeRunResult:
         if cwd is None:
             cwd = projects.get(project, projects["example"])
@@ -192,8 +194,8 @@ def run_poe(capsys, projects):
     def run_poe(
         *run_args: str,
         cwd: str = projects["example"],
-        config: Optional[Mapping[str, Any]] = None,
-        project: Optional[str] = None,
+        config: Mapping[str, Any] | None = None,
+        project: str | None = None,
         config_name="pyproject.toml",
         program_name="poe",
     ) -> PoeRunResult:
@@ -218,8 +220,8 @@ def run_poe_main(capsys, projects):
     def run_poe_main(
         *cli_args: str,
         cwd: str = projects["example"],
-        config: Optional[Mapping[str, Any]] = None,
-        project: Optional[str] = None,
+        config: Mapping[str, Any] | None = None,
+        project: str | None = None,
     ) -> PoeRunResult:
         cwd = projects.get(project, cwd)
         from poethepoet import main
@@ -238,7 +240,7 @@ def run_poe_main(capsys, projects):
 def run_poetry(use_venv, poe_project_path):
     venv_location = poe_project_path / "tests" / "temp" / "poetry_venv"
 
-    def run_poetry(args: List[str], cwd: str, env: Optional[Dict[str, str]] = None):
+    def run_poetry(args: list[str], cwd: str, env: dict[str, str] | None = None):
         venv = Virtualenv(venv_location)
 
         cmd = (venv.resolve_executable("python"), "-m", "poetry", *args)
@@ -284,7 +286,7 @@ def esc_prefix(is_windows):
 
 @pytest.fixture(scope="session")
 def install_into_virtualenv():
-    def install_into_virtualenv(location: Path, contents: List[str]):
+    def install_into_virtualenv(location: Path, contents: list[str]):
         venv = Virtualenv(location)
         Popen(
             (venv.resolve_executable("pip"), "install", *contents),
@@ -301,7 +303,7 @@ def use_venv(install_into_virtualenv):
     @contextmanager
     def use_venv(
         location: Path,
-        contents: Optional[List[str]] = None,
+        contents: list[str] | None = None,
         require_empty: bool = False,
     ):
         did_exist = location.is_dir()
@@ -333,7 +335,7 @@ def use_virtualenv(install_into_virtualenv):
     @contextmanager
     def use_virtualenv(
         location: Path,
-        contents: Optional[List[str]] = None,
+        contents: list[str] | None = None,
         require_empty: bool = False,
     ):
         did_exist = location.is_dir()
@@ -378,7 +380,7 @@ def try_rm_dir(location: Path):
 def with_virtualenv_and_venv(use_venv, use_virtualenv):
     def with_virtualenv_and_venv(
         location: Path,
-        contents: Optional[List[str]] = None,
+        contents: list[str] | None = None,
     ):
         with use_venv(location, contents, require_empty=True):
             yield


### PR DESCRIPTION
Fixes #246 
* #246 

https://docs.astral.sh/ruff/rules/#flake8-future-annotations-fa
Steps:
1. Modify `pyproject.toml` to use the new `ruff` config settings and allow `FA,UP` fixes
2. Run `ruff check --select=FA` to see which files would benefit from `from __future__ import annotations`
3. Run `ruff check --select=FA,UP --fix --unsafe-fixes`
```
Found 470 errors (470 fixed, 0 remaining).
```