### PR TITLE
fix: The UV executor exectures the wrong file

### DIFF
--- a/poethepoet/executor/uv.py
+++ b/poethepoet/executor/uv.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from .base import PoeExecutor
@@ -49,7 +48,7 @@ class UvExecutor(PoeExecutor):
     def _uv_cmd(cls):
         from_path = cls._uv_cmd_from_path()
         if from_path:
-            return str(Path(from_path).resolve())
+            return from_path
 
         return "uv"
 


### PR DESCRIPTION
`uv` is installed via Snap on Ubuntu. Snap is a wrapper providing a safe environment for execution.

Snap symlinks all executable commands to it's binary.

* Called as `snap`: Snap CLI
* Called as a symlink from any other file: Execute the file in it's environment

The `UvExecutor` class resolved the path itself including any symlinks and eventually calls `/usr/bin/snap` instead of `/snap/bin/uv`. Snaps assumes a call to it's own CLI and fails.

With this patch, the shell will resolve the path and provide the correct "executed file" information (`$0` in a Bash script) to Snap.

fixes #282

## Description of changes

Replace this text with a description of the changes proposed in this PR, including the motivation for these changes and a reference to any related GitHub issue or discussion.

## Pre-merge Checklist

- [x] New features (if any) are covered by new feature tests
- [x] New features (if any) are documented
- [x] Bug fixes (if any) are accompanied by a test (if not too complicated to do so)
- [x] `poe check` executed successfully
- [x] This PR targets the *development* branch for code changes or *main* if only documentation is updated
