### PR TITLE
Passing free arguments to sequence, parallel and switch tasks is now possible.

### DIFF
--- a/docs/guides/args_guide.rst
+++ b/docs/guides/args_guide.rst
@@ -331,6 +331,17 @@ calling the task like so:
 
 will result in poe parsing the target_dir cli option, but appending the :sh:`--fix` flag to the ruff command without attempting to interpret it.
 
+For :doc:`sequence<../tasks/task_types/sequence>` and :doc:`parallel<../tasks/task_types/parallel>` tasks, free arguments are forwarded to every subtask in the sequence or parallel group. This enables patterns like passing extra flags to all sub-commands at once:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.test-all]
+  sequence = ["test-py311", "test-py312"]
+
+.. code-block:: sh
+
+  poe test-all -- -k test_my_feature  # -k flag is forwarded to every subtask
+
 .. note::
 
    Passing :sh:`--` in the arguments list to any other task type will simply result in any subsequent arguments being ignored.

--- a/docs/guides/args_guide.rst
+++ b/docs/guides/args_guide.rst
@@ -331,12 +331,25 @@ calling the task like so:
 
 will result in poe parsing the target_dir cli option, but appending the :sh:`--fix` flag to the ruff command without attempting to interpret it.
 
-For :doc:`sequence<../tasks/task_types/sequence>` and :doc:`parallel<../tasks/task_types/parallel>` tasks, free arguments are forwarded to subtasks that have ``inherit-extra-args = true`` set. By default, subtasks do not inherit free arguments (``inherit-extra-args`` defaults to ``false``), so only subtasks explicitly opting in will receive them:
+.. note::
+
+   Passing :sh:`--` in the arguments list to any other task type will simply result in any subsequent arguments being ignored.
+
+Forwarding free arguments to subtasks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For :doc:`sequence<../tasks/task_types/sequence>` and :doc:`parallel<../tasks/task_types/parallel>` tasks, free arguments can be forwarded to individual subtasks. Because not every subtask in a group necessarily accepts extra arguments, forwarding is opt-in: a subtask must declare ``inherit-extra-args = true`` to receive them. By default ``inherit-extra-args`` is ``false``, so subtasks silently discard any extra arguments they receive.
+
+This is particularly useful when using a sequence or parallel task as a test runner that covers multiple Python versions, allowing extra arguments to be passed through to each test invocation:
 
 .. code-block:: toml
 
   [tool.poe.tasks.test-py311]
-  cmd = "pytest tests"
+  cmd = "pytest tests --cov=mypackage"
+  inherit-extra-args = true
+
+  [tool.poe.tasks.test-py312]
+  cmd = "pytest tests --cov=mypackage"
   inherit-extra-args = true
 
   [tool.poe.tasks.test-all]
@@ -344,8 +357,25 @@ For :doc:`sequence<../tasks/task_types/sequence>` and :doc:`parallel<../tasks/ta
 
 .. code-block:: sh
 
-  poe test-all -- -k test_my_feature  # -k flag is forwarded only to test-py311
+  poe test-all -- -k test_my_feature
 
-.. note::
+This forwards ``-k test_my_feature`` to both ``test-py311`` and ``test-py312``, so every ``pytest`` invocation receives the extra flag.
 
-   Passing :sh:`--` in the arguments list to any other task type will simply result in any subsequent arguments being ignored.
+If the sequence or parallel task also defines its own named arguments, free arguments must be separated from them using :sh:`--`:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.test-all]
+  sequence = ["test-py311", "test-py312"]
+  args = [{ name = "verbose", options = ["-v"], type = "boolean" }]
+
+.. code-block:: sh
+
+  poe test-all -v -- -k test_my_feature
+
+Tasks that do *not* set ``inherit-extra-args = true`` simply discard any extra arguments passed by the parent task, making it safe to mix subtasks that accept extra arguments with those that do not:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.test-all]
+  sequence = ["test-py311", "test-py312", "lint"]  # lint ignores extras by default

--- a/docs/guides/args_guide.rst
+++ b/docs/guides/args_guide.rst
@@ -331,16 +331,20 @@ calling the task like so:
 
 will result in poe parsing the target_dir cli option, but appending the :sh:`--fix` flag to the ruff command without attempting to interpret it.
 
-For :doc:`sequence<../tasks/task_types/sequence>` and :doc:`parallel<../tasks/task_types/parallel>` tasks, free arguments are forwarded to every subtask in the sequence or parallel group. This enables patterns like passing extra flags to all sub-commands at once:
+For :doc:`sequence<../tasks/task_types/sequence>` and :doc:`parallel<../tasks/task_types/parallel>` tasks, free arguments are forwarded to subtasks that have ``inherit-extra-args = true`` set. By default, subtasks do not inherit free arguments (``inherit-extra-args`` defaults to ``false``), so only subtasks explicitly opting in will receive them:
 
 .. code-block:: toml
+
+  [tool.poe.tasks.test-py311]
+  cmd = "pytest tests"
+  inherit-extra-args = true
 
   [tool.poe.tasks.test-all]
   sequence = ["test-py311", "test-py312"]
 
 .. code-block:: sh
 
-  poe test-all -- -k test_my_feature  # -k flag is forwarded to every subtask
+  poe test-all -- -k test_my_feature  # -k flag is forwarded only to test-py311
 
 .. note::
 

--- a/docs/guides/args_guide.rst
+++ b/docs/guides/args_guide.rst
@@ -338,7 +338,7 @@ will result in poe parsing the target_dir cli option, but appending the :sh:`--f
 Forwarding free arguments to subtasks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For :doc:`sequence<../tasks/task_types/sequence>` and :doc:`parallel<../tasks/task_types/parallel>` tasks, free arguments can be forwarded to individual subtasks. Because not every subtask in a group necessarily accepts extra arguments, forwarding is opt-in: a subtask must declare ``inherit-extra-args = true`` to receive them. By default ``inherit-extra-args`` is ``false``, so subtasks silently discard any extra arguments they receive.
+For :doc:`sequence<../tasks/task_types/sequence>`, :doc:`parallel<../tasks/task_types/parallel>`, and :doc:`switch<../tasks/task_types/switch>` tasks, free arguments can be forwarded to individual subtasks. Because not every subtask in a group necessarily accepts extra arguments, forwarding is opt-in: a subtask must declare ``inherit-extra-args = true`` to receive them. By default ``inherit-extra-args`` is ``false``, so subtasks silently discard any extra arguments they receive.
 
 This is particularly useful when using a sequence or parallel task as a test runner that covers multiple Python versions, allowing extra arguments to be passed through to each test invocation:
 

--- a/docs/guides/tox_replacement_guide.rst
+++ b/docs/guides/tox_replacement_guide.rst
@@ -166,17 +166,29 @@ tox supports running tests in parallel using the ``-p`` option. Poe the Poet let
 Passing extra arguments to all test variants
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can pass additional CLI arguments through to every task in a sequence (or parallel group) by separating them from any sequence-level arguments using :sh:`--`:
+You can pass additional CLI arguments through to tasks in a sequence (or parallel group) by separating them from any sequence-level arguments using :sh:`--`. To enable a task to receive these forwarded arguments, set ``inherit-extra-args = true`` on that task:
 
 .. code-block:: bash
 
     poe test-all -- -k test_my_feature
 
-This forwards ``-k test_my_feature`` to each individual test task, so every ``pytest`` invocation receives the extra flag. This is equivalent to tox's ``tox -- -k test_my_feature`` syntax.
+This forwards ``-k test_my_feature`` to each individual test task that has opted in, so every matching ``pytest`` invocation receives the extra flag. This is equivalent to tox's ``tox -- -k test_my_feature`` syntax.
 
-For example, given the configuration from the :ref:`Basic migration` section:
+For example, given the configuration from the :ref:`Basic migration` section, add ``inherit-extra-args = true`` to the individual test tasks:
 
 .. code-block:: toml
+
+    [tool.poe.tasks.test-py310]
+    cmd = "pytest tests --cov=mypackage"
+    inherit-extra-args = true
+
+    [tool.poe.tasks.test-py311]
+    cmd = "pytest tests --cov=mypackage"
+    inherit-extra-args = true
+
+    [tool.poe.tasks.test-py312]
+    cmd = "pytest tests --cov=mypackage"
+    inherit-extra-args = true
 
     [tool.poe.tasks.test-all]
     sequence = ["test-py310", "test-py311", "test-py312"]

--- a/docs/guides/tox_replacement_guide.rst
+++ b/docs/guides/tox_replacement_guide.rst
@@ -163,6 +163,32 @@ tox supports running tests in parallel using the ``-p`` option. Poe the Poet let
     [tool.poe.tasks.test-parallel]
     parallel = ["test-py39", "test-py310", "test-py311", "test-py312"]
 
+Passing extra arguments to all test variants
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can pass additional CLI arguments through to every task in a sequence (or parallel group) by separating them from any sequence-level arguments using :sh:`--`:
+
+.. code-block:: bash
+
+    poe test-all -- -k test_my_feature
+
+This forwards ``-k test_my_feature`` to each individual test task, so every ``pytest`` invocation receives the extra flag. This is equivalent to tox's ``tox -- -k test_my_feature`` syntax.
+
+For example, given the configuration from the :ref:`Basic migration` section:
+
+.. code-block:: toml
+
+    [tool.poe.tasks.test-all]
+    sequence = ["test-py310", "test-py311", "test-py312"]
+
+Running:
+
+.. code-block:: bash
+
+    poe test-all -- -k test_my_feature --tb=short
+
+will run ``pytest tests --cov=mypackage -k test_my_feature --tb=short`` for each Python version.
+
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/tasks/task_types/parallel.rst
+++ b/docs/tasks/task_types/parallel.rst
@@ -87,6 +87,12 @@ Alternatively you can declare other task types inline like so:
   An array within a parallel task is interpreted as a :doc:`sequence<sequence>` task, so you can run certain parallel subtasks :ref:`with strict ordering<Composing tasks to run in parallel>`.
 
 
+Forwarding free arguments to subtasks
+--------------------------------------
+
+Free arguments can be forwarded to individual subtasks by setting ``inherit-extra-args = true`` on those subtasks. See :ref:`Forwarding free arguments to subtasks` in the :doc:`args guide<../../guides/args_guide>` for details.
+
+
 Customize output prefixing
 --------------------------
 

--- a/docs/tasks/task_types/sequence.rst
+++ b/docs/tasks/task_types/sequence.rst
@@ -76,51 +76,7 @@ If you want strings in the array to be interpreted as a task type other than :do
 Forwarding free arguments to subtasks
 --------------------------------------
 
-Any free arguments passed to a sequence task (either all arguments when no named args are defined, or arguments passed after :sh:`--` when named args are defined) are forwarded to subtasks that have :toml:`inherit-extra-args = true` set.
-
-By default, subtasks **do not** inherit free arguments from the parent sequence task (``inherit-extra-args`` defaults to ``false``). To opt a subtask into receiving the forwarded arguments, set ``inherit-extra-args = true`` on that task:
-
-.. code-block:: toml
-
-  [tool.poe.tasks.test-py311]
-  cmd = "pytest tests"
-  executor = { isolated = true, python = "3.11" }
-  inherit-extra-args = true
-
-  [tool.poe.tasks.test-py312]
-  cmd = "pytest tests"
-  executor = { isolated = true, python = "3.12" }
-  inherit-extra-args = true
-
-  [tool.poe.tasks.test-all]
-  sequence = ["test-py311", "test-py312"]
-
-Calling the task like:
-
-.. code-block:: sh
-
-  poe test-all -- -k test_my_feature
-
-will run both ``test-py311`` and ``test-py312`` with the extra ``-k test_my_feature`` argument appended to each ``pytest`` invocation.
-
-If the sequence task also defines its own named arguments, free arguments are separated from them using :sh:`--`:
-
-.. code-block:: toml
-
-  [tool.poe.tasks.test-all]
-  sequence = ["test-py311", "test-py312"]
-  args = [{ name = "verbose", options = ["-v"], type = "boolean" }]
-
-.. code-block:: sh
-
-  poe test-all -v -- -k test_my_feature
-
-Tasks with ``inherit-extra-args = false`` (the default) simply discard any extra arguments they receive from the parent sequence or parallel task, making it safe to mix tasks that accept extra arguments with those that do not:
-
-.. code-block:: toml
-
-  [tool.poe.tasks.test-all]
-  sequence = ["test-py311", "test-py312", "lint"]  # lint ignores extras by default
+Free arguments can be forwarded to individual subtasks by setting ``inherit-extra-args = true`` on those subtasks. See :ref:`Forwarding free arguments to subtasks` in the :doc:`args guide<../../guides/args_guide>` for details.
 
 
 Sequence task as an array of tables

--- a/docs/tasks/task_types/sequence.rst
+++ b/docs/tasks/task_types/sequence.rst
@@ -73,6 +73,47 @@ If you want strings in the array to be interpreted as a task type other than :do
   release.default_item_type = "script"
 
 
+Forwarding free arguments to subtasks
+--------------------------------------
+
+Any free arguments passed to a sequence task (either all arguments when no named args are defined, or arguments passed after :sh:`--` when named args are defined) are forwarded to every subtask in the sequence.
+
+This is particularly useful when using a sequence task as a test runner that covers multiple environments, allowing extra arguments to be passed through to each test command:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.test-py311]
+  cmd = "pytest tests"
+  executor = { isolated = true, python = "3.11" }
+
+  [tool.poe.tasks.test-py312]
+  cmd = "pytest tests"
+  executor = { isolated = true, python = "3.12" }
+
+  [tool.poe.tasks.test-all]
+  sequence = ["test-py311", "test-py312"]
+
+Calling the task like:
+
+.. code-block:: sh
+
+  poe test-all -- -k test_my_feature
+
+will run both ``test-py311`` and ``test-py312`` with the extra ``-k test_my_feature`` argument appended to each ``pytest`` invocation.
+
+If the sequence task also defines its own named arguments, free arguments are separated from them using :sh:`--`:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.test-all]
+  sequence = ["test-py311", "test-py312"]
+  args = [{ name = "verbose", options = ["-v"], type = "boolean" }]
+
+.. code-block:: sh
+
+  poe test-all -v -- -k test_my_feature
+
+
 Sequence task as an array of tables
 -----------------------------------
 

--- a/docs/tasks/task_types/sequence.rst
+++ b/docs/tasks/task_types/sequence.rst
@@ -76,19 +76,21 @@ If you want strings in the array to be interpreted as a task type other than :do
 Forwarding free arguments to subtasks
 --------------------------------------
 
-Any free arguments passed to a sequence task (either all arguments when no named args are defined, or arguments passed after :sh:`--` when named args are defined) are forwarded to every subtask in the sequence.
+Any free arguments passed to a sequence task (either all arguments when no named args are defined, or arguments passed after :sh:`--` when named args are defined) are forwarded to subtasks that have :toml:`inherit-extra-args = true` set.
 
-This is particularly useful when using a sequence task as a test runner that covers multiple environments, allowing extra arguments to be passed through to each test command:
+By default, subtasks **do not** inherit free arguments from the parent sequence task (``inherit-extra-args`` defaults to ``false``). To opt a subtask into receiving the forwarded arguments, set ``inherit-extra-args = true`` on that task:
 
 .. code-block:: toml
 
   [tool.poe.tasks.test-py311]
   cmd = "pytest tests"
   executor = { isolated = true, python = "3.11" }
+  inherit-extra-args = true
 
   [tool.poe.tasks.test-py312]
   cmd = "pytest tests"
   executor = { isolated = true, python = "3.12" }
+  inherit-extra-args = true
 
   [tool.poe.tasks.test-all]
   sequence = ["test-py311", "test-py312"]
@@ -112,6 +114,13 @@ If the sequence task also defines its own named arguments, free arguments are se
 .. code-block:: sh
 
   poe test-all -v -- -k test_my_feature
+
+Tasks with ``inherit-extra-args = false`` (the default) simply discard any extra arguments they receive from the parent sequence or parallel task, making it safe to mix tasks that accept extra arguments with those that do not:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.test-all]
+  sequence = ["test-py311", "test-py312", "lint"]  # lint ignores extras by default
 
 
 Sequence task as an array of tables

--- a/docs/tasks/task_types/switch.rst
+++ b/docs/tasks/task_types/switch.rst
@@ -126,3 +126,9 @@ So running this task would look like:
   Poe <= flavor
   Poe => make_chocolate_icecream
   ...
+
+
+Forwarding free arguments to case tasks
+----------------------------------------
+
+Free arguments can be forwarded to individual case tasks by setting ``inherit-extra-args = true`` on those case tasks. See :ref:`Forwarding free arguments to subtasks` in the :doc:`args guide<../../guides/args_guide>` for details.

--- a/poethepoet/task/base.py
+++ b/poethepoet/task/base.py
@@ -5,13 +5,14 @@ import sys
 from collections.abc import Iterator, Mapping, Sequence
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, NamedTuple
 
 from ..config.primitives import EmptyDict, EnvDefault, EnvfileOption
 from ..exceptions import ConfigValidationError, PoeException
 from ..executor.task_run import PoeTaskRun
 from ..io import PoeIO
 from ..options import PoeOptions
+from ..options.annotations import Metadata
 
 if TYPE_CHECKING:
     from ..config import ConfigPartition, PoeConfig
@@ -184,6 +185,9 @@ class PoeTask(metaclass=MetaPoeTask):
         envfile: str | Sequence[str] | EnvfileOption = ()
         executor: Mapping[str, str | Sequence[str] | bool] | str | None = None
         help: str | None = None
+        inherit_extra_args: Annotated[
+            bool, Metadata(config_name="inherit-extra-args")
+        ] = False
         uses: Mapping[str, str] | None = None
         verbosity: Literal[-2, -1, 0, 1, 2] | None = None
 

--- a/poethepoet/task/parallel.py
+++ b/poethepoet/task/parallel.py
@@ -158,24 +158,22 @@ class ParallelTask(PoeTask):
     ):
         assert capture_stdout in (False, None)
         super().__init__(spec, invocation, ctx)
-        self._subtasks = [
-            task_spec.create_task(
-                invocation=(self._subtask_name(task_spec.name, index),),
-                ctx=TaskContext.from_task(self, task_spec),
-            )
-            for index, task_spec in enumerate(spec.subtasks)
-        ]
 
     async def _handle_run(
         self, context: RunContext, env: TaskEnv, task_state: PoeTaskRun
     ):
-        named_arg_values, _ = self.get_parsed_arguments(env)
+        named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.register_task_args(named_arg_values)
 
-        if not named_arg_values and any(arg.strip() for arg in self.invocation[1:]):
-            raise PoeException(f"Parallel task {self.name!r} does not accept arguments")
+        subtasks = [
+            task_spec.create_task(
+                invocation=(self._subtask_name(task_spec.name, index), *extra_args),
+                ctx=TaskContext.from_task(self, task_spec),
+            )
+            for index, task_spec in enumerate(self.spec.subtasks)
+        ]
 
-        if len(self._subtasks) > 1:
+        if len(subtasks) > 1:
             # Indicate on the global context that there are multiple stages
             context.multistage = True
 
@@ -190,7 +188,7 @@ class ParallelTask(PoeTask):
         )
 
         with context.output_streaming(enabled=True) as streaming_enabled:
-            for subtask in self._subtasks:
+            for subtask in subtasks:
                 subtask_run: PoeTaskRun | None = None
                 try:
                     subtask_run = await subtask.run(context=context, parent_env=env)

--- a/poethepoet/task/parallel.py
+++ b/poethepoet/task/parallel.py
@@ -167,7 +167,10 @@ class ParallelTask(PoeTask):
 
         subtasks = [
             task_spec.create_task(
-                invocation=(self._subtask_name(task_spec.name, index), *extra_args),
+                invocation=(
+                    self._subtask_name(task_spec.name, index),
+                    *(extra_args if task_spec.options.inherit_extra_args else ()),
+                ),
                 ctx=TaskContext.from_task(self, task_spec),
             )
             for index, task_spec in enumerate(self.spec.subtasks)

--- a/poethepoet/task/ref.py
+++ b/poethepoet/task/ref.py
@@ -22,6 +22,7 @@ class RefTask(PoeTask):
 
     class TaskOptions(PoeTask.TaskOptions):
         ignore_fail: bool = False
+        inherit_extra_args: bool = True
 
         def validate(self):
             """
@@ -84,15 +85,20 @@ class RefTask(PoeTask):
         named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.register_task_args(named_arg_values)
 
-        ref_invocation = (
-            *(
-                env.fill_template(token)
-                for token in shlex.split(env.fill_template(self.spec.content.strip()))
-            ),
-            *extra_args,
+        ref_tokens = tuple(
+            env.fill_template(token)
+            for token in shlex.split(env.fill_template(self.spec.content.strip()))
         )
-
-        task_spec = self.ctx.specs.get(ref_invocation[0])
+        task_spec = self.ctx.specs.get(ref_tokens[0])
+        # When called as a subtask (spec has a parent), respect the target task's
+        # inherit_extra_args option. When called directly, always forward extra_args.
+        should_forward_extra_args = (
+            self.spec.parent is None or task_spec.options.inherit_extra_args
+        )
+        ref_invocation = (
+            *ref_tokens,
+            *(extra_args if should_forward_extra_args else ()),
+        )
         task = task_spec.create_task(
             invocation=ref_invocation,
             ctx=TaskContext.from_task(self, task_spec),

--- a/poethepoet/task/sequence.py
+++ b/poethepoet/task/sequence.py
@@ -118,7 +118,6 @@ class SequenceTask(PoeTask):
                 subtask.validate(config, task_specs)
 
     spec: TaskSpec
-    _subtasks: Sequence[PoeTask]
 
     def __init__(
         self,
@@ -129,24 +128,22 @@ class SequenceTask(PoeTask):
     ):
         assert capture_stdout in (False, None)
         super().__init__(spec, invocation, ctx)
-        self._subtasks: Sequence[PoeTask] = [
-            task_spec.create_task(
-                invocation=(self._subtask_name(task_spec.name, index),),
-                ctx=TaskContext.from_task(self, task_spec),
-            )
-            for index, task_spec in enumerate(spec.subtasks)
-        ]
 
     async def _handle_run(
         self, context: RunContext, env: TaskEnv, task_state: PoeTaskRun
     ):
-        named_arg_values, _ = self.get_parsed_arguments(env)
+        named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.register_task_args(named_arg_values)
 
-        if not named_arg_values and any(arg.strip() for arg in self.invocation[1:]):
-            raise PoeException(f"Sequence task {self.name!r} does not accept arguments")
+        subtasks: Sequence[PoeTask] = [
+            task_spec.create_task(
+                invocation=(self._subtask_name(task_spec.name, index), *extra_args),
+                ctx=TaskContext.from_task(self, task_spec),
+            )
+            for index, task_spec in enumerate(self.spec.subtasks)
+        ]
 
-        if len(self._subtasks) > 1:
+        if len(subtasks) > 1:
             # Indicate on the global context that there are multiple stages
             context.multistage = True
 
@@ -155,7 +152,7 @@ class SequenceTask(PoeTask):
             task_state.ignore_failure()
 
         non_zero_subtasks = []
-        for subtask in self._subtasks:
+        for subtask in subtasks:
             subtask_run: PoeTaskRun | None = None
             try:
                 subtask_run = await subtask.run(context=context, parent_env=env)

--- a/poethepoet/task/sequence.py
+++ b/poethepoet/task/sequence.py
@@ -137,7 +137,10 @@ class SequenceTask(PoeTask):
 
         subtasks: Sequence[PoeTask] = [
             task_spec.create_task(
-                invocation=(self._subtask_name(task_spec.name, index), *extra_args),
+                invocation=(
+                    self._subtask_name(task_spec.name, index),
+                    *(extra_args if task_spec.options.inherit_extra_args else ()),
+                ),
                 ctx=TaskContext.from_task(self, task_spec),
             )
             for index, task_spec in enumerate(self.spec.subtasks)

--- a/poethepoet/task/switch.py
+++ b/poethepoet/task/switch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
-from ..exceptions import ConfigValidationError, ExecutionError, PoeException
+from ..exceptions import ConfigValidationError, ExecutionError
 from .base import PoeTask, TaskContext
 
 if TYPE_CHECKING:
@@ -173,8 +173,20 @@ class SwitchTask(PoeTask):
         control_task_name = f"{spec.name}[__control__]"
         control_invocation: tuple[str, ...] = (control_task_name,)
         options = self.spec.options
+        all_user_args = invocation[1:]
+
         if options.get("args"):
-            control_invocation = (*control_invocation, *invocation[1:])
+            try:
+                split_idx = all_user_args.index("--")
+                named_portion = all_user_args[:split_idx]
+                extra_portion = all_user_args[split_idx + 1 :]
+            except ValueError:
+                named_portion = all_user_args
+                extra_portion = ()
+            control_invocation = (*control_invocation, *named_portion)
+        else:
+            named_portion = ()
+            extra_portion = all_user_args
 
         self.control_task = self.spec.control_task_spec.create_task(
             invocation=control_invocation,
@@ -186,7 +198,17 @@ class SwitchTask(PoeTask):
         for case_keys, case_spec in spec.case_task_specs:
             task_invocation: tuple[str, ...] = (f"{spec.name}[{','.join(case_keys)}]",)
             if options.get("args"):
-                task_invocation = (*task_invocation, *invocation[1:])
+                if case_spec.options.inherit_extra_args and extra_portion:
+                    task_invocation = (
+                        *task_invocation,
+                        *named_portion,
+                        "--",
+                        *extra_portion,
+                    )
+                else:
+                    task_invocation = (*task_invocation, *named_portion)
+            elif case_spec.options.inherit_extra_args:
+                task_invocation = (*task_invocation, *extra_portion)
 
             case_task = case_spec.create_task(
                 invocation=task_invocation,
@@ -201,9 +223,6 @@ class SwitchTask(PoeTask):
     ):
         named_arg_values, _ = self.get_parsed_arguments(env)
         env.register_task_args(named_arg_values)
-
-        if not named_arg_values and any(arg.strip() for arg in self.invocation[1:]):
-            raise PoeException(f"Switch task {self.name!r} does not accept arguments")
 
         # Indicate on the global context that there are multiple stages to this task
         context.multistage = True

--- a/tests/fixtures/parallel_project/pyproject.toml
+++ b/tests/fixtures/parallel_project/pyproject.toml
@@ -67,6 +67,12 @@ parallel = [
   { expr = "{'flag':flag, 'val':val}" },
 ]
 
+[tool.poe.tasks.echo-args]
+cmd = "poe_test_echo one two"
+
+[tool.poe.tasks.forward-free-args-par]
+parallel = ["echo-args", "echo-args"]
+
 [tool.poe.tasks.parallel_with_stdout_capture]
 parallel = [
   { cmd = "poe_test_echo \"1 going to stdout 1\"" },

--- a/tests/fixtures/parallel_project/pyproject.toml
+++ b/tests/fixtures/parallel_project/pyproject.toml
@@ -69,9 +69,16 @@ parallel = [
 
 [tool.poe.tasks.echo-args]
 cmd = "poe_test_echo one two"
+inherit-extra-args = true
+
+[tool.poe.tasks.echo-args-ignore-extra]
+cmd = "poe_test_echo one two"
 
 [tool.poe.tasks.forward-free-args-par]
 parallel = ["echo-args", "echo-args"]
+
+[tool.poe.tasks.forward-free-args-par-ignore-extra]
+parallel = ["echo-args-ignore-extra", "echo-args-ignore-extra"]
 
 [tool.poe.tasks.parallel_with_stdout_capture]
 parallel = [

--- a/tests/fixtures/sequences_project/pyproject.toml
+++ b/tests/fixtures/sequences_project/pyproject.toml
@@ -73,9 +73,16 @@ sequence = ["./tools/poetry-ci-install.sh"]
 
 [tool.poe.tasks.echo-args]
 cmd = "poe_test_echo one two"
+inherit-extra-args = true
+
+[tool.poe.tasks.echo-args-ignore-extra]
+cmd = "poe_test_echo one two"
 
 [tool.poe.tasks.forward-free-args-seq]
 sequence = ["echo-args", "echo-args"]
+
+[tool.poe.tasks.forward-free-args-seq-ignore-extra]
+sequence = ["echo-args-ignore-extra", "echo-args-ignore-extra"]
 
 [tool.poe.tasks.forward-free-args-seq-with-named]
 sequence = ["echo-args", "echo-args"]

--- a/tests/fixtures/sequences_project/pyproject.toml
+++ b/tests/fixtures/sequences_project/pyproject.toml
@@ -71,6 +71,16 @@ cwd = "my_package"
 default_item_type = "cmd"
 sequence = ["./tools/poetry-ci-install.sh"]
 
+[tool.poe.tasks.echo-args]
+cmd = "poe_test_echo one two"
+
+[tool.poe.tasks.forward-free-args-seq]
+sequence = ["echo-args", "echo-args"]
+
+[tool.poe.tasks.forward-free-args-seq-with-named]
+sequence = ["echo-args", "echo-args"]
+args = [{ name = "greeting", positional = true, default = "hello" }]
+
 [tool.poe.tasks.sequential_parallel]
 args = [
   { name = "d0", positional = true, default = "0" },

--- a/tests/fixtures/switch_project/pyproject.toml
+++ b/tests/fixtures/switch_project/pyproject.toml
@@ -140,3 +140,36 @@ args = [
 \\${tru}=${tru} \\${tru:+plus}=${tru:+plus} \\${tru:-minus}=${tru:-minus}\\
 \\${txt}=${txt} \\${txt:+plus}=${txt:+plus} \\${txt:-minus}=${txt:-minus}
 """
+
+[tool.poe.tasks.forward-free-args-switch]
+control.cmd = "poe_test_echo run"
+
+  [[tool.poe.tasks.forward-free-args-switch.switch]]
+  case = "run"
+  cmd = "poe_test_echo one two"
+  inherit-extra-args = true
+
+  [[tool.poe.tasks.forward-free-args-switch.switch]]
+  cmd = "poe_test_echo wrong"
+
+[tool.poe.tasks.forward-free-args-switch-ignore-extra]
+control.cmd = "poe_test_echo run"
+
+  [[tool.poe.tasks.forward-free-args-switch-ignore-extra.switch]]
+  case = "run"
+  cmd = "poe_test_echo one two"
+
+  [[tool.poe.tasks.forward-free-args-switch-ignore-extra.switch]]
+  cmd = "poe_test_echo wrong"
+
+[tool.poe.tasks.forward-free-args-switch-with-named]
+control.cmd = "poe_test_echo run"
+args = [{ name = "greeting", positional = true, default = "hello" }]
+
+  [[tool.poe.tasks.forward-free-args-switch-with-named.switch]]
+  case = "run"
+  cmd = "poe_test_echo one two"
+  inherit-extra-args = true
+
+  [[tool.poe.tasks.forward-free-args-switch-with-named.switch]]
+  cmd = "poe_test_echo wrong"

--- a/tests/test_parallel_tasks.py
+++ b/tests/test_parallel_tasks.py
@@ -592,6 +592,22 @@ def test_parallel_forwards_free_args(run_poe_subproc):
     )
 
 
+def test_parallel_inherit_extra_args_default(run_poe_subproc):
+    result = run_poe_subproc(
+        "forward-free-args-par-ignore-extra",
+        "extra1",
+        "extra2",
+        project="parallel",
+        env={"NO_COLOR": "1"},
+    )
+    assert result.capture == (
+        "Poe => poe_test_echo one two\nPoe => poe_test_echo one two\n"
+    )
+    assert result.stdout == (
+        "echo-args-ignor\u2026 | one two\necho-args-ignor\u2026 | one two\n"
+    )
+
+
 def filter_capture_lines(capture_lines: list[str], *prefixes: str) -> list[str]:
     return [
         line for line in capture_lines if not any(line.startswith(p) for p in prefixes)

--- a/tests/test_parallel_tasks.py
+++ b/tests/test_parallel_tasks.py
@@ -552,6 +552,23 @@ def test_parallel_bool_negate(run_poe):
     assert "{'flag': False, 'val': False}" in result.stdout
 
 
+def test_parallel_forwards_free_args(run_poe_subproc):
+    result = run_poe_subproc(
+        "forward-free-args-par",
+        "extra1",
+        "extra2",
+        project="parallel",
+        env={"NO_COLOR": "1"},
+    )
+    assert result.capture == (
+        "Poe => poe_test_echo one two extra1 extra2\n"
+        "Poe => poe_test_echo one two extra1 extra2\n"
+    )
+    assert result.stdout == (
+        "echo-args | one two extra1 extra2\necho-args | one two extra1 extra2\n"
+    )
+
+
 def sequences_are_similar(seq1: Sequence, seq2: Sequence, distance: int = 1):
     """
     Check if two sequences have the same items in almost the same order.

--- a/tests/test_sequence_tasks.py
+++ b/tests/test_sequence_tasks.py
@@ -204,3 +204,32 @@ def test_private_arg_inherited_can_be_remapped_public(run_poe, is_windows):
     if not is_windows:
         assert "_secret=hidden" not in result.stdout
     assert "public=hidden" in stdout_lower
+
+
+def test_sequence_forwards_free_args(run_poe_subproc):
+    result = run_poe_subproc(
+        "forward-free-args-seq", "extra1", "extra2", project="sequences"
+    )
+    assert result.capture == (
+        "Poe => poe_test_echo one two extra1 extra2\n"
+        "Poe => poe_test_echo one two extra1 extra2\n"
+    )
+    assert result.stdout == "one two extra1 extra2\none two extra1 extra2\n"
+    assert result.stderr == ""
+
+
+def test_sequence_with_named_args_forwards_free_args(run_poe_subproc):
+    result = run_poe_subproc(
+        "forward-free-args-seq-with-named",
+        "hi",
+        "--",
+        "extra1",
+        "extra2",
+        project="sequences",
+    )
+    assert result.capture == (
+        "Poe => poe_test_echo one two extra1 extra2\n"
+        "Poe => poe_test_echo one two extra1 extra2\n"
+    )
+    assert result.stdout == "one two extra1 extra2\none two extra1 extra2\n"
+    assert result.stderr == ""

--- a/tests/test_sequence_tasks.py
+++ b/tests/test_sequence_tasks.py
@@ -233,3 +233,14 @@ def test_sequence_with_named_args_forwards_free_args(run_poe_subproc):
     )
     assert result.stdout == "one two extra1 extra2\none two extra1 extra2\n"
     assert result.stderr == ""
+
+
+def test_sequence_inherit_extra_args_default(run_poe_subproc):
+    result = run_poe_subproc(
+        "forward-free-args-seq-ignore-extra", "extra1", "extra2", project="sequences"
+    )
+    assert result.capture == (
+        "Poe => poe_test_echo one two\nPoe => poe_test_echo one two\n"
+    )
+    assert result.stdout == "one two\none two\n"
+    assert result.stderr == ""

--- a/tests/test_switch_task.py
+++ b/tests/test_switch_task.py
@@ -195,3 +195,41 @@ ${txt}=text ${txt:+plus}=plus ${txt:-minus}=text
         result.stdout
         == "{'case': True, 'non': False, 'tru': True, 'fal': False, 'txt': 'text'}\n"
     )
+
+
+def test_switch_forwards_free_args(run_poe_subproc):
+    result = run_poe_subproc(
+        "forward-free-args-switch", "extra1", "extra2", project="switch"
+    )
+    assert result.capture == (
+        "Poe <= poe_test_echo run\nPoe => poe_test_echo one two extra1 extra2\n"
+    )
+    assert result.stdout == "one two extra1 extra2\n"
+    assert result.stderr == ""
+
+
+def test_switch_with_named_args_forwards_free_args(run_poe_subproc):
+    result = run_poe_subproc(
+        "forward-free-args-switch-with-named",
+        "hi",
+        "--",
+        "extra1",
+        "extra2",
+        project="switch",
+    )
+    assert result.capture == (
+        "Poe <= poe_test_echo run\nPoe => poe_test_echo one two extra1 extra2\n"
+    )
+    assert result.stdout == "one two extra1 extra2\n"
+    assert result.stderr == ""
+
+
+def test_switch_inherit_extra_args_default(run_poe_subproc):
+    result = run_poe_subproc(
+        "forward-free-args-switch-ignore-extra", "extra1", "extra2", project="switch"
+    )
+    assert result.capture == (
+        "Poe <= poe_test_echo run\nPoe => poe_test_echo one two\n"
+    )
+    assert result.stdout == "one two\n"
+    assert result.stderr == ""


### PR DESCRIPTION
## Description of changes
This PR adds the possibility to pass free arguments to sequence and parallel tasks. These free arguments are passed to every subtask.

The motivation for this is described in #374.

Fixes #374

## Pre-merge Checklist

- [x] New features (if any) are covered by new feature tests
- [x] New features (if any) are documented
- [ ] Bug fixes (if any) are accompanied by a test (if not too complicated to do so)
- [x] `poe check` executed successfully
- [x] This PR targets the *development* branch for code changes or *main* if only documentation is updated
