### PR TITLE
refactor: executor options

### DIFF
--- a/poethepoet/executor/poetry.py
+++ b/poethepoet/executor/poetry.py
@@ -20,7 +20,6 @@ class PoetryExecutor(PoeExecutor):
     """
 
     __key__ = "poetry"
-    __options__: dict[str, type] = {}
 
     @classmethod
     def works_with_context(cls, context: ContextProtocol) -> bool:

--- a/poethepoet/executor/simple.py
+++ b/poethepoet/executor/simple.py
@@ -7,4 +7,3 @@ class SimpleExecutor(PoeExecutor):
     """
 
     __key__ = "simple"
-    __options__: dict[str, type] = {}

--- a/poethepoet/executor/uv.py
+++ b/poethepoet/executor/uv.py
@@ -17,7 +17,6 @@ class UvExecutor(PoeExecutor):
     """
 
     __key__ = "uv"
-    __options__: dict[str, type] = {}
 
     @classmethod
     def works_with_context(cls, context: ContextProtocol) -> bool:

--- a/poethepoet/options/__init__.py
+++ b/poethepoet/options/__init__.py
@@ -4,7 +4,7 @@ from keyword import iskeyword
 from typing import TYPE_CHECKING, Any, get_type_hints
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterator, Mapping, Sequence
 
 from ..exceptions import ConfigValidationError
 from .annotations import TypeAnnotation
@@ -64,7 +64,7 @@ class PoeOptions:
         source: Mapping[str, Any] | list,
         strict: bool = True,
         extra_keys: Sequence[str] = tuple(),
-    ):
+    ) -> Iterator[PoeOptions]:
         config_keys = {
             key[:-1] if key.endswith("_") and iskeyword(key[:-1]) else key: type_
             for key, type_ in cls.get_fields().items()
@@ -121,6 +121,9 @@ class PoeOptions:
         config: Any,
         strict: bool = True,
     ):
+        """
+        This may be overridden by subclasses
+        """
         if isinstance(config, (list, tuple)):
             yield from config
         else:


### PR DESCRIPTION
## Description of changes

Make  executors use PoeOptions for modelling, inheriting, parsing, and validations executor options in the conventional way.

## Pre-merge Checklist

- [x] `poe check` executed successfully
- [x] This PR targets the *development* branch for code changes or *main* if only documentation is updated
