### PR TITLE
feat!: Improve handling of unmatched glob patterns in cmd tasks

### DIFF
--- a/docs/tasks/task_types/cmd.rst
+++ b/docs/tasks/task_types/cmd.rst
@@ -18,6 +18,11 @@ Available task options
 
 ``cmd`` tasks support all of the :doc:`standard task options <../options>`.
 
+The following options are also accepted:
+
+**empty_glob** : ``Literal["pass", "null", "fail"]`` :ref:`📖<Glob expansion>`
+  Determines how to handle glob patterns with no matches. The default is ``"pass"``, which causes unmatched patterns to be passed through to the command (just like in bash). Setting it to ``"null"`` will replace an unmatched pattern with nothing, and setting it to ``"fail"`` will cause the task to fail with an error if there are no matches.
+
 
 Shell like features
 -------------------
@@ -77,19 +82,22 @@ In this example we declare a boolean argument with no default, so if the ``--arn
 Glob expansion
 ~~~~~~~~~~~~~~
 
-Glob patterns in cmd tasks are expanded and replaced with the list of matching files and directories. The supported glob syntax is that of the |glob_link|, which differs from bash in that square bracket patterns don't support character classes, don't break on whitespace, and don't allow escaping of contained characters.
+Glob patterns in cmd tasks are expanded and replaced with the list of matching files and directories. Glob patterns are evaluated relative to the working directory of the task.
 
-Glob patterns are evaluated relative to the working directory of the task, and if there are no matches then the pattern is expanded to nothing.
+The supported glob syntax is that of the |glob_link|, which differs from bash in that square bracket patterns don't support character classes, don't break on whitespace, and don't allow escaping of contained characters.
 
-Here's an example of task using a recursive glob pattern:
+If there are no matches then by default the pattern is passed through to the command unchanged (just like in bash). This behavior can be overridden for a specific task by setting the :toml:`empty_glob` option to ``"null"`` or ``"fail"``. If set to ``"null"`` then the pattern will be replaced with nothing (similar to how bash behaves with the |nullglob_link| is set), and if set to ``"fail"`` then a glob pattern with no matches will cause the task execution will fail with an error.
+
+The following task uses glob patterns to specify all ``.pyc`` files and ``__pycache__`` directories in the project in the project for removal, and thanks to the :toml:`empty_glob` options it will succeed even if there are no matches since no arguments will be passed to the ``rm`` command.
 
 .. code-block:: toml
 
-  [tool.poe.tasks]
-  clean = """
+  [tool.poe.tasks.clean]
+  cmd = """
   rm -rf ./**/*.pyc
          ./**/__pycache__    # this will match all __pycache__ dirs in the project
   """
+  empty_glob = "null"
 
 .. code-block:: sh
 
@@ -100,7 +108,7 @@ Here's an example of task using a recursive glob pattern:
 
   Notice that this example also demonstrates that comments and excess whitespace (including new lines) are ignored, without needing to escape new lines.
 
-.. seealso::
+.. tip::
 
   Just like in bash, the glob pattern can be escaped by wrapping it in quotes, or preceding it with a backslash.
 
@@ -108,3 +116,7 @@ Here's an example of task using a recursive glob pattern:
 .. |glob_link| raw:: html
 
    <a href="https://docs.python.org/3/library/glob.html" target="_blank">python standard library glob module</a>
+
+.. |nullglob_link| raw:: html
+
+   <a href="https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html" target="_blank">nullglob option</a>

--- a/docs/tasks/task_types/switch.rst
+++ b/docs/tasks/task_types/switch.rst
@@ -30,7 +30,7 @@ The following options are also accepted:
 **control** : ``str`` | ``dict``
   A **required** inline definition for a task to be executed to get the value that will determine which case task to run.
 
-**default** : ``Literal["pass"]`` | ``Literal["fail"]`` :ref:`📖<Don't fail if there's no match>`
+**default** : ``Literal["pass", "fail"]`` :ref:`📖<Don't fail if there's no match>`
   Setting ``default =  "pass"`` will make the task succeed even if no case was matched to the value and there was no default case.
 
 

--- a/poethepoet/task/base.py
+++ b/poethepoet/task/base.py
@@ -513,7 +513,7 @@ class PoeTask(metaclass=MetaPoeTask):
         working_dir = Path(cwd_option)
 
         if not working_dir.is_absolute():
-            working_dir = self.ctx.config.project_dir / working_dir
+            working_dir = self.ctx.config.project_dir.joinpath(working_dir).resolve()
 
         return working_dir
 

--- a/tests/fixtures/cmds_project/pyproject.toml
+++ b/tests/fixtures/cmds_project/pyproject.toml
@@ -28,21 +28,35 @@ args = ["formal-greeting", "subject"]
 
 [tool.poe.tasks.surfin-bird]
 cmd = "poe_test_echo $WORD is the word"
-env = { WORD = "${SOME_INPUT_VAR}"}
+env = { WORD = "${SOME_INPUT_VAR}" }
 
 [tool.poe.tasks.multiple-value-arg]
 cmd = "poe_test_echo \"first: ${first} second: ${second}\""
 
-  [[tool.poe.tasks.multiple-value-arg.args]]
-  name       = "first"
-  positional = true
+[[tool.poe.tasks.multiple-value-arg.args]]
+name = "first"
+positional = true
 
-  [[tool.poe.tasks.multiple-value-arg.args]]
-  name       = "second"
-  positional = true
-  multiple   = true
-  type       = "integer"
+[[tool.poe.tasks.multiple-value-arg.args]]
+name = "second"
+positional = true
+multiple = true
+type = "integer"
 
 [tool.poe.tasks.meeseeks]
-cmd            = """poe_test_echo "I'm Mr. Meeseeks! Look at me!" """
+cmd = """poe_test_echo "I'm Mr. Meeseeks! Look at me!" """
 capture_stdout = "${POE_PWD}/message.txt"
+
+[tool.poe.tasks.try-globs-pass]
+cmd = """poe_test_echo cmds_pro* - n*thing"""
+cwd = ".."
+
+[tool.poe.tasks.try-globs-null]
+cmd = """poe_test_echo cmds_pro* - n*thing"""
+empty_glob = "null"
+cwd = ".."
+
+[tool.poe.tasks.try-globs-fail]
+cmd = """poe_test_echo cmds_pro* - n*thing"""
+empty_glob = "fail"
+cwd = ".."

--- a/tests/test_cmd_tasks.py
+++ b/tests/test_cmd_tasks.py
@@ -209,3 +209,35 @@ def test_cmd_multiline(run_poe_subproc, testcase):
     assert result.capture == "Poe => poe_test_echo first_arg second_arg\n"
     assert result.stdout == "first_arg second_arg\n"
     assert result.stderr == ""
+
+
+def test_cmd_with_empty_glob_pass(run_poe_subproc, is_windows):
+    result = run_poe_subproc("try-globs-pass", project="cmds")
+    assert result.capture.startswith("Poe => poe_test_echo ")
+    if is_windows:
+        assert result.capture.endswith("tests\\fixtures\\cmds_project' - 'n*thing'\n")
+        assert result.stdout.endswith("tests\\fixtures\\cmds_project - n*thing\n")
+    else:
+        assert result.capture.endswith("tests/fixtures/cmds_project - 'n*thing'\n")
+        assert result.stdout.endswith("tests/fixtures/cmds_project - n*thing\n")
+    assert result.stderr == ""
+
+
+def test_cmd_with_empty_glob_null(run_poe_subproc, is_windows):
+    result = run_poe_subproc("try-globs-null", project="cmds")
+    assert result.capture.startswith("Poe => poe_test_echo ")
+    if is_windows:
+        assert result.capture.endswith("tests\\fixtures\\cmds_project' -\n")
+        assert result.stdout.endswith("tests\\fixtures\\cmds_project -\n")
+    else:
+        assert result.capture.endswith("tests/fixtures/cmds_project -\n")
+        assert result.stdout.endswith("tests/fixtures/cmds_project -\n")
+    assert result.stderr == ""
+
+
+def test_cmd_with_empty_glob_fail(run_poe_subproc, is_windows):
+    result = run_poe_subproc("try-globs-fail", project="cmds")
+    assert result.capture.startswith(
+        "Error: Glob pattern 'n*thing' did not match any files in working directory"
+    )
+    assert result.stderr == ""


### PR DESCRIPTION
Unmatched glob patterns will now be passed through to the task untouched, instead of being replaced with nothing.

The old behavior can be restored for a task be setting the new `empty_glob` option to "null" (like the nullglob option in bash). This option can also be set to "fail" to make the task execution fail with an error when an unmatched glob pattern is encountered.

In case a task fails in a way that might have been due to this breaking change then we write a warning message with a link to explain the breaking change.

Also:
- resolve relative paths for task level cwd early in the process.

## Pre-merge Checklist

- [x] New features (if any) are covered by new feature tests
- [x] New features (if any) are documented
- [x] `poe check` executed successfully
- [x] This PR targets the *development* branch for code changes or *main* if only documentation is updated
