### PR TITLE
fix: improve detection of poetry 2 projects

### DIFF
--- a/poethepoet/config/config.py
+++ b/poethepoet/config/config.py
@@ -120,9 +120,14 @@ class PoeConfig:
 
     @property
     def is_poetry_project(self) -> bool:
-        return (
-            self._project_config.path.name == "pyproject.toml"
-            and "poetry" in self._project_config.full_config.get("tool", {})
+        full_config = self._project_config.full_config
+        return self._project_config.path.name == "pyproject.toml" and (
+            "poetry" in full_config.get("tool", {})
+            or (
+                # Fallback required to work out of the box with some poetry 2.0 projects
+                full_config.get("build-system", {}).get("build-backend", "")
+                == "poetry.core.masonry.api"
+            )
         )
 
     @property

--- a/poethepoet/plugin.py
+++ b/poethepoet/plugin.py
@@ -154,7 +154,7 @@ class PoetryPlugin(ApplicationPlugin):
         # Try respect poetry's '--directory' if set
         try:
             pyproject_dir = application.poetry.pyproject_path.parent
-        except AttributeError:
+        except (AttributeError, RuntimeError):
             pyproject_dir = None
 
         poe_config = PoeConfig(cwd=pyproject_dir)


### PR DESCRIPTION
Projects created with poetry >= 2.0 don't necessarily include a tool.poetry 
table in the pyproject.toml. Thus poethepoet cannot rely on the presence or 
absence of this table to tell whether it is appropriate to default to using 
the PoetryExecutor to run tasks with poetry's venv.

It seems the best remaining indicator is the content of the build-system which 
poetry still configures consistently, although this is less ideal.