### PR TITLE
Add the `uv` executor to the documentation

### DIFF
--- a/docs/global_options.rst
+++ b/docs/global_options.rst
@@ -100,6 +100,7 @@ You can configure poe to use a specific executor by setting
 
 - **auto**: to automatically use the most appropriate of the following executors in order
 - **poetry**: to run tasks in the poetry managed environment
+- **uv**: to run tasks in an uv environment
 - **virtualenv**: to run tasks in the indicated virtualenv (or else "./.venv" or "./venv" if present)
 - **simple**: to run tasks without doing any specific environment setup
 


### PR DESCRIPTION
## Description of changes

Support for "uv" was added in #271. This change adds the uv executor to the documentation.

The executor is usually auto-detected. The documentation should reflect all executors.

## Pre-merge Checklist

- [X] New features (if any) are covered by new feature tests
- [x] New features (if any) are documented
- [x] Bug fixes (if any) are accompanied by a test (if not too complicated to do so)
- [x] `poe check` executed successfully
- [x] This PR targets the *development* branch for code changes or *main* if only documentation is updated
