### PR TITLE
fix: set uv to quiet mode during shell completion

### DIFF
--- a/poethepoet/config/config.py
+++ b/poethepoet/config/config.py
@@ -256,6 +256,7 @@ class PoeConfig:
             if invocation not in self._packaged_config_cache:
                 from ..context import InitializationContext
                 from ..env.manager import EnvVarsManager
+                from ..io import PoeIO
 
                 context = InitializationContext(config=self)
                 env = EnvVarsManager(self, base_env=environ)
@@ -266,7 +267,7 @@ class PoeConfig:
                     executor_config=include_script.get("executor"),
                     capture_stdout=True,
                     resolve_python=True,
-                    io=self._io,
+                    io=PoeIO(parent=self._io, verbosity_offset=-1),
                 )
 
                 script = (


### PR DESCRIPTION
### Problem
When using include_scripts in a uv project then the uv executor is used to run the tasks package as part of listing the available tasks for tab completion. Uv may need to sync the venv in the process which is usually fast enough but produces some output to stdout, which is unexpected and undesirable in the context of tab completion of task names.

### Solution
With this change the PoeIO exposed to the UvExecutor used for collecting tasks will have a verbosity_offset of -1, which will generally cause `uv run` to be called with the `-q` flag, thus suppressing the usual output from syncing the venv, including any warnings. Error messages from failure may still be output, because I couldn't see an elegant way to suppress these.