### PR TITLE
fix: handle SIGHUP and SIGBREAK signals to stop tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,14 @@ jobs:
     name: Check coding standards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install poetry
         run: pipx install poetry
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: 3.12
+          python-version: 3.13
           cache: poetry
 
       - name: Install dependencies
@@ -51,21 +51,21 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - name: Install uv for use in tests
+        uses: astral-sh/setup-uv@v7
 
       - name: Install poetry
         run: pipx install poetry
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
 
       - name: Install dependencies
-        run: poetry --ansi install --without docs
+        run: poetry --ansi install --without docs --without ci
 
       - name: Run tests
         run: poetry --ansi run pytest -v --color=yes
@@ -75,14 +75,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [code-quality, run-tests]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install poetry
         run: pipx install poetry
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - name: Build package
         run: poetry --ansi build

--- a/poethepoet/shutdown.py
+++ b/poethepoet/shutdown.py
@@ -28,6 +28,7 @@ class ShutdownManager:
         self._backup_sighup = None
         self._backup_sigint = None
         self._backup_sigterm = None
+        self._backup_sigbreak = None
         self._is_windows = sys.platform == "win32"
         self._shutdown_worker: asyncio.Task | None = None
 
@@ -153,6 +154,8 @@ class ShutdownManager:
         self._backup_sigint = signal.signal(signal.SIGINT, self.shutdown)
         if hasattr(signal, "SIGTERM"):
             self._backup_sigterm = signal.signal(signal.SIGTERM, self.shutdown)
+        if hasattr(signal, "SIGBREAK"):  # Windows
+            self._backup_sigbreak = signal.signal(signal.SIGBREAK, self.shutdown)
 
     def restore_handler(self):
         if hasattr(signal, "SIGHUP"):
@@ -160,3 +163,5 @@ class ShutdownManager:
         signal.signal(signal.SIGINT, self._backup_sigint or signal.SIG_DFL)
         if hasattr(signal, "SIGTERM"):
             signal.signal(signal.SIGTERM, self._backup_sigterm or signal.SIG_DFL)
+        if hasattr(signal, "SIGBREAK"):  # Windows
+            signal.signal(signal.SIGBREAK, self._backup_sigbreak or signal.SIG_DFL)

--- a/poethepoet/shutdown.py
+++ b/poethepoet/shutdown.py
@@ -25,6 +25,7 @@ class ShutdownManager:
         self._urgency = 0
         self.tasks: WeakSet[asyncio.Task] = WeakSet()
         self.processes: WeakSet[Process] = WeakSet()
+        self._backup_sighup = None
         self._backup_sigint = None
         self._backup_sigterm = None
         self._is_windows = sys.platform == "win32"
@@ -36,9 +37,9 @@ class ShutdownManager:
             self._urgency += max(1, 3 - self._urgency)
         else:
             self._urgency += 1
-        self._loop.call_soon_threadsafe(self._being_shut_down)
+        self._loop.call_soon_threadsafe(self._initialize_shutdown)
 
-    def _being_shut_down(self):
+    def _initialize_shutdown(self):
         if self._shutdown_worker:
             self._shutdown_worker.cancel()
         self._shutdown_worker = self._loop.create_task(
@@ -70,11 +71,10 @@ class ShutdownManager:
         else:
             for proc in tuple(self.processes):
                 if proc.returncode is None:
-                    with contextlib.suppress(ProcessLookupError):
-                        self._io.print_debug(
-                            " ! Sending SIGINT to subprocess group %s", proc.pid
-                        )
-                        os.killpg(os.getpgid(proc.pid), signal.SIGINT)
+                    self._io.print_debug(
+                        " ! Sending SIGINT to subprocess group %s", proc.pid
+                    )
+                    self._send_signal_to_group(proc, signal.SIGINT)
                 else:
                     self.processes.discard(proc)
 
@@ -106,8 +106,7 @@ class ShutdownManager:
                 while self.processes:
                     proc = self.processes.pop()
                     if proc.returncode is None:
-                        with contextlib.suppress(ProcessLookupError):
-                            os.killpg(os.getpgid(proc.pid), 9)
+                        self._send_signal_to_group(proc, 9)
 
         if self._urgency >= 4:
             self._io.print_debug(" ! Forceful shutdown triggered: killing subprocesses")
@@ -124,15 +123,40 @@ class ShutdownManager:
                 while self.processes:
                     proc = self.processes.pop()
                     if proc.returncode is None:
-                        with contextlib.suppress(ProcessLookupError):
-                            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                        self._send_signal_to_group(proc, signal.SIGKILL)
+
+    def _send_signal_to_group(self, proc: Process, sig: int):
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(os.getpgid(proc.pid), sig)
+
+    def _propagate_sighup(self, signum=None, frame=None):
+        """
+        If we receive SIGHUP then this means the parent TTY has closed. Since tasks run
+        in process groups we need to explicitly propagate the SIGHUP to them, and then
+        trigger shutdown so poe exits cleanly.
+        """
+        self._io.print_debug(" ! SIGHUP received: propagating to subprocess groups")
+        for proc in tuple(self.processes):
+            if proc.returncode is None:
+                self._io.print_debug(
+                    " ! Sending SIGHUP to subprocess group %s", proc.pid
+                )
+                self._send_signal_to_group(proc, signal.SIGHUP)
+            else:
+                self.processes.discard(proc)
+        # Also trigger shutdown so poe exits cleanly
+        self.shutdown(signum, frame)
 
     def install_handler(self):
+        if hasattr(signal, "SIGHUP"):
+            self._backup_sighup = signal.signal(signal.SIGHUP, self._propagate_sighup)
         self._backup_sigint = signal.signal(signal.SIGINT, self.shutdown)
         if hasattr(signal, "SIGTERM"):
             self._backup_sigterm = signal.signal(signal.SIGTERM, self.shutdown)
 
     def restore_handler(self):
+        if hasattr(signal, "SIGHUP"):
+            signal.signal(signal.SIGHUP, self._backup_sighup or signal.SIG_DFL)
         signal.signal(signal.SIGINT, self._backup_sigint or signal.SIG_DFL)
         if hasattr(signal, "SIGTERM"):
             signal.signal(signal.SIGTERM, self._backup_sigterm or signal.SIG_DFL)

--- a/poetry.lock
+++ b/poetry.lock
@@ -70,7 +70,7 @@ version = "1.2.0"
 description = "Backport of asyncio.Runner, a context manager that controls event loop life cycle."
 optional = false
 python-versions = "<3.11,>=3.8"
-groups = ["ci"]
+groups = ["test"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5"},
@@ -453,12 +453,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "ci", "docs"]
+groups = ["main", "ci", "docs", "test"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "python_version < \"4.0\" and extra == \"poetry-plugin\" and os_name == \"nt\"", ci = "platform_system == \"Windows\" or sys_platform == \"win32\"", docs = "sys_platform == \"win32\""}
+markers = {main = "python_version < \"4.0\" and extra == \"poetry-plugin\" and os_name == \"nt\"", ci = "platform_system == \"Windows\"", docs = "sys_platform == \"win32\"", test = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -466,7 +466,7 @@ version = "7.11.3"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["ci"]
+groups = ["test"]
 files = [
     {file = "coverage-7.11.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0c986537abca9b064510f3fd104ba33e98d3036608c7f2f5537f869bc10e1ee5"},
     {file = "coverage-7.11.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:28c5251b3ab1d23e66f1130ca0c419747edfbcb4690de19467cd616861507af7"},
@@ -638,7 +638,7 @@ version = "0.3.9"
 description = "Distribution utilities"
 optional = false
 python-versions = "*"
-groups = ["main", "ci"]
+groups = ["main", "test"]
 files = [
     {file = "distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87"},
     {file = "distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"},
@@ -731,12 +731,12 @@ version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "ci"]
+groups = ["main", "test"]
 files = [
     {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
     {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
 ]
-markers = {main = "python_version == \"3.10\" and extra == \"poetry-plugin\"", ci = "python_version == \"3.10\""}
+markers = {main = "python_version == \"3.10\" and extra == \"poetry-plugin\"", test = "python_version == \"3.10\""}
 
 [package.extras]
 test = ["pytest (>=6)"]
@@ -763,7 +763,7 @@ version = "3.16.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "ci"]
+groups = ["main", "test"]
 files = [
     {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
     {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
@@ -929,7 +929,7 @@ version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.7"
-groups = ["ci"]
+groups = ["test"]
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
@@ -1370,7 +1370,7 @@ version = "24.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "ci", "docs"]
+groups = ["main", "ci", "docs", "test"]
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
@@ -1445,7 +1445,7 @@ version = "4.3.6"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "ci"]
+groups = ["main", "ci", "test"]
 files = [
     {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
     {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
@@ -1462,7 +1462,7 @@ version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.8"
-groups = ["ci"]
+groups = ["test"]
 files = [
     {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
     {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
@@ -1478,7 +1478,7 @@ version = "0.2.0"
 description = "Provides cross platform executables to help with testing"
 optional = false
 python-versions = ">=3.7"
-groups = ["ci"]
+groups = ["test"]
 files = []
 develop = false
 
@@ -1691,11 +1691,12 @@ version = "2.19.1"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["ci", "docs"]
+groups = ["ci", "docs", "test"]
 files = [
     {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
     {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
 ]
+markers = {ci = "python_version < \"4\""}
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
@@ -1719,7 +1720,7 @@ version = "9.0.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["ci"]
+groups = ["test"]
 files = [
     {file = "pytest-9.0.1-py3-none-any.whl", hash = "sha256:67be0030d194df2dfa7b556f2e56fb3c3315bd5c8822c6951162b92b32ce7dad"},
     {file = "pytest-9.0.1.tar.gz", hash = "sha256:3e9c069ea73583e255c3b21cf46b8d3c56f6e3a1a8f6da94ccb0fcf57b9d73c8"},
@@ -1743,7 +1744,7 @@ version = "1.3.0"
 description = "Pytest support for asyncio"
 optional = false
 python-versions = ">=3.10"
-groups = ["ci"]
+groups = ["test"]
 files = [
     {file = "pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5"},
     {file = "pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5"},
@@ -1764,7 +1765,7 @@ version = "7.0.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
 python-versions = ">=3.9"
-groups = ["ci"]
+groups = ["test"]
 files = [
     {file = "pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861"},
     {file = "pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1"},
@@ -1784,7 +1785,7 @@ version = "16.1"
 description = "pytest plugin to re-run tests to eliminate flaky failures"
 optional = false
 python-versions = ">=3.10"
-groups = ["ci"]
+groups = ["test"]
 files = [
     {file = "pytest_rerunfailures-16.1-py3-none-any.whl", hash = "sha256:5d11b12c0ca9a1665b5054052fcc1084f8deadd9328962745ef6b04e26382e86"},
     {file = "pytest_rerunfailures-16.1.tar.gz", hash = "sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e"},
@@ -2407,7 +2408,7 @@ version = "2.2.1"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "ci", "docs"]
+groups = ["main", "ci", "docs", "test"]
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
     {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
@@ -2442,7 +2443,7 @@ files = [
     {file = "tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"},
     {file = "tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"},
 ]
-markers = {main = "python_version == \"3.10\"", ci = "python_full_version <= \"3.11.0a6\"", docs = "python_version == \"3.10\""}
+markers = {main = "python_version == \"3.10\"", ci = "python_version == \"3.10\"", docs = "python_version == \"3.10\"", test = "python_full_version <= \"3.11.0a6\""}
 
 [[package]]
 name = "tomlkit"
@@ -2528,12 +2529,12 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "ci"]
+groups = ["main", "ci", "test"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {main = "python_version < \"3.13\" and extra == \"poetry-plugin\" or python_version == \"3.10\""}
+markers = {main = "python_version < \"3.13\" and extra == \"poetry-plugin\" or python_version == \"3.10\"", test = "python_version < \"3.13\""}
 
 [[package]]
 name = "urllib3"
@@ -2560,7 +2561,7 @@ version = "20.35.4"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "ci"]
+groups = ["main", "test"]
 files = [
     {file = "virtualenv-20.35.4-py3-none-any.whl", hash = "sha256:c21c9cede36c9753eeade68ba7d523529f228a403463376cf821eaae2b650f1b"},
     {file = "virtualenv-20.35.4.tar.gz", hash = "sha256:643d3914d73d3eeb0c552cbb12d7e82adf0e504dbf86a3182f8771a153a1971c"},
@@ -2804,4 +2805,4 @@ poetry-plugin = ["poetry"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "ea889e2cd8ff118fdd65ccb9604b5f76dbf27f1182fd555f53ee510c75b8d11c"
+content-hash = "1122812a3c5e6f1a7ed92c04010d077c9a76fce13a0363bea3529dc663a33971"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,16 +51,17 @@ poe = "poethepoet:main"
 [tool.poetry.group.ci.dependencies]
 black                = "^25.11.0"
 mypy                 = "^1.18.2"
+rstcheck             = { version = "^6.2.4", python = "<4" }
+ruff                 = "^0.14.5"
+types-pyyaml         = "^6.0.12.20250915"
+
+[tool.poetry.group.test.dependencies]
+poe_test_helpers     = { path = "./tests/fixtures/packages/poe_test_helpers" }
 pytest               = "^9.0.1"
 pytest-asyncio       = "^1.3.0"
 pytest-cov           = "^7.0.0"
 pytest-rerunfailures = "^16.1"
-rstcheck             = { version = "^6.2.4", python = "<4" }
-ruff                 = "^0.14.5"
-types-pyyaml         = "^6.0.12.20250915"
 virtualenv           = "^20.35.4"
-
-poe_test_helpers = { path = "./tests/fixtures/packages/poe_test_helpers" }
 
 [tool.poetry.group.docs.dependencies]
 furo                = "^2023.3.27"

--- a/tests/fixtures/packages/poe_test_helpers/poe_test_helpers/__init__.py
+++ b/tests/fixtures/packages/poe_test_helpers/poe_test_helpers/__init__.py
@@ -23,6 +23,22 @@ def delayed_echo():
     print(" ".join(content), flush=True)
 
 
+def delayed_echo_with_pidfile():
+    """
+    A process that takes some time to start and then echoes the second argument.
+    The third argument is a file path where the process writes its own PID.
+
+    Usage: delayed_echo_with_pidfile sleep_time content pid_file_path
+    """
+    delay = sys.argv[1]
+    content = sys.argv[2]
+    pid_file_path = sys.argv[3]
+    with open(pid_file_path, "w") as pid_file:
+        pid_file.write(str(os.getpid()))
+    time.sleep(int(delay) / 1000)
+    print(" ".join(content), flush=True)
+
+
 def immortal_echo():
     """
     Swallow N interrupts and then echo the arguments on start and on each interrupt.

--- a/tests/fixtures/packages/poe_test_helpers/pyproject.toml
+++ b/tests/fixtures/packages/poe_test_helpers/pyproject.toml
@@ -12,6 +12,7 @@ poe_test_echo = "poe_test_helpers:echo"
 poe_test_env = "poe_test_helpers:env"
 poe_test_pwd = "poe_test_helpers:pwd"
 poe_test_delayed_echo = "poe_test_helpers:delayed_echo"
+poe_test_delayed_echo_with_pidfile = "poe_test_helpers:delayed_echo_with_pidfile"
 poe_test_fail = "poe_test_helpers:fail"
 poe_test_immortal = "poe_test_helpers:immortal_echo"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,7 +116,6 @@ def test_pass_dry_run_and_verbosity_to_script(run_poe_subproc):
     result = run_poe_subproc("check-global-options", project="scripts")
     assert result.capture == "Poe => check-global-options\n"
     assert result.stdout == ("args ()\nkwargs {'dry': False, 'verbosity': '0'}\n")
-    assert result.stderr == ""
 
     result = run_poe_subproc("-d", "check-global-options", project="scripts")
     assert result.capture == "Poe => check-global-options\n"

--- a/tests/test_poe_config.py
+++ b/tests/test_poe_config.py
@@ -11,6 +11,7 @@ def test_setting_default_task_type(run_poe_subproc, projects, esc_prefix):
         r"welcome to " + esc_prefix + "${POE_ROOT}",
         project="scripts",
         env=poetry_vars,
+        shell=True,
     )
     assert (
         result.capture == f"Poe => echo-args nat, 'welcome to {projects['scripts']}'\n"

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,5 +1,6 @@
 import os
 import signal
+import sys
 import time
 
 import pytest
@@ -40,23 +41,46 @@ def _pid_exists(pid: int) -> bool:
 def long_running_task(run_poe_subproc_handle, temp_pyproject, tmp_path):
     """Fixture that starts a long-running poe task and returns handles to check."""
     pid_file = tmp_path / "child.pid"
+    # Use forward slashes for Windows compatibility in the command string
+    pid_file_str = str(pid_file).replace("\\", "/")
     project_path = temp_pyproject(
         f"""
         [tool.poe.tasks.hang]
-        cmd = "poe_test_delayed_echo_with_pidfile 60000 'done' '{pid_file}'"
+        cmd = "poe_test_delayed_echo_with_pidfile 60000 'done' '{pid_file_str}'"
         """
     )
 
     poe_handle = run_poe_subproc_handle("hang", cwd=str(project_path))
 
     # Wait for child to start and write its PID
-    deadline = time.monotonic() + 5.0
+    deadline = time.monotonic() + 10.0
     while time.monotonic() < deadline:
+        # Check if poe exited early (indicates task failure)
+        if poe_handle.process.poll() is not None:
+            stdout, stderr = poe_handle.process.communicate()
+            pytest.fail(
+                f"Poe exited early (code {poe_handle.process.returncode})\n"
+                f"pid_file_str: {pid_file_str}\n"
+                f"stdout: {stdout.decode(errors='replace')}\n"
+                f"stderr: {stderr.decode(errors='replace')}"
+            )
         if pid_file.exists() and pid_file.stat().st_size > 0:
             break
         time.sleep(0.1)
     else:
-        pytest.fail("Child process did not write PID file in time")
+        # Timeout - gather debug info
+        poll_result = poe_handle.process.poll()
+        stdout, stderr = b"", b""
+        if poll_result is not None:
+            stdout, stderr = poe_handle.process.communicate()
+        pytest.fail(
+            f"Child process did not write PID file in time\n"
+            f"pid_file_str: {pid_file_str}\n"
+            f"pid_file exists: {pid_file.exists()}\n"
+            f"poe poll(): {poll_result}\n"
+            f"stdout: {stdout.decode(errors='replace')}\n"
+            f"stderr: {stderr.decode(errors='replace')}"
+        )
 
     child_pid = int(pid_file.read_text())
 
@@ -68,22 +92,23 @@ def long_running_task(run_poe_subproc_handle, temp_pyproject, tmp_path):
         poe_handle.process.wait()
 
 
-@pytest.mark.skipif(not hasattr(signal, "SIGINT"), reason="SIGINT not available")
-def test_sigint_terminates_task_and_children(long_running_task):
-    """SIGINT to poe should terminate both poe and its child processes."""
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows does not have usable signals for this test"
+)
+def test_interrupt_terminates_task_and_children(long_running_task):
+    """Interrupt signal to poe should terminate both poe and its child processes."""
     poe_handle, child_pid = long_running_task
 
     # Verify both processes are running
     assert poe_handle.process.poll() is None, "poe should be running"
     assert _pid_exists(child_pid), "child should be running"
 
-    # Send SIGINT
     poe_handle.process.send_signal(signal.SIGINT)
 
     # Both should exit
-    assert _wait_for_proc_exit(poe_handle.process), "poe should exit after SIGINT"
+    assert _wait_for_proc_exit(poe_handle.process), "poe should exit after interrupt"
     poe_handle.process.wait()  # Reap zombie
-    assert _wait_for_pid_exit(child_pid), "child should exit after SIGINT"
+    assert _wait_for_pid_exit(child_pid), "child should exit after interrupt"
 
 
 @pytest.mark.skipif(not hasattr(signal, "SIGHUP"), reason="SIGHUP not available")

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,0 +1,104 @@
+import os
+import signal
+import time
+
+import pytest
+
+
+def _wait_for_proc_exit(proc, timeout: float = 5.0) -> bool:
+    """Wait for a Popen process to exit, return True if it exited."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def _wait_for_pid_exit(pid: int, timeout: float = 5.0) -> bool:
+    """Wait for a PID to no longer exist, return True if it exited."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def _pid_exists(pid: int) -> bool:
+    """Check if a PID exists in the process table."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+
+
+@pytest.fixture
+def long_running_task(run_poe_subproc_handle, temp_pyproject, tmp_path):
+    """Fixture that starts a long-running poe task and returns handles to check."""
+    pid_file = tmp_path / "child.pid"
+    project_path = temp_pyproject(
+        f"""
+        [tool.poe.tasks.hang]
+        cmd = "poe_test_delayed_echo_with_pidfile 60000 'done' '{pid_file}'"
+        """
+    )
+
+    poe_handle = run_poe_subproc_handle("hang", cwd=str(project_path))
+
+    # Wait for child to start and write its PID
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if pid_file.exists() and pid_file.stat().st_size > 0:
+            break
+        time.sleep(0.1)
+    else:
+        pytest.fail("Child process did not write PID file in time")
+
+    child_pid = int(pid_file.read_text())
+
+    yield poe_handle, child_pid
+
+    # Cleanup: ensure processes are dead
+    if poe_handle.process.poll() is None:
+        poe_handle.process.kill()
+        poe_handle.process.wait()
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGINT"), reason="SIGINT not available")
+def test_sigint_terminates_task_and_children(long_running_task):
+    """SIGINT to poe should terminate both poe and its child processes."""
+    poe_handle, child_pid = long_running_task
+
+    # Verify both processes are running
+    assert poe_handle.process.poll() is None, "poe should be running"
+    assert _pid_exists(child_pid), "child should be running"
+
+    # Send SIGINT
+    poe_handle.process.send_signal(signal.SIGINT)
+
+    # Both should exit
+    assert _wait_for_proc_exit(poe_handle.process), "poe should exit after SIGINT"
+    poe_handle.process.wait()  # Reap zombie
+    assert _wait_for_pid_exit(child_pid), "child should exit after SIGINT"
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGHUP"), reason="SIGHUP not available")
+def test_sighup_terminates_task_and_children(long_running_task):
+    """SIGHUP to poe should propagate to children and trigger shutdown."""
+    poe_handle, child_pid = long_running_task
+
+    # Verify both processes are running
+    assert poe_handle.process.poll() is None, "poe should be running"
+    assert _pid_exists(child_pid), "child should be running"
+
+    # Send SIGHUP
+    poe_handle.process.send_signal(signal.SIGHUP)
+
+    # Both should exit (SIGHUP propagates to children and triggers shutdown)
+    assert _wait_for_proc_exit(poe_handle.process), "poe should exit after SIGHUP"
+    poe_handle.process.wait()  # Reap zombie
+    assert _wait_for_pid_exit(child_pid), "child should exit after SIGHUP"


### PR DESCRIPTION
- If a task remains after the SIGHUP is propagated then the standard shutdown sequence is initiated to force cleanup.
- SIGBREAK on windows is handled the same as SIGINT

Also refactor test fixtures to support manipulating subprocesses in tests and don't use shell subprocs

fixes: #336

## Pre-merge Checklist

- [ ] New features (if any) are covered by new feature tests
- [ ] New features (if any) are documented
- [x] Bug fixes (if any) are accompanied by a test (if not too complicated to do so)
- [x] `poe check` executed successfully
- [x] This PR targets the *development* branch for code changes or *main* if only documentation is updated
