### PR TITLE
refactor: modernize type annotations

### DIFF
--- a/poethepoet/completion/zsh.py
+++ b/poethepoet/completion/zsh.py
@@ -50,7 +50,7 @@ def get_zsh_completion_script(name: str = "") -> str:
                 for excl_group in excl_groups
                 if option in excl_group
             ),
-            tuple(),
+            (),
         )
         # collect all option strings that are exclusive with this one
         excl_option_strings: set[str] = {

--- a/poethepoet/config/config.py
+++ b/poethepoet/config/config.py
@@ -1,7 +1,8 @@
-from collections.abc import Iterator, Mapping, Sequence
+from __future__ import annotations
+
 from os import environ
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from ..exceptions import ConfigValidationError, ExpressionParseError, PoeException
 from ..helpers.eventloop import run_async
@@ -9,6 +10,8 @@ from .file import PoeConfigFile
 from .partition import ConfigPartition, IncludedConfig, PackagedConfig, ProjectConfig
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping, Sequence
+
     from ..io import PoeIO
 
 
@@ -40,7 +43,7 @@ class PoeConfig:
         cwd: Path | str | None = None,
         table: Mapping[str, Any] | None = None,
         config_name: str | Sequence[str] | None = None,
-        io: Optional["PoeIO"] = None,
+        io: PoeIO | None = None,
     ):
         if config_name is not None:
             if isinstance(config_name, str):

--- a/poethepoet/config/partition.py
+++ b/poethepoet/config/partition.py
@@ -1,11 +1,19 @@
-from collections.abc import Mapping, Sequence
-from pathlib import Path
+from __future__ import annotations
+
 from types import MappingProxyType
-from typing import Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from ..exceptions import ConfigValidationError
 from ..options import NoValue, PoeOptions
-from .primitives import EmptyDict, EnvDefault, EnvfileOption
+from ..options.annotations import option_annotation
+from .primitives import EmptyDict, EnvDefault
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from pathlib import Path
+
+    from .primitives import EnvfileOption
+
 
 KNOWN_SHELL_INTERPRETERS = (
     "posix",
@@ -19,6 +27,7 @@ KNOWN_SHELL_INTERPRETERS = (
 )
 
 
+@option_annotation
 class IncludeScriptItem(TypedDict):
     script: str
     cwd: str
@@ -28,6 +37,7 @@ class IncludeScriptItem(TypedDict):
 IncludeScriptItem.__optional_keys__ = frozenset({"cwd", "executor"})
 
 
+@option_annotation
 class IncludeItem(TypedDict):
     path: str
     cwd: str

--- a/poethepoet/config/primitives.py
+++ b/poethepoet/config/primitives.py
@@ -2,13 +2,17 @@ from collections.abc import Mapping, Sequence
 from types import MappingProxyType
 from typing import TypedDict
 
+from ..options.annotations import option_annotation
+
 EmptyDict: Mapping = MappingProxyType({})
 
 
+@option_annotation
 class EnvDefault(TypedDict):
     default: str
 
 
+@option_annotation
 class EnvfileOption(TypedDict, total=False):
     expected: str | Sequence[str]
     optional: str | Sequence[str]

--- a/poethepoet/env/cache.py
+++ b/poethepoet/env/cache.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -9,10 +11,10 @@ if TYPE_CHECKING:
 
 class EnvFileCache:
     _cache: dict[str, dict[str, str]] = {}
-    _io: "PoeIO"
+    _io: PoeIO
     _project_dir: Path
 
-    def __init__(self, project_dir: Path, io: "PoeIO"):
+    def __init__(self, project_dir: Path, io: PoeIO):
         self._project_dir = project_dir
         self._io = io
 

--- a/poethepoet/env/template.py
+++ b/poethepoet/env/template.py
@@ -34,7 +34,7 @@ class SpyDict(dict):
     A kind of dict in which the behavior __getitem__ can be overridden.
     """
 
-    def __init__(self, content=tuple(), *, getitem_spy=None):
+    def __init__(self, content=(), *, getitem_spy=None):
         super().__init__(content)
         self._getitem_spy = getitem_spy
 

--- a/poethepoet/exceptions.py
+++ b/poethepoet/exceptions.py
@@ -1,4 +1,6 @@
 # ruff: noqa: N818
+
+
 class PoeException(RuntimeError):
     cause: str | None
 

--- a/poethepoet/helpers/command/__init__.py
+++ b/poethepoet/helpers/command/__init__.py
@@ -1,15 +1,18 @@
+from __future__ import annotations
+
 import re
-from collections.abc import Iterable, Iterator, Mapping
 from glob import escape
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 from .ast import Comment
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping
+
     from .ast import Line, ParseConfig
 
 
-def parse_poe_cmd(source: str, config: Optional["ParseConfig"] = None):
+def parse_poe_cmd(source: str, config: ParseConfig | None = None):
     from .ast import Glob, ParseConfig, ParseCursor, PythonGlob, Script
 
     if not config:
@@ -22,9 +25,9 @@ def parse_poe_cmd(source: str, config: Optional["ParseConfig"] = None):
 
 
 def resolve_command_tokens(
-    lines: Iterable["Line"],
+    lines: Iterable[Line],
     env: Mapping[str, str],
-    config: Optional["ParseConfig"] = None,
+    config: ParseConfig | None = None,
 ) -> Iterator[tuple[str, bool]]:
     """
     Generates a sequence of tokens, and indicates for each whether it includes glob

--- a/poethepoet/helpers/command/ast.py
+++ b/poethepoet/helpers/command/ast.py
@@ -1,4 +1,4 @@
-# ruff: noqa: N806, UP007
+# ruff: noqa: N806
 r"""
 This module implements a hierarchical parser and AST for a subset of bash syntax
 including:
@@ -12,7 +12,7 @@ including:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Union, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from .ast_core import (
     AnnotatedContentNode,
@@ -504,7 +504,7 @@ class Word(SyntaxNode[Segment]):
             self._children.append(SegmentCls(chars, self.config))
 
 
-class Line(SyntaxNode[Union[Word, Comment]]):
+class Line(SyntaxNode[Word | Comment]):
     _terminator: str
 
     @property
@@ -551,7 +551,7 @@ class Line(SyntaxNode[Union[Word, Comment]]):
 
 
 class Script(SyntaxNode[Line]):
-    def __init__(self, chars: ParseCursor, config: Union[ParseConfig, None] = None):
+    def __init__(self, chars: ParseCursor, config: ParseConfig | None = None):
         config = config or ParseConfig()
         if not config.line_separators:
             config.line_separators = LINE_SEP_CHARS

--- a/poethepoet/helpers/command/ast_core.py
+++ b/poethepoet/helpers/command/ast_core.py
@@ -3,9 +3,13 @@ This module provides a framework for defining a hierarchical parser and AST.
 See sibling ast module for an example usage.
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
-from typing import IO, Generic, TypeVar, cast
+from typing import IO, TYPE_CHECKING, Generic, TypeVar, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class ParseCursor:
@@ -41,7 +45,7 @@ class ParseCursor:
 
     @classmethod
     def from_string(cls, string: str):
-        return cls(char for char in string)
+        return cls(iter(string))
 
     @property
     def position(self):
@@ -101,18 +105,18 @@ class ParseConfig:
     to the parsed syntax without having to duplicate parsing logic.
     """
 
-    substitute_nodes: dict[type["AstNode"], type["AstNode"]]
+    substitute_nodes: dict[type[AstNode], type[AstNode]]
     line_separators: str
 
     def __init__(
         self,
-        substitute_nodes: dict[type["AstNode"], type["AstNode"]] | None = None,
+        substitute_nodes: dict[type[AstNode], type[AstNode]] | None = None,
         line_separators="",
     ):
         self.substitute_nodes = substitute_nodes or {}
         self.line_separators = line_separators
 
-    def resolve_node_cls(self, klass: type["AstNode"]) -> type["AstNode"]:
+    def resolve_node_cls(self, klass: type[AstNode]) -> type[AstNode]:
         return self.substitute_nodes.get(klass, klass)
 
 
@@ -154,8 +158,8 @@ class SyntaxNode(AstNode, Generic[T]):
         return cast("type[T]", self.config.resolve_node_cls(node_type))
 
     @property
-    def children(self) -> tuple["SyntaxNode", ...]:
-        return tuple(getattr(self, "_children", tuple()))
+    def children(self) -> tuple[SyntaxNode, ...]:
+        return tuple(getattr(self, "_children", ()))
 
     def pretty(self, indent: int = 0, increment: int = 4):
         indent += increment

--- a/poethepoet/helpers/python.py
+++ b/poethepoet/helpers/python.py
@@ -78,8 +78,8 @@ class FunctionCall(NamedTuple):
 
     expression: str
     function_ref: str
-    referenced_args: tuple[str, ...] = tuple()
-    referenced_globals: tuple[str, ...] = tuple()
+    referenced_args: tuple[str, ...] = ()
+    referenced_globals: tuple[str, ...] = ()
 
     @classmethod
     def parse(
@@ -138,7 +138,7 @@ def resolve_expression(
     arguments: Container[str],
     *,
     args_prefix: str = "__args.",
-    allowed_vars: Container[str] = tuple(),
+    allowed_vars: Container[str] = (),
 ) -> str:
     """
     Validate function call and substitute references to arguments with their namespaced
@@ -221,7 +221,7 @@ class NoInstance:
 
 
 def _validate_nodes_and_get_names(
-    node: ast.AST, source: str, *, ignore_names: Collection[str] = tuple()
+    node: ast.AST, source: str, *, ignore_names: Collection[str] = ()
 ) -> Iterator[ast.Name]:
     """
     Walk the ast from the given node and yield all of the encountered Name nodes

--- a/poethepoet/helpers/script.py
+++ b/poethepoet/helpers/script.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 def parse_script_reference(
     script_ref: str,
     parsed_args: dict[str, Any] | None = None,
-    allowed_vars: Container[str] = tuple(),
+    allowed_vars: Container[str] = (),
 ) -> tuple[str, FunctionCall]:
     """
     Parses a script reference string and returns the module name and function call.
@@ -51,7 +51,7 @@ def parse_script_reference(
     else:
         function_call = FunctionCall.parse(
             source=target_ref,
-            arguments=set(parsed_args or tuple()),
+            arguments=set(parsed_args or ()),
             allowed_vars=allowed_vars,
         )
 

--- a/poethepoet/options/annotations.py
+++ b/poethepoet/options/annotations.py
@@ -14,6 +14,16 @@ from typing import (
     get_type_hints,
 )
 
+_registered_type_hint_globals = {}
+
+
+def option_annotation(type: type):
+    """
+    Register custom types (e.g. TypedDicts) to be usable in PoeOptions fields
+    """
+    _registered_type_hint_globals[type.__name__] = type
+    return type
+
 
 class Metadata:
     __slots__ = ("config_name",)
@@ -46,6 +56,7 @@ class TypeAnnotation:
             "Union": Union,
             "TypeAnnotation": cls,
             "Metadata": Metadata,
+            **_registered_type_hint_globals,
         }
 
     @staticmethod

--- a/poethepoet/task/args.py
+++ b/poethepoet/task/args.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from contextlib import redirect_stderr
-from typing import IO, TYPE_CHECKING, Any, Literal, Union, cast
+from typing import IO, TYPE_CHECKING, Any, Literal, cast
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser
@@ -15,7 +15,7 @@ from ..exceptions import ConfigValidationError, ExecutionError
 from ..options import PoeOptions
 
 ArgParams = dict[str, Any]
-ArgsDef = Union[list[str], list[ArgParams], dict[str, ArgParams]]
+ArgsDef = list[str] | list[ArgParams] | dict[str, ArgParams]
 
 arg_types: dict[str, type] = {
     "string": str,
@@ -26,17 +26,14 @@ arg_types: dict[str, type] = {
 
 
 class ArgSpec(PoeOptions):
-    # ruff: noqa: UP007
-    default: Union[str, int, float, bool] | None = None
+    default: str | int | float | bool | None = None
     help: str = ""
     name: str
     options: Sequence[str]
-    # ruff: noqa: UP007
-    positional: Union[bool, str] = False
+    positional: bool | str = False
     required: bool = False
     type: Literal["string", "float", "integer", "boolean"] = "string"
-    # ruff: noqa: UP007
-    multiple: Union[bool, int] = False
+    multiple: bool | int = False
 
     @classmethod
     def normalize(

--- a/poethepoet/task/cmd.py
+++ b/poethepoet/task/cmd.py
@@ -1,14 +1,16 @@
+from __future__ import annotations
+
 import shlex
 from typing import TYPE_CHECKING, Literal
 
 from ..exceptions import ConfigValidationError, ExecutionError, PoeException
-from ..executor.task_run import PoeTaskRun
 from .base import PoeTask
 
 if TYPE_CHECKING:
     from ..config import PoeConfig
     from ..context import RunContext
     from ..env.manager import EnvVarsManager
+    from ..executor.task_run import PoeTaskRun
     from .base import TaskSpecFactory
 
 
@@ -39,9 +41,9 @@ class CmdTask(PoeTask):
 
     class TaskSpec(PoeTask.TaskSpec):
         content: str
-        options: "CmdTask.TaskOptions"
+        options: CmdTask.TaskOptions
 
-        def _task_validations(self, config: "PoeConfig", task_specs: "TaskSpecFactory"):
+        def _task_validations(self, config: PoeConfig, task_specs: TaskSpecFactory):
             """
             Perform validations on this TaskSpec that apply to a specific task type
             """
@@ -51,7 +53,7 @@ class CmdTask(PoeTask):
     spec: TaskSpec
 
     async def _handle_run(
-        self, context: "RunContext", env: "EnvVarsManager", task_state: PoeTaskRun
+        self, context: RunContext, env: EnvVarsManager, task_state: PoeTaskRun
     ):
         named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.update(named_arg_values)
@@ -79,7 +81,7 @@ class CmdTask(PoeTask):
                 "More details: https://github.com/nat-n/poethepoet/discussions/314",
             )
 
-    def _resolve_commandline(self, context: "RunContext", env: "EnvVarsManager"):
+    def _resolve_commandline(self, context: RunContext, env: EnvVarsManager):
         from ..helpers.command import parse_poe_cmd, resolve_command_tokens
         from ..helpers.command.ast_core import ParseError
 

--- a/poethepoet/task/expr.py
+++ b/poethepoet/task/expr.py
@@ -1,16 +1,19 @@
+from __future__ import annotations
+
 import re
-from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Annotated, Any
 
 from ..exceptions import ConfigValidationError, ExpressionParseError
-from ..executor.task_run import PoeTaskRun
 from ..options.annotations import Metadata
 from .base import PoeTask
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+
     from ..config import PoeConfig
     from ..context import RunContext
     from ..env.manager import EnvVarsManager
+    from ..executor.task_run import PoeTaskRun
     from .base import TaskSpecFactory
 
 
@@ -24,7 +27,7 @@ class ExprTask(PoeTask):
     __key__ = "expr"
 
     class TaskOptions(PoeTask.TaskOptions):
-        imports: Sequence[str] = tuple()
+        imports: Sequence[str] = ()
         assert_: Annotated[bool | int, Metadata(config_name="assert")] = False
         use_exec: bool = False
 
@@ -38,9 +41,9 @@ class ExprTask(PoeTask):
 
     class TaskSpec(PoeTask.TaskSpec):
         content: str
-        options: "ExprTask.TaskOptions"
+        options: ExprTask.TaskOptions
 
-        def _task_validations(self, config: "PoeConfig", task_specs: "TaskSpecFactory"):
+        def _task_validations(self, config: PoeConfig, task_specs: TaskSpecFactory):
             """
             Perform validations on this TaskSpec that apply to a specific task type
             """
@@ -52,7 +55,7 @@ class ExprTask(PoeTask):
     spec: TaskSpec
 
     async def _handle_run(
-        self, context: "RunContext", env: "EnvVarsManager", task_state: PoeTaskRun
+        self, context: RunContext, env: EnvVarsManager, task_state: PoeTaskRun
     ):
         from ..helpers.python import format_class
 
@@ -93,7 +96,7 @@ class ExprTask(PoeTask):
     def parse_content(
         self,
         args: dict[str, Any] | None,
-        env: "EnvVarsManager",
+        env: EnvVarsManager,
         imports: Iterable[str],
     ) -> tuple[str, dict[str, str]]:
         """
@@ -113,7 +116,7 @@ class ExprTask(PoeTask):
 
         expression = resolve_expression(
             source=expression,
-            arguments=set(args or tuple()),
+            arguments=set(args or ()),
             allowed_vars={"sys", "__env", *imports},
         )
         # Strip out any new lines because they can be problematic on windows

--- a/poethepoet/task/graph.py
+++ b/poethepoet/task/graph.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from ..exceptions import CyclicDependencyError
@@ -8,16 +10,16 @@ if TYPE_CHECKING:
 
 
 class TaskExecutionNode:
-    task: "PoeTask"
-    direct_dependants: list["TaskExecutionNode"]
+    task: PoeTask
+    direct_dependants: list[TaskExecutionNode]
     direct_dependencies: set[tuple[str, ...]]
     path_dependants: tuple[str, ...]
     capture_stdout: bool
 
     def __init__(
         self,
-        task: "PoeTask",
-        direct_dependants: list["TaskExecutionNode"],
+        task: PoeTask,
+        direct_dependants: list[TaskExecutionNode],
         path_dependants: tuple[str, ...],
         capture_stdout: bool = False,
     ):
@@ -45,7 +47,7 @@ class TaskExecutionGraph:
     one does not. Nodes are deduplicated to enforce this.
     """
 
-    _context: "RunContext"
+    _context: RunContext
     sink: TaskExecutionNode
     sources: list[TaskExecutionNode]
     captured_tasks: dict[tuple[str, ...], TaskExecutionNode]
@@ -53,11 +55,11 @@ class TaskExecutionGraph:
 
     def __init__(
         self,
-        sink_task: "PoeTask",
-        context: "RunContext",
+        sink_task: PoeTask,
+        context: RunContext,
     ):
         self._context = context
-        self.sink = TaskExecutionNode(sink_task, [], tuple())
+        self.sink = TaskExecutionNode(sink_task, [], ())
         self.sources = []
         self.captured_tasks = {}
         self.uncaptured_tasks = {}
@@ -65,7 +67,7 @@ class TaskExecutionGraph:
         # Build graph
         self._resolve_node_deps(self.sink)
 
-    def get_execution_plan(self) -> list[list["PoeTask"]]:
+    def get_execution_plan(self) -> list[list[PoeTask]]:
         """
         Derive an execution plan from the DAG in terms of stages consisting of tasks
         that could theoretically be parallelized.

--- a/poethepoet/task/parallel.py
+++ b/poethepoet/task/parallel.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import sys
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 
 from ..exceptions import ConfigValidationError, ExecutionError, PoeException
 from ..executor.task_run import PoeTaskRun, PoeTaskRunError
@@ -80,17 +82,17 @@ class ParallelTask(PoeTask):
 
     class TaskSpec(PoeTask.TaskSpec):
         content: list
-        options: "ParallelTask.TaskOptions"
-        subtasks: "Sequence[PoeTask.TaskSpec]"
+        options: ParallelTask.TaskOptions
+        subtasks: Sequence[PoeTask.TaskSpec]
 
         def __init__(
             self,
             name: str,
             task_def: dict[str, Any],
-            factory: "TaskSpecFactory",
-            source: "ConfigPartition",
+            factory: TaskSpecFactory,
+            source: ConfigPartition,
             *,
-            parent: Union["PoeTask.TaskSpec", None] = None,
+            parent: PoeTask.TaskSpec | None = None,
         ):
             super().__init__(name, task_def, factory, source, parent=parent)
 
@@ -129,7 +131,7 @@ class ParallelTask(PoeTask):
                         task_name=self.name,
                     ) from error
 
-        def _task_validations(self, config: "PoeConfig", task_specs: "TaskSpecFactory"):
+        def _task_validations(self, config: PoeConfig, task_specs: TaskSpecFactory):
             """
             Perform validations on this TaskSpec that apply to a specific task type
             """
@@ -161,7 +163,7 @@ class ParallelTask(PoeTask):
         ]
 
     async def _handle_run(
-        self, context: "RunContext", env: "EnvVarsManager", task_state: "PoeTaskRun"
+        self, context: RunContext, env: EnvVarsManager, task_state: PoeTaskRun
     ):
         named_arg_values, _ = self.get_parsed_arguments(env)
         env.update(named_arg_values)
@@ -218,7 +220,7 @@ class ParallelTask(PoeTask):
                 )
                 raise
 
-    async def _handle_task_failures(self, task_state: "PoeTaskRun"):
+    async def _handle_task_failures(self, task_state: PoeTaskRun):
         ignore_fail = self.spec.options.ignore_fail
         non_zero_subtasks = []
         # listen for completion and error events from subtasks
@@ -265,7 +267,7 @@ class ParallelTask(PoeTask):
             )
 
     async def _format_output_lines(
-        self, task_name: str, subtask_index: int, subproc: "Process"
+        self, task_name: str, subtask_index: int, subproc: Process
     ):
         if not subproc.stdout:
             return

--- a/poethepoet/task/ref.py
+++ b/poethepoet/task/ref.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from ..exceptions import ConfigValidationError
-from ..executor.task_run import PoeTaskRun
 from .base import PoeTask, TaskContext
 
 if TYPE_CHECKING:
     from ..config import PoeConfig
     from ..context import RunContext
     from ..env.manager import EnvVarsManager
+    from ..executor.task_run import PoeTaskRun
     from .base import TaskSpecFactory
 
 
@@ -34,9 +36,9 @@ class RefTask(PoeTask):
 
     class TaskSpec(PoeTask.TaskSpec):
         content: str
-        options: "RefTask.TaskOptions"
+        options: RefTask.TaskOptions
 
-        def _task_validations(self, config: "PoeConfig", task_specs: "TaskSpecFactory"):
+        def _task_validations(self, config: PoeConfig, task_specs: TaskSpecFactory):
             """
             Perform validations on this TaskSpec that apply to a specific task type
             """
@@ -59,7 +61,7 @@ class RefTask(PoeTask):
     spec: TaskSpec
 
     async def _handle_run(
-        self, context: "RunContext", env: "EnvVarsManager", task_state: PoeTaskRun
+        self, context: RunContext, env: EnvVarsManager, task_state: PoeTaskRun
     ):
         """
         Lookup and delegate to the referenced task
@@ -94,9 +96,9 @@ class RefTask(PoeTask):
 
     async def _run_task_graph(
         self,
-        task: "PoeTask",
-        context: "RunContext",
-        env: "EnvVarsManager",
+        task: PoeTask,
+        context: RunContext,
+        env: EnvVarsManager,
         task_state: PoeTaskRun,
     ):
         from ..exceptions import ExecutionError

--- a/poethepoet/task/script.py
+++ b/poethepoet/task/script.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import shlex
 from typing import TYPE_CHECKING
 
 from ..exceptions import ConfigValidationError
-from ..executor.task_run import PoeTaskRun
 from ..helpers.script import parse_script_reference
 from .base import PoeTask
 
@@ -10,6 +11,7 @@ if TYPE_CHECKING:
     from ..config import PoeConfig
     from ..context import RunContext
     from ..env.manager import EnvVarsManager
+    from ..executor.task_run import PoeTaskRun
     from .base import TaskSpecFactory
 
 
@@ -36,9 +38,9 @@ class ScriptTask(PoeTask):
 
     class TaskSpec(PoeTask.TaskSpec):
         content: str
-        options: "ScriptTask.TaskOptions"
+        options: ScriptTask.TaskOptions
 
-        def _task_validations(self, config: "PoeConfig", task_specs: "TaskSpecFactory"):
+        def _task_validations(self, config: PoeConfig, task_specs: TaskSpecFactory):
             """
             Perform validations on this TaskSpec that apply to a specific task type
             """
@@ -56,7 +58,7 @@ class ScriptTask(PoeTask):
     spec: TaskSpec
 
     async def _handle_run(
-        self, context: "RunContext", env: "EnvVarsManager", task_state: PoeTaskRun
+        self, context: RunContext, env: EnvVarsManager, task_state: PoeTaskRun
     ):
         from ..helpers.python import format_class
 
@@ -117,7 +119,7 @@ class ScriptTask(PoeTask):
         await task_state.add_process(process, finalize=True)
 
     async def _run_module(
-        self, context: "RunContext", env: "EnvVarsManager", task_state: PoeTaskRun
+        self, context: RunContext, env: EnvVarsManager, task_state: PoeTaskRun
     ):
         """
         Execute the python module referenced by the task content

--- a/poethepoet/task/sequence.py
+++ b/poethepoet/task/sequence.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from ..exceptions import ConfigValidationError, ExecutionError, PoeException
 from .base import PoeTask, TaskContext
@@ -46,17 +48,17 @@ class SequenceTask(PoeTask):
 
     class TaskSpec(PoeTask.TaskSpec):
         content: list
-        options: "SequenceTask.TaskOptions"
-        subtasks: "Sequence[PoeTask.TaskSpec]"
+        options: SequenceTask.TaskOptions
+        subtasks: Sequence[PoeTask.TaskSpec]
 
         def __init__(
             self,
             name: str,
             task_def: dict[str, Any],
-            factory: "TaskSpecFactory",
-            source: "ConfigPartition",
+            factory: TaskSpecFactory,
+            source: ConfigPartition,
             *,
-            parent: Union["PoeTask.TaskSpec", None] = None,
+            parent: PoeTask.TaskSpec | None = None,
         ):
             super().__init__(name, task_def, factory, source, parent=parent)
 
@@ -99,7 +101,7 @@ class SequenceTask(PoeTask):
                         task_name=self.name,
                     ) from error
 
-        def _task_validations(self, config: "PoeConfig", task_specs: "TaskSpecFactory"):
+        def _task_validations(self, config: PoeConfig, task_specs: TaskSpecFactory):
             """
             Perform validations on this TaskSpec that apply to a specific task type
             """
@@ -112,7 +114,7 @@ class SequenceTask(PoeTask):
                 subtask.validate(config, task_specs)
 
     spec: TaskSpec
-    _subtasks: "Sequence[PoeTask]"
+    _subtasks: Sequence[PoeTask]
 
     def __init__(
         self,
@@ -132,7 +134,7 @@ class SequenceTask(PoeTask):
         ]
 
     async def _handle_run(
-        self, context: "RunContext", env: "EnvVarsManager", task_state: "PoeTaskRun"
+        self, context: RunContext, env: EnvVarsManager, task_state: PoeTaskRun
     ):
         named_arg_values, _ = self.get_parsed_arguments(env)
         env.update(named_arg_values)

--- a/poethepoet/task/shell.py
+++ b/poethepoet/task/shell.py
@@ -1,16 +1,19 @@
+from __future__ import annotations
+
 import re
-from collections.abc import Sequence
 from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..exceptions import ConfigValidationError, PoeException
-from ..executor.task_run import PoeTaskRun
 from .base import PoeTask
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from ..context import RunContext
     from ..env.manager import EnvVarsManager
+    from ..executor.task_run import PoeTaskRun
 
 
 class ShellTask(PoeTask):
@@ -54,12 +57,12 @@ class ShellTask(PoeTask):
 
     class TaskSpec(PoeTask.TaskSpec):
         content: str
-        options: "ShellTask.TaskOptions"
+        options: ShellTask.TaskOptions
 
     spec: TaskSpec
 
     async def _handle_run(
-        self, context: "RunContext", env: "EnvVarsManager", task_state: PoeTaskRun
+        self, context: RunContext, env: EnvVarsManager, task_state: PoeTaskRun
     ):
         named_arg_values, _ = self.get_parsed_arguments(env)
         env.update(named_arg_values)

--- a/poethepoet/task/switch.py
+++ b/poethepoet/task/switch.py
@@ -1,16 +1,17 @@
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from ..exceptions import ConfigValidationError, ExecutionError, PoeException
-from ..executor.task_run import PoeTaskRun
 from .base import PoeTask, TaskContext
 
 if TYPE_CHECKING:
-    from collections.abc import MutableMapping
+    from collections.abc import Mapping, MutableMapping
 
     from ..config import ConfigPartition, PoeConfig
     from ..context import RunContext
     from ..env.manager import EnvVarsManager
+    from ..executor.task_run import PoeTaskRun
     from .base import TaskSpecFactory
 
 
@@ -62,16 +63,16 @@ class SwitchTask(PoeTask):
     class TaskSpec(PoeTask.TaskSpec):
         control_task_spec: PoeTask.TaskSpec
         case_task_specs: tuple[tuple[tuple[Any, ...], PoeTask.TaskSpec], ...]
-        options: "SwitchTask.TaskOptions"
+        options: SwitchTask.TaskOptions
 
         def __init__(
             self,
             name: str,
             task_def: dict[str, Any],
-            factory: "TaskSpecFactory",
-            source: "ConfigPartition",
+            factory: TaskSpecFactory,
+            source: ConfigPartition,
             *,
-            parent: Optional["PoeTask.TaskSpec"] = None,
+            parent: PoeTask.TaskSpec | None = None,
         ):
             super().__init__(name, task_def, factory, source, parent=parent)
 
@@ -112,7 +113,7 @@ class SwitchTask(PoeTask):
 
             self.case_task_specs = tuple(case_task_specs)
 
-        def _task_validations(self, config: "PoeConfig", task_specs: "TaskSpecFactory"):
+        def _task_validations(self, config: PoeConfig, task_specs: TaskSpecFactory):
             from collections import defaultdict
 
             allowed_control_task_types = ("expr", "cmd", "script")
@@ -192,7 +193,7 @@ class SwitchTask(PoeTask):
                 self.switch_tasks[case_key] = case_task
 
     async def _handle_run(
-        self, context: "RunContext", env: "EnvVarsManager", task_state: PoeTaskRun
+        self, context: RunContext, env: EnvVarsManager, task_state: PoeTaskRun
     ):
         named_arg_values, _ = self.get_parsed_arguments(env)
         env.update(named_arg_values)

--- a/poethepoet/ui.py
+++ b/poethepoet/ui.py
@@ -167,7 +167,7 @@ class PoeUi:
             help=maybe_suppress("ansi", "Force disable ANSI output"),
         )
 
-        parser.add_argument("task", default=tuple(), nargs=argparse.REMAINDER)
+        parser.add_argument("task", default=(), nargs=argparse.REMAINDER)
 
         return parser
 

--- a/tests/helpers/command/test_ast.py
+++ b/tests/helpers/command/test_ast.py
@@ -259,7 +259,7 @@ def test_parse_param_operators():
         "10",
         (
             "x",
-            (":-", tuple()),
+            (":-", ()),
         ),
         "B",
     )


### PR DESCRIPTION
- Banish `Union`, `Optional` and string forward references from the code base.
- Tweak parallel task tests to be less flaky

## Pre-merge Checklist

- [x] `poe check` executed successfully
- [x] This PR targets the *development* branch for code changes or *main* if only documentation is updated
