### PR TITLE
feat: support ignore_fail on execution task types and ref tasks

### DIFF
--- a/docs/tasks/index.rst
+++ b/docs/tasks/index.rst
@@ -36,34 +36,40 @@ This implies that you can also define tasks of other types on a single line, lik
 .. code-block:: toml
 
   [tool.poe.tasks]
-  tunnel.shell = "ssh -N -L 0.0.0.0:8080:$PROD:8080 $PROD &" } # (posix) shell based task
+  tunnel.shell = "ssh -N -L 0.0.0.0:8080:$PROD:8080 $PROD &" # (posix) shell based task
 
 :doc:`Some options <options>` are applicable to all tasks, whereas other are only applicable to :ref:`specific types of tasks<Types of task>`.
 
 .. seealso::
 
-   Top level tasks are defined as members of :toml:`[tool.poe.tasks]`, but sometimes tasks can be defined as children of other tasks, for example as items within a :doc:`sequence <task_types/sequence>` task, or as the ``control`` or ``case`` roles with a :doc:`switch <task_types/sequence>` task.
+   Top level tasks are defined as members of :toml:`[tool.poe.tasks]`, but sometimes tasks can be defined as children of other tasks, for example as items within a :doc:`sequence <task_types/sequence>` task, or as the ``control`` or ``case`` roles within a :doc:`switch <task_types/switch>` task.
 
 Types of task
 -------------
 
-You can define eight different types of task:
+There are two categories of task each including four types: *Execution tasks* that run task content in a subprocess, and *Orchestration tasks* that run other tasks.
+
+Execution tasks
+~~~~~~~~~~~~~~~
 
 - :doc:`Command tasks <task_types/cmd>` :code:`cmd` : for simple commands that are executed as a subprocess without a shell
 
 - :doc:`Script tasks<task_types/script>` :code:`script` : for python function calls
 
-- :doc:`Shell tasks<task_types/shell>` :code:`shell` : for scripts to be executed with via an external interpreter (such as sh).
+- :doc:`Shell tasks<task_types/shell>` :code:`shell` : for scripts to be executed with via an external interpreter (such as bash).
+
+- :doc:`Expression tasks<task_types/expr>` :code:`expr` : which consist of a python expression to evaluate
+
+Orchestration tasks
+~~~~~~~~~~~~~~~~~~~
 
 - :doc:`Sequence tasks<task_types/sequence>` :code:`sequence` : for composing multiple tasks into a sequence
 
 - :doc:`Parallel tasks<task_types/parallel>` :code:`parallel` : for running multiple tasks concurrently
 
-- :doc:`Expression tasks<task_types/expr>` :code:`expr` : which consist of a python expression to evaluate
+- :doc:`Switch tasks<task_types/switch>` :code:`switch` : for running different tasks depending on the output of a *control* task
 
-- :doc:`Switch tasks<task_types/switch>` :code:`switch` : for running different tasks depending on a control value (such as the platform)
-
-- :doc:`Reference tasks<task_types/ref>` :code:`ref` : for defining a task as an alias of another task, such as in a sequence task.
+- :doc:`Reference tasks<task_types/ref>` :code:`ref` : for defining a task as an alias of another task, such as in a sequence task
 
 
 .. toctree::

--- a/docs/tasks/task_types/cmd.rst
+++ b/docs/tasks/task_types/cmd.rst
@@ -20,6 +20,9 @@ Available task options
 
 The following options are also accepted:
 
+**ignore_fail** : ``bool`` | ``list[int]``  :ref:`📖<Ignore task failure>`
+  Return exit code 0 even if the task fails, or specify a list of task exit codes to ignore.
+
 **empty_glob** : ``Literal["pass", "null", "fail"]`` :ref:`📖<Glob expansion>`
   Determines how to handle glob patterns with no matches. The default is ``"pass"``, which causes unmatched patterns to be passed through to the command (just like in bash). Setting it to ``"null"`` will replace an unmatched pattern with nothing, and setting it to ``"fail"`` will cause the task to fail with an error if there are no matches.
 
@@ -27,10 +30,9 @@ The following options are also accepted:
 Shell like features
 -------------------
 
-It is important to understand that ``cmd`` tasks are executed without a shell (to maximise portability). However some shell like features are still available including basic parameter expansion and pattern matching. Quotes and escapes are also generally interpreted as one would expect in a shell.
+It is important to understand that ``cmd`` tasks are executed without a shell (to maximize portability). However some shell like features are still available including basic parameter expansion and pattern matching. Quotes and escapes are also generally interpreted as one would expect in a shell.
 
 .. _ref_env_vars:
-
 
 Referencing environment variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -55,7 +57,6 @@ Parameter expansion can also can be disabled by escaping the $ with a backslash 
   [tool.poe.tasks]
   greet = "echo Hello \\$USER"  # the backslash itself needs escaping for the toml parser
 
-
 Parameter expansion operators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -77,7 +78,6 @@ The ``:+`` or *alternate value* operator is especially useful in cases such as t
   args = [{ name = "ARN_ONLY", options = ["--arn-only"], type = "boolean" }]
 
 In this example we declare a boolean argument with no default, so if the ``--arn-only`` flag is provided to the task then three additional CLI options will be included in the task content.
-
 
 Glob expansion
 ~~~~~~~~~~~~~~
@@ -120,3 +120,27 @@ The following task uses glob patterns to specify all ``.pyc`` files and ``__pyca
 .. |nullglob_link| raw:: html
 
    <a href="https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html" target="_blank">nullglob option</a>
+
+
+Ignore task failure
+-------------------
+
+.. important::
+
+  This option works the same for all *Execution task types* including :doc:`cmd<cmd>`, :doc:`script<script>`, :doc:`expr<expr>`, and :doc:`shell<shell>`, but has a slightly different interpretation for :doc:`sequence<sequence>`, :doc:`parallel<parallel>`, and :doc:`ref<ref>` tasks.
+
+Normally if a task subprocess returns a non-zero exit code, then the task is considered to have failed. This failure propagates to the parent task (if any), and ultimately poe will return the same exit code to the host shell. However it is possible to configure a task to ignore failure, and return zero regardless, by setting the ``ignore_fail`` option like so:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.clean]
+  cmd         = "rm -rf ./src/**/*.pyc"
+  ignore_fail = true
+
+You can also ignore tasks failures just in case of one or more specific exit codes by providing a list of integers:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.serve]
+  cmd        = "pytest"
+  ignore_fail = [4, 5] # don't fail if no tests are found

--- a/docs/tasks/task_types/expr.rst
+++ b/docs/tasks/task_types/expr.rst
@@ -39,6 +39,9 @@ The following options are also accepted:
 **assert** : ``bool`` :ref:`📖<Fail if the expression result is falsey>`
   If set to true and the result of the expression is found to be a falsey value then the task will fail with a non-zero return value.
 
+**ignore_fail** : ``bool`` | ``list[int]``  :ref:`📖<Ignore task failure>`
+  Return exit code 0 even if the task fails, or specify a list of task exit codes to ignore.
+
 
 Referencing arguments and environment variables
 -----------------------------------------------

--- a/docs/tasks/task_types/parallel.rst
+++ b/docs/tasks/task_types/parallel.rst
@@ -20,8 +20,8 @@ Available task options
 
 The following options are also accepted:
 
-**ignore_fail** : ``bool`` | ``str`` :ref:`📖<Continue on task failure>`
-  If true then the failure (or non-zero return value) of one task in the parallel group does not abort the execution.
+**ignore_fail** : ``bool`` | ``Literal["return_zero", "return_non_zero"]`` :ref:`📖<Continue on subtask failure>`
+  If set to something other than false then the failure (or non-zero return value) of one task in the parallel group does not abort the execution.
 
 **default_item_type** : ``str`` :ref:`📖<Changing the default item type>`
   Change the task type that is applied to string array items in this parallel group.
@@ -47,7 +47,7 @@ A failure (non-zero result) will result in any remaining subtasks being cancelle
   attempts.parallel = ["task1", "task2", "task3"]
   attempts.ignore_fail = true
 
-If you want to run all the subtasks to completion but return non-zero result in the end of the sequence if any of the subtasks have failed you can set :toml:`ignore_fail` option to the :toml:`return_non_zero` like so:
+If you want to run all the subtasks to completion but return non-zero result in the end of the parallel group if any of the subtasks have failed you can set :toml:`ignore_fail` option to the :toml:`return_non_zero` like so:
 
 .. code-block:: toml
 

--- a/docs/tasks/task_types/ref.rst
+++ b/docs/tasks/task_types/ref.rst
@@ -32,13 +32,34 @@ would be equivalent to executing the following in the shell:
 Available task options
 ----------------------
 
-``ref`` tasks support all of the :doc:`standard task options <../options>` with the exception of ``use_exec``and ``executor``.
+``ref`` tasks support all of the :doc:`standard task options <../options>` with the exception of ``use_exec`` and ``executor``.
+
+**ignore_fail** : ``bool`` :ref:`📖<Ignore reference task failure>`
+  If true the failure of the referenced task will be ignored and the ref task will return exit code 0.
 
 .. warning::
 
-  A ref that references a :doc:`sequence<../tasks/task_types/sequence>` or :doc:`parallel<../tasks/task_types/parallel>` task cannot use the ``capture_stdout`` option.
+  A ref task that references a :doc:`sequence<../task_types/sequence>` or :doc:`parallel<../task_types/parallel>` task cannot use the ``capture_stdout`` option.
+
 
 Passing arguments
 -----------------
 
 By default any arguments passed to a ref task will be forwarded to the referenced task, allowing it to function as a task alias. If named arguments are configured for the ref task then additional arguments can still be passed to the referenced task after ``--`` on the command line.
+
+
+Ignore reference task failure
+-----------------------------
+
+By default if the referenced task fails (has a non-zero exit code) then the ref task will also fail. However it is possible to configure a ref task to ignore failure using the :toml:`ignore_fail` option like so:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.test]
+  test = "pytest"
+
+  [tool.poe.tasks.always-pass]
+  ref = "test"
+  ignore_fail = true
+
+If the referenced task is configured to ignore failure itself then the ref task will see the referenced task as having succeeded regardless of its actual exit code.

--- a/docs/tasks/task_types/script.rst
+++ b/docs/tasks/task_types/script.rst
@@ -39,6 +39,9 @@ The following options are also accepted:
 **print_result** : ``bool`` :ref:`📖<Output the return value>`
   If true then the return value of the python callable will be output to stdout, unless it is ``None``.
 
+**ignore_fail** : ``bool`` | ``list[int]``  :ref:`📖<Ignore task failure>`
+  Return exit code 0 even if the task fails, or specify a list of task exit codes to ignore.
+
 
 Output the return value
 -----------------------

--- a/docs/tasks/task_types/sequence.rst
+++ b/docs/tasks/task_types/sequence.rst
@@ -27,8 +27,8 @@ Available task options
 
 The following options are also accepted:
 
-**ignore_fail** : ``bool`` | ``str`` :ref:`📖<Continue sequence on task failure>`
-  If true then the failure (or non-zero return value) of one task in the sequence does not abort the sequence.
+**ignore_fail** : ``bool`` | ``Literal["return_zero", "return_non_zero"]`` :ref:`📖<Continue sequence on task failure>`
+  If set to something other than false then the failure (or non-zero return value) of one task in the sequence does not abort the sequence.
 
 **default_item_type** : ``str`` :ref:`📖<Changing the default item type>`
   Change the task type that is applied to string array items in this sequence.
@@ -37,19 +37,15 @@ The following options are also accepted:
 Continue sequence on task failure
 ---------------------------------
 
-A failure (non-zero result) will result in the rest of the tasks in the sequence not
-being executed, unless the :toml:`ignore_fail` option is set on the task to
-:toml:`true`, :toml:`"return_zero"`, or :toml:`"return_non_zero"` like so:
+A failure (non-zero result) will result in the rest of the tasks in the sequence being skipped, unless the :toml:`ignore_fail` option is set on the task to :toml:`true`, :toml:`"return_zero"`, or :toml:`"return_non_zero"` like so:
 
 .. code-block:: toml
 
-  [tool.poe.tasks]
-  attempts.sequence = ["task1", "task2", "task3"]
-  attempts.ignore_fail = true
+  [tool.poe.tasks.attempts]
+  sequence = ["task1", "task2", "task3"]
+  ignore_fail = true
 
-If you want to run all the subtasks in the sequence but return non-zero result in the
-end of the sequence if any of the subtasks have failed you can set :toml:`ignore_fail`
-option to the :toml:`return_non_zero` value like so:
+If you want to run all the subtasks in the sequence but return non-zero result in the end of the sequence if any of the subtasks have failed you can set :toml:`ignore_fail` option to the :toml:`return_non_zero` value like so:
 
 .. code-block:: toml
 

--- a/docs/tasks/task_types/shell.rst
+++ b/docs/tasks/task_types/shell.rst
@@ -31,6 +31,9 @@ The following options are also accepted:
 **interpreter** : ``str`` | ``list[str]`` :ref:`📖<Using a different shell interpreter>`
   Specify the shell interpreter that this task should execute with, or a list of interpreters in order of preference.
 
+**ignore_fail** : ``bool`` | ``list[int]``  :ref:`📖<Ignore task failure>`
+  Return exit code 0 even if the task fails, or specify a list of task exit codes to ignore.
+
 
 Using a different shell interpreter
 -----------------------------------

--- a/poethepoet/options/annotations.py
+++ b/poethepoet/options/annotations.py
@@ -8,21 +8,23 @@ from typing import (
     Any,
     Literal,
     Optional,
+    TypeVar,
     Union,
     get_args,
     get_origin,
     get_type_hints,
 )
 
+T = TypeVar("T", bound=Any)
 _registered_type_hint_globals = {}
 
 
-def option_annotation(type: type):
+def option_annotation(cls: T) -> T:
     """
     Register custom types (e.g. TypedDicts) to be usable in PoeOptions fields
     """
-    _registered_type_hint_globals[type.__name__] = type
-    return type
+    _registered_type_hint_globals[cls.__name__] = cls
+    return cls
 
 
 class Metadata:

--- a/poethepoet/task/base.py
+++ b/poethepoet/task/base.py
@@ -203,8 +203,8 @@ class PoeTask(metaclass=MetaPoeTask):
 
                 # Normalize executor option:
                 # > Mapping[str, str | Sequence[str] | bool] | str | None
-                #       => Mapping[str, str | Sequence[str | bool] | bool]
-                if (executor := item.get("executor")) and isinstance(executor, str):
+                #     => Mapping[str, str | Sequence[str | bool] | bool]
+                if isinstance((executor := item.get("executor")), str):
                     item["executor"] = {"type": executor}
 
                 yield item

--- a/poethepoet/task/cmd.py
+++ b/poethepoet/task/cmd.py
@@ -27,6 +27,7 @@ class CmdTask(PoeTask):
     class TaskOptions(PoeTask.TaskOptions):
         use_exec: bool = False
         empty_glob: Literal["pass", "null", "fail"] = "pass"
+        ignore_fail: bool | list[int] = False
 
         def validate(self):
             """
@@ -55,6 +56,9 @@ class CmdTask(PoeTask):
     async def _handle_run(
         self, context: RunContext, env: EnvVarsManager, task_state: PoeTaskRun
     ):
+        if ignore_fail := self.spec.options.ignore_fail:
+            task_state.ignore_failure(ignore_fail)
+
         named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.update(named_arg_values)
 

--- a/poethepoet/task/expr.py
+++ b/poethepoet/task/expr.py
@@ -30,6 +30,7 @@ class ExprTask(PoeTask):
         imports: Sequence[str] = ()
         assert_: Annotated[bool | int, Metadata(config_name="assert")] = False
         use_exec: bool = False
+        ignore_fail: bool | list[int] = False
 
         def validate(self):
             super().validate()
@@ -58,6 +59,9 @@ class ExprTask(PoeTask):
         self, context: RunContext, env: EnvVarsManager, task_state: PoeTaskRun
     ):
         from ..helpers.python import format_class
+
+        if ignore_fail := self.spec.options.ignore_fail:
+            task_state.ignore_failure(ignore_fail)
 
         named_arg_values, _ = self.get_parsed_arguments(env)
         env.update(named_arg_values)

--- a/poethepoet/task/script.py
+++ b/poethepoet/task/script.py
@@ -27,6 +27,7 @@ class ScriptTask(PoeTask):
     class TaskOptions(PoeTask.TaskOptions):
         use_exec: bool = False
         print_result: bool = False
+        ignore_fail: bool | list[int] = False
 
         def validate(self):
             super().validate()
@@ -61,6 +62,9 @@ class ScriptTask(PoeTask):
         self, context: RunContext, env: EnvVarsManager, task_state: PoeTaskRun
     ):
         from ..helpers.python import format_class
+
+        if ignore_fail := self.spec.options.ignore_fail:
+            task_state.ignore_failure(ignore_fail)
 
         named_arg_values, _ = self.get_parsed_arguments(env)
         env.update(named_arg_values)

--- a/poethepoet/task/shell.py
+++ b/poethepoet/task/shell.py
@@ -27,6 +27,7 @@ class ShellTask(PoeTask):
 
     class TaskOptions(PoeTask.TaskOptions):
         interpreter: str | Sequence[str] | None = None
+        ignore_fail: bool | list[int] = False
 
         def validate(self):
             super().validate()
@@ -64,6 +65,9 @@ class ShellTask(PoeTask):
     async def _handle_run(
         self, context: RunContext, env: EnvVarsManager, task_state: PoeTaskRun
     ):
+        if ignore_fail := self.spec.options.ignore_fail:
+            task_state.ignore_failure(ignore_fail)
+
         named_arg_values, _ = self.get_parsed_arguments(env)
         env.update(named_arg_values)
 

--- a/tests/fixtures/parallel_project/pyproject.toml
+++ b/tests/fixtures/parallel_project/pyproject.toml
@@ -3,11 +3,11 @@ words-of-wisdom = "poe_test_echo \"Let it be\""
 
 [tool.poe.tasks.sleep_sort]
 parallel = [
-  { cmd = "poe_test_delayed_echo 333 333" },
+  { cmd = "poe_test_delayed_echo 450 450" },
   { cmd = "poe_test_delayed_echo 0 0" },
-  { cmd = "poe_test_delayed_echo 444 444" },
-  { cmd = "poe_test_delayed_echo 222 222" },
-  { cmd = "poe_test_delayed_echo 111 111" },
+  { cmd = "poe_test_delayed_echo 600 600" },
+  { cmd = "poe_test_delayed_echo 300 300" },
+  { cmd = "poe_test_delayed_echo 150 150" },
 ]
 
 [tool.poe.tasks.custom_prefix_task]

--- a/tests/test_ignore_fail.py
+++ b/tests/test_ignore_fail.py
@@ -530,6 +530,8 @@ def test_ref_parallel_return_non_zero(generate_composed_pyproject, run_poe):
     assert result.code == 1, "Expected non-zero result"
     assert "Subtasks 'child_fail_a', 'child_fail_b' returned non-zero exit status" in (
         result.capture
+    ) or "Subtasks 'child_fail_b', 'child_fail_a' returned non-zero exit status" in (
+        result.capture
     )
 
 
@@ -539,6 +541,9 @@ def test_ref_parallel_return_non_zero_ignore(generate_composed_pyproject, run_po
     assert result.code == 0, "Expected zero result"
     assert (
         "Warning: Subtasks 'child_fail_a', 'child_fail_b' returned non-zero exit status"
+        in result.capture
+    ) or (
+        "Warning: Subtasks 'child_fail_b', 'child_fail_a' returned non-zero exit status"
         in result.capture
     )
 

--- a/tests/test_ignore_fail.py
+++ b/tests/test_ignore_fail.py
@@ -1,17 +1,34 @@
 import pytest
 
 
+def fmt_ignore_fail(value):
+    if value is True:
+        return "ignore_fail = true"
+    if isinstance(value, str):
+        return f'ignore_fail = "{value}"'
+    if isinstance(value, list):
+        return f"ignore_fail = {value}"
+    return ""
+
+
+EXEC_TASK_CASES = (
+    ("cmd", "cmd_fail_1", "poe_test_fail 0 1", 1),
+    ("shell", "shell_fail_1", "sys.exit(1)", 1),
+    ("expr", "expr_fail_1", "Poe => False", 1),
+    ("script", "script_fail_1", "Poe => script_fail_1", 1),
+)
+EXEC_TASK_FAIL_2_CASES = (
+    ("cmd", "cmd_fail_2", "poe_test_fail 0 2", 2),
+    ("shell", "shell_fail_2", "sys.exit(2)", 2),
+    ("expr", "expr_fail_2", "Poe => False", 2),
+    ("script", "script_fail_2", "Poe => script_fail_2", 2),
+)
+EXEC_TASK_IDS = [case[0] for case in EXEC_TASK_CASES]
+
+
 @pytest.fixture
 def generate_pyproject(temp_pyproject):
     def generator(lvl1_ignore_fail=False, lvl2_ignore_fail=False):
-        def fmt_ignore_fail(value):
-            if value is True:
-                return "ignore_fail = true"
-            elif isinstance(value, str):
-                return f'ignore_fail = "{value}"'
-            else:
-                return ""
-
         project_tmpl = f"""
             [tool.poe.tasks]
             task_0 = "echo 'task 0 success'"
@@ -26,6 +43,170 @@ def generate_pyproject(temp_pyproject):
             [tool.poe.tasks.lvl2_seq]
             sequence = ["task_0", "lvl1_seq", "task_3"]
             {fmt_ignore_fail(lvl2_ignore_fail)}
+        """
+
+        return temp_pyproject(project_tmpl)
+
+    return generator
+
+
+@pytest.fixture
+def generate_exec_pyproject(temp_pyproject):
+    def generator(ignore_fail_overrides=None):
+        ignore_fail_overrides = ignore_fail_overrides or {}
+
+        def task_ignore(task_name):
+            return fmt_ignore_fail(ignore_fail_overrides.get(task_name))
+
+        project_tmpl = f"""
+            [tool.poe.tasks.cmd_fail_1]
+            cmd = "poe_test_fail 0 1"
+            {task_ignore("cmd_fail_1")}
+
+            [tool.poe.tasks.cmd_fail_2]
+            cmd = "poe_test_fail 0 2"
+            {task_ignore("cmd_fail_2")}
+
+            [tool.poe.tasks.shell_fail_1]
+            interpreter = "python"
+            shell = "import sys; sys.exit(1)"
+            {task_ignore("shell_fail_1")}
+
+            [tool.poe.tasks.shell_fail_2]
+            interpreter = "python"
+            shell = "import sys; sys.exit(2)"
+            {task_ignore("shell_fail_2")}
+
+            [tool.poe.tasks.expr_fail_1]
+            expr = "False"
+            assert = 1
+            {task_ignore("expr_fail_1")}
+
+            [tool.poe.tasks.expr_fail_2]
+            expr = "False"
+            assert = 2
+            {task_ignore("expr_fail_2")}
+
+            [tool.poe.tasks.script_fail_1]
+            script = "sys:exit(1)"
+            {task_ignore("script_fail_1")}
+
+            [tool.poe.tasks.script_fail_2]
+            script = "sys:exit(2)"
+            {task_ignore("script_fail_2")}
+        """
+
+        return temp_pyproject(project_tmpl)
+
+    return generator
+
+
+@pytest.fixture
+def generate_ref_pyproject(temp_pyproject):
+    def generator(ref_invalid_ignore_fail=False):
+        project_tmpl = f"""
+            [tool.poe.tasks.target_fail]
+            cmd = "poe_test_fail 0 1"
+
+            [tool.poe.tasks.target_ignore]
+            cmd = "poe_test_fail 0 1"
+            ignore_fail = true
+
+            [tool.poe.tasks.ref_no_ignore]
+            ref = "target_fail"
+
+            [tool.poe.tasks.ref_ignore]
+            ref = "target_fail"
+            ignore_fail = true
+
+            [tool.poe.tasks.ref_child_ignore]
+            ref = "target_ignore"
+
+            [tool.poe.tasks.ref_both_ignore]
+            ref = "target_ignore"
+            ignore_fail = true
+
+            [tool.poe.tasks.seq_fail]
+            sequence = ["target_fail", "target_fail"]
+
+            [tool.poe.tasks.ref_seq_no_ignore]
+            ref = "seq_fail"
+
+            [tool.poe.tasks.ref_seq_ignore]
+            ref = "seq_fail"
+            ignore_fail = true
+
+            [tool.poe.tasks.ref_invalid]
+            ref = "target_fail"
+            {fmt_ignore_fail(ref_invalid_ignore_fail)}
+        """
+
+        return temp_pyproject(project_tmpl)
+
+    return generator
+
+
+@pytest.fixture
+def generate_composed_pyproject(temp_pyproject):
+    def generator():
+        project_tmpl = """
+            [tool.poe.tasks]
+            ok_task = "poe_test_echo ok"
+            child_ignore_true = { cmd = "poe_test_fail 0 1", ignore_fail = true }
+            child_ignore_list = { cmd = "poe_test_fail 0 2", ignore_fail = [2] }
+            child_fail_a = "poe_test_fail 0 1"
+            child_fail_b = "poe_test_fail 0 1"
+            dep_fail_ignore = { cmd = "poe_test_fail 0 1", ignore_fail = true }
+            dep_fail_list = { cmd = "poe_test_fail 0 2", ignore_fail = [2] }
+            dep_fail_plain = "poe_test_fail 0 1"
+
+            [tool.poe.tasks.parent_seq_no_ignore]
+            sequence = ["child_ignore_true", "child_ignore_list", "ok_task"]
+
+            [tool.poe.tasks.parent_par_no_ignore]
+            parallel = ["child_ignore_true", "child_ignore_list", "ok_task"]
+
+            [tool.poe.tasks.child_seq_return_non_zero]
+            sequence = ["child_fail_a", "child_fail_b"]
+            ignore_fail = "return_non_zero"
+
+            [tool.poe.tasks.child_par_return_non_zero]
+            parallel = ["child_fail_a", "child_fail_b"]
+            ignore_fail = "return_non_zero"
+
+            [tool.poe.tasks.parent_seq_ignore_true]
+            sequence = ["child_seq_return_non_zero", "ok_task"]
+            ignore_fail = true
+
+            [tool.poe.tasks.parent_par_ignore_true]
+            parallel = ["child_seq_return_non_zero", "ok_task"]
+            ignore_fail = true
+
+            [tool.poe.tasks.ref_seq_return_non_zero]
+            ref = "child_seq_return_non_zero"
+
+            [tool.poe.tasks.ref_seq_return_non_zero_ignore]
+            ref = "child_seq_return_non_zero"
+            ignore_fail = true
+
+            [tool.poe.tasks.ref_par_return_non_zero]
+            ref = "child_par_return_non_zero"
+
+            [tool.poe.tasks.ref_par_return_non_zero_ignore]
+            ref = "child_par_return_non_zero"
+            ignore_fail = true
+
+            [tool.poe.tasks.graph_root]
+            cmd = "poe_test_echo graph"
+            deps = ["dep_fail_ignore", "dep_fail_list"]
+
+            [tool.poe.tasks.graph_root_fail]
+            cmd = "poe_test_echo graph_fail"
+            deps = ["dep_fail_plain"]
+
+            [tool.poe.tasks.ref_graph_root_fail_ignore]
+            ref = "graph_root_fail"
+            ignore_fail = true
         """
 
         return temp_pyproject(project_tmpl)
@@ -63,8 +244,8 @@ def test_return_non_zero(generate_pyproject, run_poe):
     assert "Subtasks 'task_1', 'task_2' returned non-zero exit status" in result.capture
 
 
-def test_invalid_ignore_value(generate_pyproject, run_poe):
-    project_path = generate_pyproject(lvl1_ignore_fail="invalid_value")
+def test_invalid_ignore_list_value(generate_pyproject, run_poe):
+    project_path = generate_pyproject(lvl1_ignore_fail=[1])
     result = run_poe("lvl1_seq", cwd=project_path)
     assert result.code == 1, "Expected non-zero result"
     assert (
@@ -119,3 +300,263 @@ def test_nested_both_return_non_zero(generate_pyproject, run_poe):
         in result.capture
     )
     assert "Error: Subtask 'lvl1_seq' returned non-zero exit status" in result.capture
+
+
+@pytest.mark.parametrize(
+    ("_task_type", "task_name", "capture_hint", "expected_code"),
+    EXEC_TASK_CASES,
+    ids=EXEC_TASK_IDS,
+)
+def test_exec_without_ignore(
+    generate_exec_pyproject, run_poe, _task_type, task_name, capture_hint, expected_code
+):
+    project_path = generate_exec_pyproject()
+    result = run_poe(task_name, cwd=project_path)
+    assert result.code == expected_code, "Expected non-zero result"
+    assert capture_hint in result.capture
+
+
+@pytest.mark.parametrize(
+    ("_task_type", "task_name", "capture_hint", "_expected_code"),
+    EXEC_TASK_CASES,
+    ids=EXEC_TASK_IDS,
+)
+def test_exec_ignore_true(
+    generate_exec_pyproject,
+    run_poe,
+    _task_type,
+    task_name,
+    capture_hint,
+    _expected_code,
+):
+    project_path = generate_exec_pyproject({task_name: True})
+    result = run_poe(task_name, cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert capture_hint in result.capture
+
+
+@pytest.mark.parametrize(
+    ("_task_type", "task_name", "capture_hint", "_expected_code"),
+    EXEC_TASK_CASES,
+    ids=EXEC_TASK_IDS,
+)
+def test_exec_ignore_list_match(
+    generate_exec_pyproject,
+    run_poe,
+    _task_type,
+    task_name,
+    capture_hint,
+    _expected_code,
+):
+    project_path = generate_exec_pyproject({task_name: [1]})
+    result = run_poe(task_name, cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert capture_hint in result.capture
+
+
+@pytest.mark.parametrize(
+    ("_task_type", "task_name", "capture_hint", "expected_code"),
+    EXEC_TASK_FAIL_2_CASES,
+    ids=EXEC_TASK_IDS,
+)
+def test_exec_ignore_list_nonmatch(
+    generate_exec_pyproject, run_poe, _task_type, task_name, capture_hint, expected_code
+):
+    project_path = generate_exec_pyproject({task_name: [1]})
+    result = run_poe(task_name, cwd=project_path)
+    assert result.code == expected_code, "Expected non-zero result"
+    assert capture_hint in result.capture
+
+
+@pytest.mark.parametrize(
+    ("_task_type", "task_name", "capture_hint", "_expected_code"),
+    EXEC_TASK_FAIL_2_CASES,
+    ids=EXEC_TASK_IDS,
+)
+def test_exec_ignore_list_multi_match(
+    generate_exec_pyproject,
+    run_poe,
+    _task_type,
+    task_name,
+    capture_hint,
+    _expected_code,
+):
+    project_path = generate_exec_pyproject({task_name: [1, 2]})
+    result = run_poe(task_name, cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert capture_hint in result.capture
+
+
+@pytest.mark.parametrize("invalid_value", [["1"], "return_non_zero"])
+@pytest.mark.parametrize(
+    ("_task_type", "task_name", "_capture_hint", "_expected_code"),
+    EXEC_TASK_CASES,
+    ids=EXEC_TASK_IDS,
+)
+def test_exec_invalid_ignore_values(
+    generate_exec_pyproject,
+    run_poe,
+    invalid_value,
+    _task_type,
+    task_name,
+    _capture_hint,
+    _expected_code,
+):
+    project_path = generate_exec_pyproject({task_name: invalid_value})
+    result = run_poe(task_name, cwd=project_path)
+    assert result.code == 1, "Expected non-zero result"
+    assert "Option 'ignore_fail" in result.capture
+    assert "value of type" in result.capture
+
+
+def test_ref_without_ignore(generate_ref_pyproject, run_poe):
+    project_path = generate_ref_pyproject()
+    result = run_poe("ref_no_ignore", cwd=project_path)
+    assert result.code == 1, "Expected non-zero result"
+    assert "poe_test_fail 0 1" in result.capture
+
+
+def test_ref_ignore_true(generate_ref_pyproject, run_poe):
+    project_path = generate_ref_pyproject()
+    result = run_poe("ref_ignore", cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert "poe_test_fail 0 1" in result.capture
+
+
+def test_ref_child_ignore(generate_ref_pyproject, run_poe):
+    project_path = generate_ref_pyproject()
+    result = run_poe("ref_child_ignore", cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert "poe_test_fail 0 1" in result.capture
+
+
+def test_ref_both_ignore(generate_ref_pyproject, run_poe):
+    project_path = generate_ref_pyproject()
+    result = run_poe("ref_both_ignore", cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert "poe_test_fail 0 1" in result.capture
+
+
+def test_ref_sequence_without_ignore(generate_ref_pyproject, run_poe):
+    project_path = generate_ref_pyproject()
+    result = run_poe("ref_seq_no_ignore", cwd=project_path)
+    assert result.code == 1, "Expected non-zero result"
+    assert "Sequence aborted after failed subtask 'target_fail'" in result.capture
+
+
+def test_ref_sequence_ignore_true(generate_ref_pyproject, run_poe):
+    project_path = generate_ref_pyproject()
+    result = run_poe("ref_seq_ignore", cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert (
+        "Warning: Sequence aborted after failed subtask 'target_fail'" in result.capture
+    )
+
+
+@pytest.mark.parametrize("invalid_value", [[1], "return_non_zero"])
+def test_ref_invalid_ignore_values(generate_ref_pyproject, run_poe, invalid_value):
+    project_path = generate_ref_pyproject(ref_invalid_ignore_fail=invalid_value)
+    result = run_poe("ref_invalid", cwd=project_path)
+    assert result.code == 1, "Expected non-zero result"
+    assert "Option 'ignore_fail' must have a value of type: bool" in result.capture
+
+
+def test_parent_uses_child_ignore(generate_composed_pyproject, run_poe):
+    project_path = generate_composed_pyproject()
+    result = run_poe("parent_seq_no_ignore", cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert "Poe => poe_test_fail 0 1" in result.capture
+    assert "Poe => poe_test_fail 0 2" in result.capture
+    assert "Poe => poe_test_echo ok" in result.capture
+
+
+def test_parallel_parent_uses_child_ignore(generate_composed_pyproject, run_poe):
+    project_path = generate_composed_pyproject()
+    result = run_poe("parent_par_no_ignore", cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert "Poe => poe_test_fail 0 1" in result.capture
+    assert "Poe => poe_test_fail 0 2" in result.capture
+    assert "Poe => poe_test_echo ok" in result.capture
+
+
+def test_parent_ignore_true_with_child_return_non_zero(
+    generate_composed_pyproject, run_poe
+):
+    project_path = generate_composed_pyproject()
+    result = run_poe("parent_seq_ignore_true", cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert (
+        "Warning: Subtasks 'child_fail_a', 'child_fail_b' returned non-zero exit status"
+        in result.capture
+    )
+    assert "Poe => poe_test_echo ok" in result.capture
+
+
+def test_parallel_parent_ignore_true_with_child_return_non_zero(
+    generate_composed_pyproject, run_poe
+):
+    project_path = generate_composed_pyproject()
+    result = run_poe("parent_par_ignore_true", cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert (
+        "Warning: Parallel subtask 'child_seq_return_non_zero' failed with exception"
+        in result.capture
+    )
+    assert "Poe => poe_test_echo ok" in result.capture
+
+
+def test_ref_return_non_zero(generate_composed_pyproject, run_poe):
+    project_path = generate_composed_pyproject()
+    result = run_poe("ref_seq_return_non_zero", cwd=project_path)
+    assert result.code == 1, "Expected non-zero result"
+    assert "Subtasks 'child_fail_a', 'child_fail_b' returned non-zero exit status" in (
+        result.capture
+    )
+
+
+def test_ref_return_non_zero_ignore(generate_composed_pyproject, run_poe):
+    project_path = generate_composed_pyproject()
+    result = run_poe("ref_seq_return_non_zero_ignore", cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert (
+        "Warning: Subtasks 'child_fail_a', 'child_fail_b' returned non-zero exit status"
+        in result.capture
+    )
+
+
+def test_ref_parallel_return_non_zero(generate_composed_pyproject, run_poe):
+    project_path = generate_composed_pyproject()
+    result = run_poe("ref_par_return_non_zero", cwd=project_path)
+    assert result.code == 1, "Expected non-zero result"
+    assert "Subtasks 'child_fail_a', 'child_fail_b' returned non-zero exit status" in (
+        result.capture
+    )
+
+
+def test_ref_parallel_return_non_zero_ignore(generate_composed_pyproject, run_poe):
+    project_path = generate_composed_pyproject()
+    result = run_poe("ref_par_return_non_zero_ignore", cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert (
+        "Warning: Subtasks 'child_fail_a', 'child_fail_b' returned non-zero exit status"
+        in result.capture
+    )
+
+
+def test_task_graph_dep_ignore(generate_composed_pyproject, run_poe):
+    project_path = generate_composed_pyproject()
+    result = run_poe("graph_root", cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert "Poe => poe_test_fail 0 1" in result.capture
+    assert "Poe => poe_test_fail 0 2" in result.capture
+    assert "Poe => poe_test_echo graph" in result.capture
+
+
+def test_ref_task_graph_ignore(generate_composed_pyproject, run_poe):
+    project_path = generate_composed_pyproject()
+    result = run_poe("ref_graph_root_fail_ignore", cwd=project_path)
+    assert result.code == 0, "Expected zero result"
+    assert (
+        "Warning: Task graph aborted after failed task 'dep_fail_plain'"
+        in result.capture
+    )

--- a/tests/test_parallel_tasks.py
+++ b/tests/test_parallel_tasks.py
@@ -13,18 +13,18 @@ def test_parallel_task_parallelism(run_poe_subproc):
     result = run_poe_subproc("--ansi", "sleep_sort", project="parallel")
 
     assert result.capture_lines == [
-        "\x1b[37mPoe =>\x1b[0m \x1b[94mpoe_test_delayed_echo 333 333\x1b[0m",
+        "\x1b[37mPoe =>\x1b[0m \x1b[94mpoe_test_delayed_echo 450 450\x1b[0m",
         "\x1b[37mPoe =>\x1b[0m \x1b[94mpoe_test_delayed_echo 0 0\x1b[0m",
-        "\x1b[37mPoe =>\x1b[0m \x1b[94mpoe_test_delayed_echo 444 444\x1b[0m",
-        "\x1b[37mPoe =>\x1b[0m \x1b[94mpoe_test_delayed_echo 222 222\x1b[0m",
-        "\x1b[37mPoe =>\x1b[0m \x1b[94mpoe_test_delayed_echo 111 111\x1b[0m",
+        "\x1b[37mPoe =>\x1b[0m \x1b[94mpoe_test_delayed_echo 600 600\x1b[0m",
+        "\x1b[37mPoe =>\x1b[0m \x1b[94mpoe_test_delayed_echo 300 300\x1b[0m",
+        "\x1b[37mPoe =>\x1b[0m \x1b[94mpoe_test_delayed_echo 150 150\x1b[0m",
     ]
     assert result.stdout == (
         "\x1b[32msleep_sort[1]\x1b[0m | 0\n"
-        "\x1b[35msleep_sort[4]\x1b[0m | 111\n"
-        "\x1b[34msleep_sort[3]\x1b[0m | 222\n"
-        "\x1b[31msleep_sort[0]\x1b[0m | 333\n"
-        "\x1b[33msleep_sort[2]\x1b[0m | 444\n"
+        "\x1b[35msleep_sort[4]\x1b[0m | 150\n"
+        "\x1b[34msleep_sort[3]\x1b[0m | 300\n"
+        "\x1b[31msleep_sort[0]\x1b[0m | 450\n"
+        "\x1b[33msleep_sort[2]\x1b[0m | 600\n"
     )
 
 


### PR DESCRIPTION
For execution tasks the ignore_fail option also recieves a list of exit codes to ignore.

Fix a few other typos in docs.

fixes: #256

## Pre-merge Checklist

- [x] New features (if any) are covered by new feature tests
- [x] New features (if any) are documented
- [ ] Bug fixes (if any) are accompanied by a test (if not too complicated to do so)
- [x] `poe check` executed successfully
- [x] This PR targets the *development* branch for code changes or *main* if only documentation is updated
