### PR TITLE
feat: Support displaying help for a single task

### DIFF
--- a/poethepoet/app.py
+++ b/poethepoet/app.py
@@ -103,12 +103,14 @@ class PoeThePoet:
             self.ui.print_version()
             return 0
 
+        should_display_help = self.ui["help"] != Ellipsis
+
         try:
             self.config.load(target_path=self.ui["project_root"])
             for task_spec in self.task_specs.load_all():
                 task_spec.validate(self.config, self.task_specs)
         except PoeException as error:
-            if self.ui["help"]:
+            if should_display_help:
                 self.print_help()
                 return 0
             self.print_help(error=error)
@@ -116,7 +118,7 @@ class PoeThePoet:
 
         self.ui.set_default_verbosity(self.config.verbosity)
 
-        if self.ui["help"]:
+        if should_display_help:
             self.print_help()
             return 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,6 +148,31 @@ def test_poe_env_vars_are_set(run_poe_subproc):
         assert env_var in result.stdout
 
 
+def test_documentation_of_single_task_with_no_help_or_args(run_poe):
+    result = run_poe("-h", "echo-args", project="scripts")
+    assert result.capture == (
+        "\n"
+        "Usage:\n"
+        "  poe [global options] echo-args [named arguments] -- [free arguments]\n"
+        "\n\n"
+    )
+
+
+def test_documentation_of_single_task_with_help_and_args(run_poe):
+    result = run_poe("--help", "greet-strict", project="scripts")
+    assert result.capture == (
+        "\n"
+        "Description:\n"
+        "  All arguments are required\n\n"
+        "Usage:\n"
+        "  poe [global options] greet-strict [named arguments] -- [free arguments]\n\n"
+        "Named arguments:\n"
+        "  --greeting          this one is required [default: ${DOES}n't ${STUFF}]\n"
+        "  --name              and this one is required\n"
+        "\n\n"
+    )
+
+
 def test_documentation_of_task_named_args(run_poe):
     result = run_poe(project="scripts")
     assert result.capture.startswith(


### PR DESCRIPTION
fixes #271

You can now pass a task name to the global `--help` option to display help for just that task.