### PR TITLE
fix: Explicitly disallow capture_stdout option on sequence tasks

### DIFF
--- a/docs/tasks/task_types/sequence.rst
+++ b/docs/tasks/task_types/sequence.rst
@@ -24,7 +24,7 @@ By default the contents of the array are interpreted as references to other task
 Available task options
 ----------------------
 
-``sequence`` tasks support all of the :doc:`standard task options <../options>` with the exception of ``use_exec``.
+``sequence`` tasks support all of the :doc:`standard task options <../options>` with the exception of ``use_exec`` and ``capture_stdout``.
 
 The following options are also accepted:
 

--- a/poethepoet/task/sequence.py
+++ b/poethepoet/task/sequence.py
@@ -37,6 +37,10 @@ class SequenceTask(PoeTask):
                     "Unsupported value for option `default_item_type`,\n"
                     f"Expected one of {PoeTask.get_task_types(content_type=str)}"
                 )
+            if self.capture_stdout is not None:
+                raise ConfigValidationError(
+                    "Unsupported option for sequence task `capture_stdout`"
+                )
 
     class TaskSpec(PoeTask.TaskSpec):
         content: list


### PR DESCRIPTION
fixes #222 