### PR TITLE
fix: always validate task args when loading config

### DIFF
--- a/poethepoet/task/base.py
+++ b/poethepoet/task/base.py
@@ -329,6 +329,12 @@ class PoeTask(metaclass=MetaPoeTask):
                             f"option set: {dep_task_name!r}"
                         )
 
+            if self.options.args:
+                from .args import ArgSpec
+
+                for _ in ArgSpec.parse(self.options.args):
+                    pass
+
         def _task_validations(self, config: "PoeConfig", task_specs: TaskSpecFactory):
             """
             Perform validations on this TaskSpec that apply to a specific task type

--- a/tests/fixtures/include_scripts_project/tasks.py
+++ b/tests/fixtures/include_scripts_project/tasks.py
@@ -14,7 +14,7 @@ def tasks1(task_suffix: str = ""):
                 "help": "Checking that we can pass an arg",
                 "args": [
                     {
-                        "name ": "ARG_VAR",
+                        "name": "ARG_VAR",
                         "options": ["--something"],
                         "help": "This is the arg",
                     }

--- a/tests/fixtures/scripts_project/bad_content.toml
+++ b/tests/fixtures/scripts_project/bad_content.toml
@@ -1,3 +1,3 @@
 [tool.poe.tasks.bad-type]
 script = "dummy_package:main[greeting]"
-args = { greeting = {type = "datetime"} }
+args = { greeting = {type = "string"} }


### PR DESCRIPTION
Also make error reporting for task args config validation more robust.