### PR TITLE
fix: preserve quotes in :+/:- operation arguments

### DIFF
--- a/poethepoet/helpers/command/__init__.py
+++ b/poethepoet/helpers/command/__init__.py
@@ -34,7 +34,14 @@ def resolve_command_tokens(
     patterns that are not escaped or quoted. In case there are glob patterns in the
     token, any escaped glob characters will have been escaped with [].
     """
-    from .ast import Glob, ParamArgument, ParamExpansion, ParseConfig, PythonGlob
+    from .ast import (
+        Glob,
+        ParamArgument,
+        ParamExpansion,
+        ParseConfig,
+        PythonGlob,
+        WhitespaceText,
+    )
 
     if not config:
         config = ParseConfig(substitute_nodes={Glob: PythonGlob})
@@ -87,6 +94,22 @@ def resolve_command_tokens(
 
         return param_value
 
+    def get_operation_argument(
+        element: ParamExpansion, env: Mapping[str, str]
+    ) -> ParamArgument | None:
+        """
+        If param expansion has an active :+/:- operation, return the argument
+        for inline expansion (to preserve quote structure).
+        """
+        if not element.operation:
+            return None
+        param_value = env.get(element.param_name, "")
+        if param_value and element.operation.operator == ":+":
+            return element.operation.argument
+        if not param_value and element.operation.operator == ":-":
+            return element.operation.argument
+        return None
+
     for line in lines:
         # Ignore line breaks, assuming they're only due to comments
         for word in line:
@@ -98,6 +121,79 @@ def resolve_command_tokens(
             for segment in word:
                 for element in segment:
                     if isinstance(element, ParamExpansion):
+                        # For unquoted expansions with active operations,
+                        # expand the argument inline to preserve quote
+                        # structure (e.g. single-quoted strings within the
+                        # operation argument stay as single tokens).
+                        if not segment.is_quoted:
+                            op_arg = get_operation_argument(element, env)
+                            if op_arg is not None:
+                                for arg_seg in op_arg.segments:
+                                    for arg_el in arg_seg:
+                                        if isinstance(arg_el, ParamExpansion):
+                                            nested = resolve_param_value(
+                                                arg_el, env
+                                            )
+                                            if not nested:
+                                                continue
+                                            if arg_seg.is_quoted:
+                                                token_parts.append(
+                                                    (nested, False)
+                                                )
+                                            elif nested.isspace():
+                                                if token_parts:
+                                                    yield finalize_token(
+                                                        token_parts
+                                                    )
+                                            else:
+                                                if (
+                                                    nested[0].isspace()
+                                                    and token_parts
+                                                ):
+                                                    yield finalize_token(
+                                                        token_parts
+                                                    )
+                                                pwords = (
+                                                    (
+                                                        w,
+                                                        bool(
+                                                            glob_pattern.search(
+                                                                w
+                                                            )
+                                                        ),
+                                                    )
+                                                    for w in nested.split()
+                                                )
+                                                token_parts.append(
+                                                    next(pwords)
+                                                )
+                                                for pw in pwords:
+                                                    if token_parts:
+                                                        yield finalize_token(
+                                                            token_parts
+                                                        )
+                                                    token_parts.append(pw)
+                                                if (
+                                                    nested[-1].isspace()
+                                                    and token_parts
+                                                ):
+                                                    yield finalize_token(
+                                                        token_parts
+                                                    )
+                                        elif (
+                                            isinstance(arg_el, WhitespaceText)
+                                            and not arg_seg.is_quoted
+                                        ):
+                                            if token_parts:
+                                                yield finalize_token(
+                                                    token_parts
+                                                )
+                                        else:
+                                            token_parts.append(
+                                                (arg_el.content, False)
+                                            )
+                                continue
+
                         param_value = resolve_param_value(element, env)
                         if not param_value:
                             # Empty param value has no effect

--- a/tests/helpers/command/test_command_parsing.py
+++ b/tests/helpers/command/test_command_parsing.py
@@ -77,3 +77,45 @@ def test_resolve_command_tokens():
         ("two", False),
         ("three", False),
     ]
+
+
+def test_resolve_param_operation_preserves_quotes():
+    """Regression test for https://github.com/nat-n/poethepoet/issues/333
+
+    Quotes within :+ and :- operation arguments should be preserved so that
+    quoted strings remain single tokens after word splitting.
+    """
+    # Single quotes in :+ alternate value
+    line = parse_poe_cmd("echo pytest ${SKIP_BUILD:+ -m 'not build'}")[0]
+    assert list(resolve_command_tokens([line], {"SKIP_BUILD": "1"})) == [
+        ("echo", False),
+        ("pytest", False),
+        ("-m", False),
+        ("not build", False),
+    ]
+    # When unset, alternate value is not used
+    assert list(resolve_command_tokens([line], {})) == [
+        ("echo", False),
+        ("pytest", False),
+    ]
+
+    # Double quotes in :- default value
+    line = parse_poe_cmd('echo ${GREETING:-"hello world"}')[0]
+    assert list(resolve_command_tokens([line], {})) == [
+        ("echo", False),
+        ("hello world", False),
+    ]
+    # When set, default value is not used
+    assert list(resolve_command_tokens([line], {"GREETING": "hi"})) == [
+        ("echo", False),
+        ("hi", False),
+    ]
+
+    # Mixed: unquoted and quoted parts in operation argument
+    line = parse_poe_cmd("cmd ${X:+--flag 'a b' --other}")[0]
+    assert list(resolve_command_tokens([line], {"X": "1"})) == [
+        ("cmd", False),
+        ("--flag", False),
+        ("a b", False),
+        ("--other", False),
+    ]


### PR DESCRIPTION
Fixes #333

## Problem

When using parameter expansion operators like `${VAR:+ -m 'not build'}`, the
operation argument is resolved to a flat string via `resolve_param_argument`
before being word-split. This strips the quote structure, causing single-quoted
(or double-quoted) multi-word values to be split into separate command tokens.

**Before:** `echo pytest ${SKIP_BUILD:+ -m 'not build'}` with `SKIP_BUILD` set
produces tokens `echo`, `pytest`, `-m`, `not`, `build` (5 tokens — quotes lost).

**After:** Same expression produces tokens `echo`, `pytest`, `-m`, `not build`
(4 tokens — quoted string preserved as a single token).

## Fix

When a `ParamExpansion` in an unquoted context has an active `:+` or `:-`
operation, expand the operation's `ParamArgument` segments inline within
`resolve_command_tokens`, respecting each segment's quote boundaries:

- Quoted segments → content stays as a single token part (no word splitting)
- Unquoted segments → `WhitespaceText` nodes produce token boundaries as usual

This replaces the previous path that flattened the entire argument to a string
before word splitting.

## Validation

- All 16 existing `tests/helpers/command/` tests pass
- All 18 existing `tests/test_cmd_param_expansion.py` tests pass
- Added regression test covering single quotes in `:+`, double quotes in `:-`,
  and mixed quoted/unquoted content in operation arguments