### PR TITLE
feat: Make command parsing support operations on param expansions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,14 +118,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger update of homebrew formula
-        run: >
+        run: |
           sleep 10 # some delay seems to be necessary
-          curl -L -X POST
-          -H "Accept: application/vnd.github+json"
-          -H "Authorization: Bearer ${{ secrets.homebrew_pat }}"
-          -H "X-GitHub-Api-Version: 2022-11-28"
-          https://api.github.com/repos/nat-n/homebrew-poethepoet/actions/workflows/71211730/dispatches
-          -d '{"ref":"main", "inputs":{}}'
+          curl -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.homebrew_pat }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/nat-n/homebrew-poethepoet/actions/workflows/71211730/dispatches \
+            -d '{"ref":"main", "inputs":{}}'
 
   github-release:
     name: >-

--- a/docs/tasks/task_types/cmd.rst
+++ b/docs/tasks/task_types/cmd.rst
@@ -26,6 +26,7 @@ It is important to understand that ``cmd`` tasks are executed without a shell (t
 
 .. _ref_env_vars:
 
+
 Referencing environment variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -48,6 +49,29 @@ Parameter expansion can also can be disabled by escaping the $ with a backslash 
 
   [tool.poe.tasks]
   greet = "echo Hello \\$USER"  # the backslash itself needs escaping for the toml parser
+
+
+Parameter expansion operators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When referencing an environment variable in a cmd task you can use the ``:-`` operator from bash to specify a *default value*, to be used in case the variable is unset. Similarly the ``:+`` operator can be used to specify an *alternate value* to use in place of the environment variable if it *is* set.
+
+In the following example, if ``AWS_REGION`` has a value then it will be used, otherwise ``us-east-1`` will be used as a fallback.
+
+.. code-block:: toml
+
+  [tool.poe.tasks]
+  tables = "aws dynamodb list-tables --region ${AWS_REGION:-us-east-1}"
+
+The ``:+`` or *alternate value* operator is especially useful in cases such as the following where you might want to control whether some CLI options are passed to the command.
+
+.. code-block:: toml
+
+  [tool.poe.tasks.aws-identity]
+  cmd = "aws sts get-caller-identity ${ARN_ONLY:+ --no-cli-pager --output text --query 'Arn'}"
+  args = [{ name = "ARN_ONLY", options = ["--arn-only"], type = "boolean" }]
+
+In this example we declare a boolean argument with no default, so if the ``--arn-only`` flag is provided to the task then three additional CLI options will be included in the task content.
 
 
 Glob expansion
@@ -78,7 +102,7 @@ Here's an example of task using a recursive glob pattern:
 
 .. seealso::
 
-  Much like in bash, the glob pattern can be escaped by wrapping it in quotes, or preceding it with a backslash.
+  Just like in bash, the glob pattern can be escaped by wrapping it in quotes, or preceding it with a backslash.
 
 
 .. |glob_link| raw:: html

--- a/poethepoet/app.py
+++ b/poethepoet/app.py
@@ -20,28 +20,38 @@ class PoeThePoet:
         this determines where to look for a pyproject.toml file, defaults to
         ``Path().resolve()``
     :type cwd: Path, optional
+
     :param config:
         Either a dictionary with the same schema as a pyproject.toml file, or a
         `PoeConfig <https://github.com/nat-n/poethepoet/blob/main/poethepoet/config/config.py>`_
         object to use as an alternative to loading config from a file.
     :type config: dict | PoeConfig, optional
+
     :param output:
         A stream for the application to write its own output to, defaults to sys.stdout
     :type output: IO, optional
+
     :param poetry_env_path:
         The path to the poetry virtualenv. If provided then it is used by the
         `PoetryExecutor <https://github.com/nat-n/poethepoet/blob/main/poethepoet/executor/poetry.py>`_,
         instead of having to execute poetry in a subprocess to determine this.
     :type poetry_env_path: str, optional
+
     :param config_name:
         The name of the file to load tasks and configuration from. If not set then poe
         will search for config by the following file names: pyproject.toml
         poe_tasks.toml poe_tasks.yaml poe_tasks.json
     :type config_name: str, optional
+
     :param program_name:
         The name of the program that is being run. This is used primarily when
         outputting help messages, defaults to "poe"
     :type program_name: str, optional
+
+    :param env:
+        Optionally provide an alternative base environment for tasks to run with.
+        If no mapping is provided then ``os.environ`` is used.
+    :type env: dict, optional
     """
 
     cwd: Path
@@ -58,6 +68,7 @@ class PoeThePoet:
         poetry_env_path: Optional[str] = None,
         config_name: Optional[str] = None,
         program_name: str = "poe",
+        env: Optional[Mapping[str, str]] = None,
     ):
         from .config import PoeConfig
         from .ui import PoeUi
@@ -75,6 +86,7 @@ class PoeThePoet:
         )
         self.ui = PoeUi(output=output, program_name=program_name)
         self._poetry_env_path = poetry_env_path
+        self._env = env if env is not None else os.environ
 
     def __call__(self, cli_args: Sequence[str], internal: bool = False) -> int:
         """
@@ -212,9 +224,9 @@ class PoeThePoet:
         result = RunContext(
             config=self.config,
             ui=self.ui,
-            env=os.environ,
+            env=self._env,
             dry=self.ui["dry_run"],
-            poe_active=os.environ.get("POE_ACTIVE"),
+            poe_active=self._env.get("POE_ACTIVE"),
             multistage=multistage,
             cwd=self.cwd,
         )

--- a/poethepoet/env/template.py
+++ b/poethepoet/env/template.py
@@ -56,7 +56,7 @@ def apply_envvars_to_template(
     content: str, env: Mapping[str, str], require_braces=False
 ) -> str:
     """
-    Template in ${environmental} $variables from env as if we were in a shell
+    Template in ${environment} $variables from env as if we were in a shell
 
     Supports escaping of the $ if preceded by an odd number of backslashes, in which
     case the backslash immediately preceding the $ is removed. This is an

--- a/poethepoet/exceptions.py
+++ b/poethepoet/exceptions.py
@@ -6,9 +6,19 @@ class PoeException(RuntimeError):
     cause: Optional[str]
 
     def __init__(self, msg, *args):
+        super().__init__(msg, *args)
         self.msg = msg
-        self.cause = args[0].args[0] if args else None
-        self.args = (msg, *args)
+
+        if args:
+            cause = args[0]
+            position_clause = (
+                f", near line {cause.line}, position {cause.position}."
+                if getattr(cause, "has_position", False)
+                else "."
+            )
+            self.cause = cause.args[0] + position_clause
+        else:
+            self.cause = None
 
 
 class CyclicDependencyError(PoeException):
@@ -34,7 +44,7 @@ class ConfigValidationError(PoeException):
         task_name: Optional[str] = None,
         index: Optional[int] = None,
         global_option: Optional[str] = None,
-        filename: Optional[str] = None
+        filename: Optional[str] = None,
     ):
         super().__init__(msg, *args)
         self.context = context

--- a/poethepoet/helpers/command/ast_core.py
+++ b/poethepoet/helpers/command/ast_core.py
@@ -1,5 +1,5 @@
 """
-This module core a framework for defining hierarchical parser and ASTs.
+This module provides a framework for defining a hierarchical parser and AST.
 See sibling ast module for an example usage.
 """
 
@@ -9,23 +9,26 @@ from typing import IO, Generic, Optional, TypeVar, cast
 
 
 class ParseCursor:
-    """
+    r"""
     This makes it easier to parse a text by wrapping it an abstraction like a stack,
     so the parser can pop off the next character but also push back characters that need
-    to be reprocessed.
+    to be reprocessed by a different node.
 
-    TODO: keep track of the current line number and position of the read head.
+    The line and position tracking which may be used for error reporting assumes that
+    whatever source we're reading the file from encodes new lines as simply '\n'.
     """
 
     _line: int
     _position: int
+    _line_lengths: list[int]
     _source: Iterator[str]
     _pushback_stack: list[str]
 
     def __init__(self, source: Iterator[str]):
         self._source = source
         self._line = 0
-        self._position = 0
+        self._position = -1
+        self._line_lengths = []
         self._pushback_stack = []
 
     @classmethod
@@ -40,6 +43,10 @@ class ParseCursor:
     def from_string(cls, string: str):
         return cls(char for char in string)
 
+    @property
+    def position(self):
+        return (max(0, self._line), max(0, self._position))
+
     def peek(self):
         if not self._pushback_stack:
             try:
@@ -49,21 +56,31 @@ class ParseCursor:
         return self._pushback_stack[-1]
 
     def take(self):
-        # TODO: update _line and _position
         if self._pushback_stack:
-            return self._pushback_stack.pop()
+            result = self._pushback_stack.pop()
+        else:
+            try:
+                result = next(self._source)
+            except StopIteration:
+                result = None
 
-        try:
-            return next(self._source)
-        except StopIteration:
-            return None
+        if result == "\n":
+            self._line_lengths.append(self._position)
+            self._line += 1
+            self._position = -1
+        else:
+            self._position += 1
+
+        return result
 
     def pushback(self, *items: str):
         for item in reversed(items):
-            # TODO: rewind _line and _position
-            # HOW to get length of previous line which pushback a line break?
-            #   would need to keep a stack of all previous line lengths to be sure!?
             self._pushback_stack.append(item)
+            if item == "\n":
+                self._position = self._line_lengths.pop(0)
+                self._line = max(0, self._line - 1)
+            else:
+                self._position -= 1
 
     def __iter__(self):
         return self
@@ -78,6 +95,12 @@ class ParseCursor:
 
 
 class ParseConfig:
+    """
+    A ParseConfig is passed to every AstNode in a tree, and may be used to configure
+    alternative parsing behaviors, thus making to possible to declare small variations
+    to the parsed syntax without having to duplicate parsing logic.
+    """
+
     substitute_nodes: dict[type["AstNode"], type["AstNode"]]
     line_separators: str
 
@@ -116,10 +139,14 @@ class AstNode(ABC):
         ...
 
 
-T = TypeVar("T")
+T = TypeVar("T", bound=AstNode)
 
 
 class SyntaxNode(AstNode, Generic[T]):
+    """
+    A SyntaxNode is a branching AST node with no content of its own
+    """
+
     _children: list[T]
 
     def get_child_node_cls(self, node_type: type[AstNode]) -> type[T]:
@@ -138,7 +165,7 @@ class SyntaxNode(AstNode, Generic[T]):
         return "\n".join(
             [
                 f"{self.__class__.__name__}:",
-                *(" " * indent + child.pretty(indent) for child in self),
+                *(" " * indent + child.pretty(indent, increment) for child in self),
             ]
         )
 
@@ -163,6 +190,10 @@ class SyntaxNode(AstNode, Generic[T]):
 
 
 class ContentNode(AstNode):
+    """
+    A ContentNode is a terminal AST node with string content
+    """
+
     _content: str = ""
 
     @property
@@ -171,6 +202,13 @@ class ContentNode(AstNode):
 
     def pretty(self, indent: int = 0, increment: int = 4):
         return f"{self.__class__.__name__}: {self._content!r}"
+
+    def get_child_node_cls(self, node_type: type[AstNode]) -> type:
+        """
+        Apply Node class substitution for the given node AstNode if specified in
+        the ParseConfig.
+        """
+        return cast(type, self.config.resolve_node_cls(node_type))
 
     def __str__(self):
         return self._content
@@ -187,5 +225,54 @@ class ContentNode(AstNode):
         return super().__eq__(other)
 
 
+class AnnotatedContentNode(ContentNode, Generic[T]):
+    """
+    A AnnotatedContentNode is like a ContentNode except that it may also have a
+    single child node, which is considered an annotation on the content.
+    """
+
+    _annotation: Optional[T] = None
+
+    def pretty(self, indent: int = 0, increment: int = 4):
+        indent += increment
+        content_line = f"{self.__class__.__name__}: {self._content!r}"
+        if self._annotation is not None:
+            return (
+                f"{content_line}\n"
+                f"{' '*indent}{self._annotation.pretty(indent, increment)}"
+            )
+        return content_line
+
+    def __repr__(self):
+        annotation = f", {self._annotation!r}" if self._annotation else ""
+        return f"{self.__class__.__name__}({self._content!r}{annotation})"
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return self._content == other
+        if isinstance(other, tuple):
+            if self._annotation is None:
+                return (self._content,) == other
+            return (self._content, self._annotation) == other
+        return super().__eq__(other)
+
+
 class ParseError(RuntimeError):
-    pass
+    line: Optional[int]
+    position: Optional[int]
+
+    def __init__(self, message: str, cursor: Optional[ParseCursor] = None):
+        super().__init__(message)
+        self.message = message
+        if cursor is not None:
+            self.line, self.position = cursor.position
+
+    @property
+    def has_position(self) -> bool:
+        return None not in (self.line, self.position)
+
+    def __repr__(self):
+        details = (
+            f", line={self.line}, position={self.position}" if self.has_position else ""
+        )
+        return f'{self.__class__.__name__}("{self.message}"{details})'

--- a/poethepoet/task/cmd.py
+++ b/poethepoet/task/cmd.py
@@ -69,14 +69,14 @@ class CmdTask(PoeTask):
             command_lines = parse_poe_cmd(self.spec.content).command_lines
         except ParseError as error:
             raise PoeException(
-                f"Couldn't parse command line for task {self.name!r}: {error.args[0]}"
-            ) from error
+                f"Couldn't parse command line for task {self.name!r}", error
+            )
 
         if not command_lines:
             raise PoeException(
                 f"Invalid cmd task {self.name!r} does not include any command lines"
             )
-        if any(line._terminator == ";" for line in command_lines[:-1]):
+        if any(line.terminator == ";" for line in command_lines[:-1]):
             # lines terminated by a line break or comment are implicitly joined
             raise PoeException(
                 f"Invalid cmd task {self.name!r} includes multiple command lines"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,6 +204,7 @@ def run_poe(capsys, projects):
         project: Optional[str] = None,
         config_name="pyproject.toml",
         program_name="poe",
+        env: Optional[Mapping[str, str]] = None,
     ) -> PoeRunResult:
         cwd = projects.get(project, cwd)
         output_capture = StringIO()
@@ -213,6 +214,7 @@ def run_poe(capsys, projects):
             output=output_capture,
             config_name=config_name,
             program_name=program_name,
+            env=env,
         )
         result = poe(run_args)
         output_capture.seek(0)

--- a/tests/helpers/command/test_ast.py
+++ b/tests/helpers/command/test_ast.py
@@ -107,6 +107,195 @@ def test_parse_params():
     assert tree.lines[14] == ((("a", "xx1", "? a", "yy2", "b a", "$? ", "z"),),)
 
 
+def test_parse_param_operators():
+    tree = parse_poe_cmd(
+        """
+        0${x}B
+        1${x:+foo}B
+        2${x:-bar}B
+        3${x:+$foo1}B
+        4${x:-a${bar2}b}B
+        5${x:- a ${bar} b }B
+        6${x:- a ${bar:+ $incepted + 1'"'"';#" } b }B
+        7${x:++}B
+        8${x:-$}B
+        9${x:- }B
+        10${x:-}B
+        11${x:-(#);?[t]*.ok}B
+        12${x:-?[t]*.ok}B
+        13${x:-
+        split\\  \\ \
+        lines
+        '  '
+        !
+        }B
+        """,
+        config=ParseConfig(),
+    )
+    print(tree.pretty())
+    assert len(tree.lines) == 14
+    assert tree.lines[0].words[0].segments[0] == ("0", "x", "B")
+    assert tree.lines[1].words[0].segments[0] == (
+        "1",
+        (
+            "x",
+            (
+                ":+",
+                (("foo",),),
+            ),
+        ),
+        "B",
+    )
+    assert tree.lines[2].words[0].segments[0] == (
+        "2",
+        (
+            "x",
+            (
+                ":-",
+                (("bar",),),
+            ),
+        ),
+        "B",
+    )
+    assert tree.lines[3].words[0].segments[0] == (
+        "3",
+        (
+            "x",
+            (
+                ":+",
+                ((("foo1",),),),
+            ),
+        ),
+        "B",
+    )
+    assert tree.lines[4].words[0].segments[0] == (
+        "4",
+        (
+            "x",
+            (
+                ":-",
+                (("a", ("bar2",), "b"),),
+            ),
+        ),
+        "B",
+    )
+    assert tree.lines[5].words[0].segments[0] == (
+        "5",
+        (
+            "x",
+            (
+                ":-",
+                ((" ", "a", " ", ("bar",), " ", "b", " "),),
+            ),
+        ),
+        "B",
+    )
+    assert tree.lines[6].words[0].segments[0] == (
+        "6",
+        (
+            "x",
+            (
+                ":-",
+                (
+                    (
+                        " ",
+                        "a",
+                        " ",
+                        (
+                            "bar",
+                            (
+                                ":+",
+                                (
+                                    (" ", ("incepted",), " ", "+", " ", "1"),
+                                    ('"',),
+                                    ("';#",),
+                                    (" ",),
+                                ),
+                            ),
+                        ),
+                        " ",
+                        "b",
+                        " ",
+                    ),
+                ),
+            ),
+        ),
+        "B",
+    )
+    assert tree.lines[7].words[0].segments[0] == (
+        "7",
+        (
+            "x",
+            (
+                ":+",
+                (("+",),),
+            ),
+        ),
+        "B",
+    )
+    assert tree.lines[8].words[0].segments[0] == (
+        "8",
+        (
+            "x",
+            (
+                ":-",
+                (("$",),),
+            ),
+        ),
+        "B",
+    )
+    assert tree.lines[9].words[0].segments[0] == (
+        "9",
+        (
+            "x",
+            (
+                ":-",
+                ((" ",),),
+            ),
+        ),
+        "B",
+    )
+    assert tree.lines[10].words[0].segments[0] == (
+        "10",
+        (
+            "x",
+            (":-", tuple()),
+        ),
+        "B",
+    )
+    assert tree.lines[11].words[0].segments[0] == (
+        "11",
+        (
+            "x",
+            (":-", (("(#);?[t]*.ok",),)),
+        ),
+        "B",
+    )
+    assert tree.lines[12].words[0].segments[0] == (
+        "12",
+        (
+            "x",
+            (":-", (("?[t]*.ok",),)),
+        ),
+        "B",
+    )
+    assert tree.lines[13].words[0].segments[0] == (
+        "13",
+        (
+            "x",
+            (
+                ":-",
+                (
+                    (" ", "split ", " ", " ", " ", "lines", " "),
+                    ("  ",),
+                    (" ", "!", " "),
+                ),
+            ),
+        ),
+        "B",
+    )
+
+
 def test_invalid_param_expansion():
     with pytest.raises(ParseError) as excinfo:
         parse_poe_cmd("""${}""", config=ParseConfig())

--- a/tests/test_cmd_param_expansion.py
+++ b/tests/test_cmd_param_expansion.py
@@ -1,0 +1,61 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("expression", "output", "env"),
+    [
+        # basic parameter value expansion
+        (r"$", "$", {}),
+        (r"A${FOO}B", "AB", {}),
+        (r"A${FOO}B", "AB", {"FOO": ""}),
+        (r"A${FOO}B", "A x B", {"FOO": " x "}),
+        (r"A${FOO}B", "A B", {"FOO": "   "}),
+        (r"A${FOO}B", "AfooB", {"FOO": "foo"}),
+        # default value operator
+        (r"A${FOO:-}B", "AB", {}),
+        (r"A${FOO:-bar}B", "AbarB", {}),
+        (r"A${FOO:-bar}B", "AbarB", {"FOO": ""}),
+        (r"A${FOO:-bar}B", "AfooB", {"FOO": "foo"}),
+        # alternate value operator
+        (r"A${FOO:+bar}B", "AB", {}),
+        (r"A${FOO:+bar}B", "AB", {"FOO": ""}),
+        (r"A${FOO:+}B", "AB", {"FOO": "foo"}),
+        (r"A${FOO:+bar}B", "AbarB", {"FOO": "foo"}),
+        # recursion
+        (r"A${FOO:->${BAR:+ ${BAZ:- the end }<}}B", "A> the end <B", {"BAR": "X"}),
+        # weird argument content
+        (r"A${FOO:- !&%;#($)@}B", "A !&%;#($)@B", {}),
+        (r'"A${FOO:-?.*[x]}B"', "A?.*[x]B", {}),
+        (
+            r"""A${FOO:-
+
+            hey
+
+            }B""",
+            "A hey B",
+            {},
+        ),
+    ],
+)
+def test_param_expansion_operations(
+    expression, output, env, run_poe, temp_pyproject, tmp_path
+):
+    stdout_path = tmp_path / "output.txt"
+    stdout_path.touch(exist_ok=True)
+    project_toml = f'''
+    [tool.poe.tasks.echo-expression]
+    cmd = """echo {expression}"""
+    capture_stdout = "{stdout_path.as_posix()}"
+    '''
+    project_path = temp_pyproject(project_toml)
+    result = run_poe("echo-expression", cwd=project_path, env=env)
+
+    print(project_toml)
+    print("result", result)
+
+    assert result.code == 0
+
+    with stdout_path.open() as stdout_file:
+        assert (
+            stdout_file.read() == f"{output}\n"
+        ), "Task output should match test parameter"


### PR DESCRIPTION
Specifically cmd tasks may now use the following operations like in bash
- `:-` fallback value, e.g. ${AWS_REGION:-us-east-1}
- `:+` value replacement, e.g. ${AWESOME:+--awesome-mode}

This was done by adding AST parser support for Param Expansion operators

Also:
- Fix bug in param expansion logic for pure whitespace param values
- Add env paramater to PoeThePoet class to override os.environ for testing
