### PR TITLE
Fix issue with locating sh.exe when git is installed in a custom loca…

### DIFF
--- a/poethepoet/task/shell.py
+++ b/poethepoet/task/shell.py
@@ -1,6 +1,7 @@
 import re
 from collections.abc import Sequence
 from os import environ
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
 
 from ..exceptions import ConfigValidationError, PoeException

--- a/poethepoet/task/shell.py
+++ b/poethepoet/task/shell.py
@@ -142,7 +142,7 @@ class ShellTask(PoeTask):
                 result = which(f"{prog_files}\\Git\\bin\\sh.exe")
 
                 if result is None and (git_path_str := which("git")) is not None:
-                    # Check if sh.exe can be found relative to the git executable 
+                    # Check if sh.exe can be found relative to the git executable
                     # in case git is installed at a non-standard location.
                     git_path = Path(git_path_str)
                     if (sh_path := git_path.parent.parent / "bin" / "sh.exe").exists():

--- a/poethepoet/task/shell.py
+++ b/poethepoet/task/shell.py
@@ -141,16 +141,12 @@ class ShellTask(PoeTask):
             if result is None and self._is_windows:
                 result = which(f"{prog_files}\\Git\\bin\\sh.exe")
 
-            if result is None and (git_path_str := which("git")) is not None:
-                # git installation may be non-defualt library path to allow for 
-                # non-admin git-cli installation. In this case the posix shell
-                # can be located relative to the git executable.
-                from pathlib import Path
-
-                git_path = Path(git_path_str)
-                sh_path = git_path.parent.parent / "bin" / "sh.exe"
-                result = str(sh_path) if sh_path.exists() else None
-
+                if result is None and (git_path_str := which("git")) is not None:
+                    # Check if sh.exe can be found relative to the git executable 
+                    # in case git is installed at a non-standard location.
+                    git_path = Path(git_path_str)
+                    if (sh_path := git_path.parent.parent / "bin" / "sh.exe").exists():
+                        result = str(sh_path)
         elif interpreter == "bash":
             if self._is_windows:
                 # Specifically look for git bash on windows as the preferred option

--- a/poethepoet/task/shell.py
+++ b/poethepoet/task/shell.py
@@ -141,6 +141,16 @@ class ShellTask(PoeTask):
             if result is None and self._is_windows:
                 result = which(f"{prog_files}\\Git\\bin\\sh.exe")
 
+            if result is None and (git_path_str := which("git")) is not None:
+                # git installation may be non-defualt library path to allow for 
+                # non-admin git-cli installation. In this case the posix shell
+                # can be located relative to the git executable.
+                from pathlib import Path
+
+                git_path = Path(git_path_str)
+                sh_path = git_path.parent.parent / "bin" / "sh.exe"
+                result = str(sh_path) if sh_path.exists() else None
+
         elif interpreter == "bash":
             if self._is_windows:
                 # Specifically look for git bash on windows as the preferred option


### PR DESCRIPTION
Fix issue with locating sh.exe when git is installed in a custom location on windows

## Description of changes

An attempt to locate sh.exe on windows is relative to git.exe instead of just looking in `C:\Program Files\git`

This makes locating sh.exe work if git is installed in non-standard locations

## Pre-merge Checklist

- [ ] New features (if any) are covered by new feature tests
- [ ] New features (if any) are documented
- [ ] Bug fixes (if any) are accompanied by a test (if not too complicated to do so)
- [ ] `poe check` executed successfully
- [ ] This PR targets the *development* branch for code changes or *main* if only documentation is updated
