### PR TITLE
fix: issues with argument parsing in poetry 2.0 plugin

### DIFF
--- a/poethepoet/config/config.py
+++ b/poethepoet/config/config.py
@@ -177,9 +177,14 @@ class PoeConfig:
                 break
 
         else:
-            raise PoeException(
-                f"No poe configuration found from location {target_path}"
-            )
+            if target_path is not None:
+                raise PoeException(
+                    f"No poe configuration found from location {target_path}"
+                )
+            else:
+                raise PoeException(
+                    f"No poe configuration found from location {self._project_dir}"
+                )
 
         self._load_includes(strict=strict)
 

--- a/poethepoet/executor/poetry.py
+++ b/poethepoet/executor/poetry.py
@@ -52,7 +52,7 @@ class PoetryExecutor(PoeExecutor):
 
         # Run this task with `poetry run`
         return self._execute_cmd(
-            (self._poetry_cmd(), "run", *cmd),
+            (self._poetry_cmd(), "--no-plugins", "run", *cmd),
             input=input,
             use_exec=use_exec,
         )
@@ -88,7 +88,7 @@ class PoetryExecutor(PoeExecutor):
 
             exec_cache["poetry_virtualenv"] = (
                 Popen(
-                    (self._poetry_cmd(), "env", "info", "-p"),
+                    (self._poetry_cmd(), "--no-plugins", "env", "info", "-p"),
                     stdout=PIPE,
                     cwd=self.context.config.project_dir,
                     env=clean_env,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ sequence = ["docs-check", "style", "types", "lint", "test"]
 [tool.poe.tasks.install-poetry-plugin]
 help = "Install or update this project as a plugin in poetry"
 sequence = [
-  { cmd = "poetry self remove poethepoet"},
+  { cmd = "poetry --no-plugins self remove poethepoet"},
   { cmd = "poetry self add \"${POE_ROOT}[poetry_plugin]\""}
 ]
 ignore_fail = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,11 +244,14 @@ def run_poe_main(capsys, projects):
     return run_poe_main
 
 
-@pytest.fixture(scope="session")
-def run_poetry(use_venv, poe_project_path, version: str = "2.0.0"):
-    venv_location = poe_project_path / "tests" / "temp" / "poetry_venv"
+def run_poetry(use_venv, poe_project_path, version):
+    venv_location = poe_project_path / "tests" / "temp" / f"poetry_venv_{version}"
 
-    def run_poetry(args: list[str], cwd: str, env: Optional[dict[str, str]] = None):
+    def run_poetry(
+        args: list[str],
+        cwd: str,
+        env: Optional[dict[str, str]] = None,
+    ):
         venv = Virtualenv(venv_location)
 
         cmd = (venv.resolve_executable("python"), "-m", "poetry", *args)
@@ -280,6 +283,16 @@ def run_poetry(use_venv, poe_project_path, version: str = "2.0.0"):
         require_empty=True,
     ):
         yield run_poetry
+
+
+@pytest.fixture(scope="session")
+def run_poetry_1(use_venv, poe_project_path):
+    yield from run_poetry(use_venv, poe_project_path, version="1.8.2")
+
+
+@pytest.fixture(scope="session")
+def run_poetry_2(use_venv, poe_project_path):
+    yield from run_poetry(use_venv, poe_project_path, version="2.0.0")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_poetry_plugin_v1.py
+++ b/tests/test_poetry_plugin_v1.py
@@ -1,0 +1,206 @@
+import os
+import re
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def _setup_poetry_project(run_poetry_1, projects):
+    run_poetry_1(["install"], cwd=projects["poetry_plugin"])
+
+
+@pytest.fixture(scope="module")
+def _setup_poetry_project_empty_prefix(run_poetry_1, projects):
+    run_poetry_1(
+        ["install"],
+        cwd=projects["poetry_plugin/empty_prefix"].parent,
+    )
+
+
+@pytest.fixture(scope="module")
+def _setup_poetry_project_with_prefix(run_poetry_1, projects):
+    run_poetry_1(
+        ["install"],
+        cwd=projects["poetry_plugin/with_prefix"].parent,
+    )
+
+
+@pytest.mark.slow
+def test_poetry_help(run_poetry_1, projects):
+    result = run_poetry_1([], cwd=projects["poetry_plugin"])
+    assert result.stdout.startswith("Poetry (version ")
+    assert "poe cow-greet" in result.stdout
+    assert re.search(r"\n  poe echo\s+It's like echo\n", result.stdout)
+    # assert result.stderr == ""
+
+
+# TODO: re-enable this test
+@pytest.mark.skipif(
+    os.environ.get("GITHUB_ACTIONS", "false") == "true",
+    reason="Skipping test the doesn't seem to work in GitHub Actions lately",
+)
+@pytest.mark.slow
+@pytest.mark.usefixtures("_setup_poetry_project")
+def test_task_with_cli_dependency(run_poetry_1, projects, is_windows):
+    result = run_poetry_1(
+        ["poe", "cow-greet", "yo yo yo"],
+        cwd=projects["poetry_plugin"],
+    )
+    if is_windows:
+        assert result.stdout.startswith("Poe => cowpy 'yo yo yo'")
+        assert "< yo yo yo >" in result.stdout
+    else:
+        # On POSIX cowpy expects notices its being called as a subprocess and tries
+        # unproductively to take input from stdin
+        assert result.stdout.startswith("Poe => cowpy 'yo yo yo'")
+        assert (
+            "< Cowacter, eyes:default, tongue:False, thoughts:False >" in result.stdout
+        )
+    # assert result.stderr == ""
+
+
+# TODO: re-enable this test
+@pytest.mark.skipif(
+    os.environ.get("GITHUB_ACTIONS", "false") == "true",
+    reason="Skipping test the doesn't seem to work in GitHub Actions lately",
+)
+@pytest.mark.slow
+@pytest.mark.usefixtures("_setup_poetry_project")
+def test_task_with_lib_dependency(run_poetry_1, projects):
+    result = run_poetry_1(["poe", "cow-cheese"], cwd=projects["poetry_plugin"])
+    assert result.stdout == (
+        "Poe => from cowpy import cow; print(list(cow.COWACTERS)[5])\ncheese\n"
+    )
+    # assert result.stderr == ""
+
+
+@pytest.mark.slow
+@pytest.mark.usefixtures("_setup_poetry_project")
+def test_task_accepts_any_args(run_poetry_1, projects):
+    result = run_poetry_1(
+        ["poe", "echo", "--lol=:D", "--version", "--help"],
+        cwd=projects["poetry_plugin"],
+    )
+    assert result.stdout == (
+        "Poe => poe_test_echo --lol=:D --version --help\n--lol=:D --version --help\n"
+    )
+    # assert result.stderr == ""
+
+
+@pytest.mark.slow
+@pytest.mark.usefixtures("_setup_poetry_project_empty_prefix")
+def test_poetry_help_without_poe_command_prefix(run_poetry_1, projects):
+    result = run_poetry_1([], cwd=projects["poetry_plugin/empty_prefix"].parent)
+    assert result.stdout.startswith("Poetry (version ")
+    assert "\n  cow-greet" in result.stdout
+    assert "\n  echo               It's like echo\n" in result.stdout
+    # assert result.stderr == ""
+
+
+@pytest.mark.slow
+@pytest.mark.usefixtures("_setup_poetry_project_empty_prefix")
+def test_running_tasks_without_poe_command_prefix(run_poetry_1, projects):
+    result = run_poetry_1(
+        ["echo", "--lol=:D", "--version", "--help"],
+        cwd=projects["poetry_plugin/empty_prefix"].parent,
+    )
+    assert result.stdout == (
+        "Poe => poe_test_echo --lol=:D --version --help\n--lol=:D --version --help\n"
+    )
+    # assert result.stderr == ""
+
+
+@pytest.mark.slow
+@pytest.mark.usefixtures("_setup_poetry_project_empty_prefix")
+def test_poetry_command_from_included_file_with_empty_prefix(run_poetry_1, projects):
+    result = run_poetry_1(
+        ["included-greeting"],
+        cwd=projects["poetry_plugin/empty_prefix"].parent,
+    )
+    assert result.stdout.startswith("Poe => echo 'Greetings from another file!'")
+    # assert result.stderr == ""
+
+
+@pytest.mark.slow
+@pytest.mark.usefixtures("_setup_poetry_project_empty_prefix")
+def test_poetry_help_with_poe_command_prefix(run_poetry_1, projects):
+    result = run_poetry_1([], cwd=projects["poetry_plugin/with_prefix"].parent)
+    assert result.stdout.startswith("Poetry (version ")
+    assert "\n  foo cow-greet" in result.stdout
+    assert "\n  foo echo           It's like echo\n" in result.stdout
+    # assert result.stderr == ""
+
+
+@pytest.mark.slow
+@pytest.mark.usefixtures("_setup_poetry_project_with_prefix")
+def test_running_tasks_with_poe_command_prefix(run_poetry_1, projects):
+    result = run_poetry_1(
+        ["foo", "echo", "--lol=:D", "--version", "--help"],
+        cwd=projects["poetry_plugin/with_prefix"].parent,
+    )
+    assert result.stdout == (
+        "Poe => poe_test_echo --lol=:D --version --help\n--lol=:D --version --help\n"
+    )
+    # assert result.stderr == ""
+
+
+@pytest.mark.slow
+@pytest.mark.usefixtures("_setup_poetry_project_with_prefix")
+def test_running_tasks_with_poe_command_prefix_missing_args(run_poetry_1, projects):
+    result = run_poetry_1(
+        ["foo"],
+        cwd=projects["poetry_plugin/with_prefix"].parent,
+    )
+    assert "Usage:\n  poetry foo [global options]" in result.stdout
+    # assert result.stderr == ""
+
+
+@pytest.mark.slow
+@pytest.mark.usefixtures("_setup_poetry_project")
+def test_running_poetry_command_with_hooks(run_poetry_1, projects):
+    result = run_poetry_1(["env", "info"], cwd=projects["poetry_plugin"])
+    assert "THIS IS YOUR ENV!" in result.stdout
+    assert "THAT WAS YOUR ENV!" in result.stdout
+    # assert result.stderr == ""
+
+
+@pytest.mark.slow
+@pytest.mark.usefixtures("_setup_poetry_project")
+def test_running_poetry_command_with_hooks_with_directory(run_poetry_1, projects):
+    result = run_poetry_1(
+        ["--directory=" + str(projects["poetry_plugin"]), "env", "info"],
+        cwd=projects["poetry_plugin"].parent,
+    )
+    assert "THIS IS YOUR ENV!" in result.stdout
+    assert "THAT WAS YOUR ENV!" in result.stdout
+    # assert result.stderr == ""
+
+
+# TODO: re-enable this test
+@pytest.mark.skipif(
+    os.environ.get("GITHUB_ACTIONS", "false") == "true",
+    reason="Skipping test the doesn't seem to work in GitHub Actions lately",
+)
+@pytest.mark.slow
+@pytest.mark.usefixtures("_setup_poetry_project")
+def test_task_with_cli_dependency_with_directory(run_poetry_1, projects, is_windows):
+    result = run_poetry_1(
+        [
+            "--directory=" + str(projects["poetry_plugin"]),
+            "poe",
+            "cow-greet",
+            "yo yo yo",
+        ],
+        cwd=projects["poetry_plugin"].parent,
+    )
+    if is_windows:
+        assert result.stdout.startswith("Poe => cowpy 'yo yo yo'")
+        assert "< yo yo yo >" in result.stdout
+    else:
+        # On POSIX cowpy expects notices its being called as a subprocess and tries
+        # unproductively to take input from stdin
+        assert result.stdout.startswith("Poe => cowpy 'yo yo yo'")
+        assert (
+            "< Cowacter, eyes:default, tongue:False, thoughts:False >" in result.stdout
+        )
+    # assert result.stderr == ""

--- a/tests/test_poetry_plugin_v2.py
+++ b/tests/test_poetry_plugin_v2.py
@@ -4,24 +4,30 @@ import re
 import pytest
 
 
-@pytest.fixture(scope="session")
-def _setup_poetry_project(run_poetry, projects):
-    run_poetry(["install"], cwd=projects["poetry_plugin"])
+@pytest.fixture(scope="module")
+def _setup_poetry_project(run_poetry_2, projects):
+    run_poetry_2(["install"], cwd=projects["poetry_plugin"])
 
 
-@pytest.fixture(scope="session")
-def _setup_poetry_project_empty_prefix(run_poetry, projects):
-    run_poetry(["install"], cwd=projects["poetry_plugin/empty_prefix"].parent)
+@pytest.fixture(scope="module")
+def _setup_poetry_project_empty_prefix(run_poetry_2, projects):
+    run_poetry_2(
+        ["install"],
+        cwd=projects["poetry_plugin/empty_prefix"].parent,
+    )
 
 
-@pytest.fixture(scope="session")
-def _setup_poetry_project_with_prefix(run_poetry, projects):
-    run_poetry(["install"], cwd=projects["poetry_plugin/with_prefix"].parent)
+@pytest.fixture(scope="module")
+def _setup_poetry_project_with_prefix(run_poetry_2, projects):
+    run_poetry_2(
+        ["install"],
+        cwd=projects["poetry_plugin/with_prefix"].parent,
+    )
 
 
 @pytest.mark.slow
-def test_poetry_help(run_poetry, projects):
-    result = run_poetry([], cwd=projects["poetry_plugin"])
+def test_poetry_help(run_poetry_2, projects):
+    result = run_poetry_2([], cwd=projects["poetry_plugin"])
     assert result.stdout.startswith("Poetry (version ")
     assert "poe cow-greet" in result.stdout
     assert re.search(r"\n  poe echo\s+It's like echo\n", result.stdout)
@@ -35,8 +41,8 @@ def test_poetry_help(run_poetry, projects):
 )
 @pytest.mark.slow
 @pytest.mark.usefixtures("_setup_poetry_project")
-def test_task_with_cli_dependency(run_poetry, projects, is_windows):
-    result = run_poetry(
+def test_task_with_cli_dependency(run_poetry_2, projects, is_windows):
+    result = run_poetry_2(
         ["poe", "cow-greet", "yo yo yo"],
         cwd=projects["poetry_plugin"],
     )
@@ -60,8 +66,8 @@ def test_task_with_cli_dependency(run_poetry, projects, is_windows):
 )
 @pytest.mark.slow
 @pytest.mark.usefixtures("_setup_poetry_project")
-def test_task_with_lib_dependency(run_poetry, projects):
-    result = run_poetry(["poe", "cow-cheese"], cwd=projects["poetry_plugin"])
+def test_task_with_lib_dependency(run_poetry_2, projects):
+    result = run_poetry_2(["poe", "cow-cheese"], cwd=projects["poetry_plugin"])
     assert result.stdout == (
         "Poe => from cowpy import cow; print(list(cow.COWACTERS)[5])\ncheese\n"
     )
@@ -70,8 +76,8 @@ def test_task_with_lib_dependency(run_poetry, projects):
 
 @pytest.mark.slow
 @pytest.mark.usefixtures("_setup_poetry_project")
-def test_task_accepts_any_args(run_poetry, projects):
-    result = run_poetry(
+def test_task_accepts_any_args(run_poetry_2, projects):
+    result = run_poetry_2(
         ["poe", "echo", "--lol=:D", "--version", "--help"],
         cwd=projects["poetry_plugin"],
     )
@@ -83,8 +89,8 @@ def test_task_accepts_any_args(run_poetry, projects):
 
 @pytest.mark.slow
 @pytest.mark.usefixtures("_setup_poetry_project_empty_prefix")
-def test_poetry_help_without_poe_command_prefix(run_poetry, projects):
-    result = run_poetry([], cwd=projects["poetry_plugin/empty_prefix"].parent)
+def test_poetry_help_without_poe_command_prefix(run_poetry_2, projects):
+    result = run_poetry_2([], cwd=projects["poetry_plugin/empty_prefix"].parent)
     assert result.stdout.startswith("Poetry (version ")
     assert "\n  cow-greet" in result.stdout
     assert "\n  echo               It's like echo\n" in result.stdout
@@ -93,8 +99,8 @@ def test_poetry_help_without_poe_command_prefix(run_poetry, projects):
 
 @pytest.mark.slow
 @pytest.mark.usefixtures("_setup_poetry_project_empty_prefix")
-def test_running_tasks_without_poe_command_prefix(run_poetry, projects):
-    result = run_poetry(
+def test_running_tasks_without_poe_command_prefix(run_poetry_2, projects):
+    result = run_poetry_2(
         ["echo", "--lol=:D", "--version", "--help"],
         cwd=projects["poetry_plugin/empty_prefix"].parent,
     )
@@ -106,8 +112,8 @@ def test_running_tasks_without_poe_command_prefix(run_poetry, projects):
 
 @pytest.mark.slow
 @pytest.mark.usefixtures("_setup_poetry_project_empty_prefix")
-def test_poetry_command_from_included_file_with_empty_prefix(run_poetry, projects):
-    result = run_poetry(
+def test_poetry_command_from_included_file_with_empty_prefix(run_poetry_2, projects):
+    result = run_poetry_2(
         ["included-greeting"],
         cwd=projects["poetry_plugin/empty_prefix"].parent,
     )
@@ -117,8 +123,8 @@ def test_poetry_command_from_included_file_with_empty_prefix(run_poetry, project
 
 @pytest.mark.slow
 @pytest.mark.usefixtures("_setup_poetry_project_empty_prefix")
-def test_poetry_help_with_poe_command_prefix(run_poetry, projects):
-    result = run_poetry([], cwd=projects["poetry_plugin/with_prefix"].parent)
+def test_poetry_help_with_poe_command_prefix(run_poetry_2, projects):
+    result = run_poetry_2([], cwd=projects["poetry_plugin/with_prefix"].parent)
     assert result.stdout.startswith("Poetry (version ")
     assert "\n  foo cow-greet" in result.stdout
     assert "\n  foo echo           It's like echo\n" in result.stdout
@@ -127,8 +133,8 @@ def test_poetry_help_with_poe_command_prefix(run_poetry, projects):
 
 @pytest.mark.slow
 @pytest.mark.usefixtures("_setup_poetry_project_with_prefix")
-def test_running_tasks_with_poe_command_prefix(run_poetry, projects):
-    result = run_poetry(
+def test_running_tasks_with_poe_command_prefix(run_poetry_2, projects):
+    result = run_poetry_2(
         ["foo", "echo", "--lol=:D", "--version", "--help"],
         cwd=projects["poetry_plugin/with_prefix"].parent,
     )
@@ -140,8 +146,8 @@ def test_running_tasks_with_poe_command_prefix(run_poetry, projects):
 
 @pytest.mark.slow
 @pytest.mark.usefixtures("_setup_poetry_project_with_prefix")
-def test_running_tasks_with_poe_command_prefix_missing_args(run_poetry, projects):
-    result = run_poetry(
+def test_running_tasks_with_poe_command_prefix_missing_args(run_poetry_2, projects):
+    result = run_poetry_2(
         ["foo"],
         cwd=projects["poetry_plugin/with_prefix"].parent,
     )
@@ -151,8 +157,8 @@ def test_running_tasks_with_poe_command_prefix_missing_args(run_poetry, projects
 
 @pytest.mark.slow
 @pytest.mark.usefixtures("_setup_poetry_project")
-def test_running_poetry_command_with_hooks(run_poetry, projects):
-    result = run_poetry(["env", "info"], cwd=projects["poetry_plugin"])
+def test_running_poetry_command_with_hooks(run_poetry_2, projects):
+    result = run_poetry_2(["env", "info"], cwd=projects["poetry_plugin"])
     assert "THIS IS YOUR ENV!" in result.stdout
     assert "THAT WAS YOUR ENV!" in result.stdout
     # assert result.stderr == ""
@@ -160,8 +166,8 @@ def test_running_poetry_command_with_hooks(run_poetry, projects):
 
 @pytest.mark.slow
 @pytest.mark.usefixtures("_setup_poetry_project")
-def test_running_poetry_command_with_hooks_with_directory(run_poetry, projects):
-    result = run_poetry(
+def test_running_poetry_command_with_hooks_with_directory(run_poetry_2, projects):
+    result = run_poetry_2(
         ["--directory=" + str(projects["poetry_plugin"]), "env", "info"],
         cwd=projects["poetry_plugin"].parent,
     )
@@ -177,8 +183,8 @@ def test_running_poetry_command_with_hooks_with_directory(run_poetry, projects):
 )
 @pytest.mark.slow
 @pytest.mark.usefixtures("_setup_poetry_project")
-def test_task_with_cli_dependency_with_directory(run_poetry, projects, is_windows):
-    result = run_poetry(
+def test_task_with_cli_dependency_with_directory(run_poetry_2, projects, is_windows):
+    result = run_poetry_2(
         [
             "--directory=" + str(projects["poetry_plugin"]),
             "poe",


### PR DESCRIPTION
Fixes #270

- Create a PoeConfig once on plugin initialization, and reuse it in the command. This allows the plugin to find the config before the working directory is updated as a result of including the `--directory` option.
- Update the cleo monkeypatch to account for --directory and --project options taking an argument and being rewritten to precede the command.

Also:
- disable poetry plugins when calling the poetry CLI inside PoetryExecutor
- Duplicate poetry plugin tests to run with two poetry versions