### PR TITLE
fix: preserve quotes in :+/:- operator arguments (#333)

### DIFF
--- a/docs/tasks/task_types/cmd.rst
+++ b/docs/tasks/task_types/cmd.rst
@@ -89,6 +89,10 @@ In the example below, it prints ``"hello!"`` if the ``--hello`` flag is present;
   cmd = "echo ${hello:-hello!}"
   args = [{ name = "hello", type = "boolean", default = "hi!" }]
 
+.. note::
+
+   Unlike bash, glob patterns (``*``, ``?``, ``[...]``) inside ``:-`` and ``:+`` operator arguments are treated as literal text and are not expanded.
+
 Glob expansion
 ~~~~~~~~~~~~~~
 

--- a/poethepoet/helpers/command/__init__.py
+++ b/poethepoet/helpers/command/__init__.py
@@ -34,7 +34,14 @@ def resolve_command_tokens(
     patterns that are not escaped or quoted. In case there are glob patterns in the
     token, any escaped glob characters will have been escaped with [].
     """
-    from .ast import Glob, ParamArgument, ParamExpansion, ParseConfig, PythonGlob
+    from .ast import (
+        Glob,
+        ParamArgument,
+        ParamExpansion,
+        ParseConfig,
+        PythonGlob,
+        WhitespaceText,
+    )
 
     if not config:
         config = ParseConfig(substitute_nodes={Glob: PythonGlob})
@@ -60,32 +67,108 @@ def resolve_command_tokens(
         return (token, includes_glob)
 
     def resolve_param_argument(argument: ParamArgument, env: Mapping[str, str]):
-        token_parts = []
+        """
+        Flatten a ParamArgument to a string, discarding quote structure.
+        Used when the result will be placed in an already-quoted context.
+        """
+        parts: list[str] = []
         for segment in argument.segments:
             for element in segment:
                 if isinstance(element, ParamExpansion):
-                    token_parts.append(resolve_param_value(element, env))
+                    result = resolve_param_value(element, env)
+                    if isinstance(result, ParamArgument):
+                        parts.append(resolve_param_argument(result, env))
+                    else:
+                        parts.append(result)
                 else:
-                    token_parts.append(element.content)
+                    parts.append(element.content)
 
-        return "".join(token_parts)
+        return "".join(parts)
 
-    def resolve_param_value(element: ParamExpansion, env: Mapping[str, str]):
+    def resolve_param_value(
+        element: ParamExpansion, env: Mapping[str, str]
+    ) -> str | ParamArgument:
+        """
+        Returns a plain string for simple variable values, or a ParamArgument
+        when an operation's argument should be processed with its quoting intact.
+        """
         param_value = env.get(element.param_name, "")
 
         if element.operation:
             if param_value:
                 if element.operation.operator == ":+":
-                    # apply 'alternate value' operation
-                    param_value = resolve_param_argument(
-                        element.operation.argument, env
-                    )
-
+                    return element.operation.argument
             elif element.operation.operator == ":-":
-                # apply 'default value' operation
-                param_value = resolve_param_argument(element.operation.argument, env)
+                return element.operation.argument
 
         return param_value
+
+    def resolve_argument_tokens(
+        argument: ParamArgument,
+        env: Mapping[str, str],
+        token_parts: list[tuple[str, bool]],
+    ) -> Iterator[tuple[str, bool]]:
+        """
+        Process a ParamArgument's segments inline, respecting quoting.
+        Quoted segments are not word-split; unquoted WhitespaceText causes
+        word breaks.
+        """
+        for arg_segment in argument.segments:
+            if arg_segment.is_quoted:
+                for element in arg_segment:
+                    if isinstance(element, ParamExpansion):
+                        result = resolve_param_value(element, env)
+                        if isinstance(result, ParamArgument):
+                            flat = resolve_param_argument(result, env)
+                            if flat:
+                                token_parts.append((flat, False))
+                        elif result:
+                            token_parts.append((result, False))
+                    else:
+                        token_parts.append((element.content, False))
+            else:
+                for element in arg_segment:
+                    if isinstance(element, WhitespaceText):
+                        if token_parts:
+                            yield finalize_token(token_parts)
+                    elif isinstance(element, ParamExpansion):
+                        result = resolve_param_value(element, env)
+                        if isinstance(result, ParamArgument):
+                            yield from resolve_argument_tokens(result, env, token_parts)
+                        elif result:
+                            yield from _emit_unquoted_param_value(result, token_parts)
+                    else:
+                        token_parts.append((element.content, False))
+
+    def _emit_unquoted_param_value(
+        param_value: str,
+        token_parts: list[tuple[str, bool]],
+    ) -> Iterator[tuple[str, bool]]:
+        """
+        Handle an unquoted plain string param value: word-split on whitespace
+        and check for glob patterns.
+        """
+        if param_value.isspace():
+            if token_parts:
+                yield finalize_token(token_parts)
+            return
+
+        if param_value[0].isspace() and token_parts:
+            yield finalize_token(token_parts)
+
+        param_words = (
+            (word, bool(glob_pattern.search(word))) for word in param_value.split()
+        )
+
+        token_parts.append(next(param_words))
+
+        for param_word in param_words:
+            if token_parts:
+                yield finalize_token(token_parts)
+            token_parts.append(param_word)
+
+        if param_value[-1].isspace() and token_parts:
+            yield finalize_token(token_parts)
 
     for line in lines:
         # Ignore line breaks, assuming they're only due to comments
@@ -98,40 +181,29 @@ def resolve_command_tokens(
             for segment in word:
                 for element in segment:
                     if isinstance(element, ParamExpansion):
-                        param_value = resolve_param_value(element, env)
+                        result = resolve_param_value(element, env)
+
+                        if isinstance(result, ParamArgument) and not segment.is_quoted:
+                            # In unquoted context, process argument
+                            # segments inline to preserve quoting
+                            yield from resolve_argument_tokens(result, env, token_parts)
+                            continue
+
+                        # Flatten ParamArgument to string for quoted
+                        # contexts (or use the string value directly)
+                        param_value = (
+                            resolve_param_argument(result, env)
+                            if isinstance(result, ParamArgument)
+                            else result
+                        )
                         if not param_value:
-                            # Empty param value has no effect
                             continue
                         if segment.is_quoted:
                             token_parts.append((param_value, False))
-                        elif param_value.isspace():
-                            # collapse whitespace value
-                            token_parts.append((" ", False))
                         else:
-                            # If the the param expansion it not quoted then:
-                            # - Whitespace inside a substituted param value results in
-                            #  a word break, regardless of quotes or backslashes
-                            # - glob patterns should be evaluated
-
-                            if param_value[0].isspace() and token_parts:
-                                # param_value starts with a word break
-                                yield finalize_token(token_parts)
-
-                            param_words = (
-                                (word, bool(glob_pattern.search(word)))
-                                for word in param_value.split()
+                            yield from _emit_unquoted_param_value(
+                                param_value, token_parts
                             )
-
-                            token_parts.append(next(param_words))
-
-                            for param_word in param_words:
-                                if token_parts:
-                                    yield finalize_token(token_parts)
-                                token_parts.append(param_word)
-
-                            if param_value[-1].isspace() and token_parts:
-                                # param_value ends with a word break
-                                yield finalize_token(token_parts)
 
                     elif isinstance(element, Glob):
                         token_parts.append((element.content, True))

--- a/tests/helpers/command/test_command_parsing.py
+++ b/tests/helpers/command/test_command_parsing.py
@@ -77,3 +77,61 @@ def test_resolve_command_tokens():
         ("two", False),
         ("three", False),
     ]
+
+
+def test_resolve_alternate_value_preserves_quotes():
+    """
+    Quoted content inside :+ and :- operators should not be word-split.
+    See https://github.com/nat-n/poethepoet/issues/333
+
+    Each case is verified against bash behavior. Cases already covered by
+    integration tests in test_cmd_param_expansion.py are not repeated here.
+    """
+    # Default value not applied when var is set
+    line = parse_poe_cmd("echo ${FLAG:- -m 'not build'}")[0]
+    assert list(resolve_command_tokens([line], {"FLAG": "yes"})) == [
+        ("echo", False),
+        ("yes", False),
+    ]
+
+    # Expansion embedded in a word — leading/trailing text joins adjacent tokens
+    # bash: printf '[%s]\n' x${F:+ -m 'not build'}y → [x] [-m] [not buildy]
+    line = parse_poe_cmd("x${FLAG:+ -m 'not build'}y")[0]
+    assert list(resolve_command_tokens([line], {"FLAG": "yes"})) == [
+        ("x", False),
+        ("-m", False),
+        ("not buildy", False),
+    ]
+
+    # Nested expansion in alternate value — inner value is word-split
+    # bash: F=y O="hello world"; printf '[%s]\n' ${F:+ $O} → [hello] [world]
+    line = parse_poe_cmd("${FLAG:+ $OTHER}")[0]
+    assert list(
+        resolve_command_tokens([line], {"FLAG": "y", "OTHER": "hello world"})
+    ) == [
+        ("hello", False),
+        ("world", False),
+    ]
+
+    # Outer double quotes suppress word splitting of nested expansion
+    # bash: F=y O="hello world"; printf '[%s]\n' "${F:+ $O}" → [ hello world]
+    line = parse_poe_cmd('"${FLAG:+ $OTHER}"')[0]
+    assert list(
+        resolve_command_tokens([line], {"FLAG": "y", "OTHER": "hello world"})
+    ) == [
+        (" hello world", False),
+    ]
+
+    # Nested operations: alternate value containing default value with quotes
+    # bash: F=y; printf '[%s]\n' ${F:+${UNSET:-'hello world'}} → [hello world]
+    line = parse_poe_cmd("${FLAG:+${UNSET:-'hello world'}}")[0]
+    assert list(resolve_command_tokens([line], {"FLAG": "y"})) == [
+        ("hello world", False),
+    ]
+
+    # Empty alternate value produces nothing
+    # bash: F=y; printf '[%s]\n' A${F:+}B → [AB]
+    line = parse_poe_cmd("A${FLAG:+}B")[0]
+    assert list(resolve_command_tokens([line], {"FLAG": "y"})) == [
+        ("AB", False),
+    ]

--- a/tests/test_cmd_param_expansion.py
+++ b/tests/test_cmd_param_expansion.py
@@ -1,3 +1,5 @@
+import shlex
+
 import pytest
 
 
@@ -59,3 +61,199 @@ def test_param_expansion_operations(
         assert (
             stdout_file.read() == f"{output}\n"
         ), "Task output should match test parameter"
+
+
+@pytest.mark.parametrize(
+    ("cmd_content", "env", "expected_tokens"),
+    [
+        #
+        # ---- Core regression cases for issue #333 ----
+        #
+        # Single-quoted whitespace inside ${VAR:+...} must remain a single token.
+        # Validated in bash 5.2: <pytest><-m><not build>
+        pytest.param(
+            "echo pytest ${SKIP_BUILD:+ -m 'not build'}",
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "-m", "not build"],
+            id="alt_value_single_quoted_ws",
+        ),
+        # Double-quoted whitespace inside ${VAR:+...} must remain a single token.
+        # Validated in bash 5.2: <pytest><-m><not build>
+        pytest.param(
+            'echo pytest ${SKIP_BUILD:+ -m "not build"}',
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "-m", "not build"],
+            id="alt_value_double_quoted_ws",
+        ),
+        # The same applies to the default-value operator ${VAR:-...}.
+        # Validated in bash 5.2: <pytest><-m><not build>
+        pytest.param(
+            "echo pytest ${MARKER:- -m 'not build'}",
+            {},
+            ["echo", "pytest", "-m", "not build"],
+            id="default_value_single_quoted_ws",
+        ),
+        # Quoted segment concatenated with adjacent unquoted text must form a
+        # single concatenated token (no word break inside the quoted region).
+        # Validated in bash 5.2: <pytest><--marker=not build>
+        pytest.param(
+            "echo pytest ${SKIP_BUILD:+--marker='not build'}",
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "--marker=not build"],
+            id="alt_value_quoted_concat_unquoted",
+        ),
+        # Mixed quoted/unquoted siblings: word splitting happens between them
+        # but never inside the quoted region.
+        # Validated in bash 5.2: <pytest><-m><not build><--rest>
+        pytest.param(
+            "echo pytest ${SKIP_BUILD:+ -m 'not build' --rest}",
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "-m", "not build", "--rest"],
+            id="alt_value_mixed_quoted_unquoted_siblings",
+        ),
+        # Multiple separate quoted-with-whitespace words inside one expansion.
+        # Validated in bash 5.2: <pytest><word1><word two><word3>
+        pytest.param(
+            "echo pytest ${SKIP_BUILD:+ word1 'word two' word3}",
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "word1", "word two", "word3"],
+            id="alt_value_multiple_quoted_words",
+        ),
+        # Two adjacent single-quoted segments concatenate without a word break.
+        # Validated in bash 5.2: <pytest><a bc d>
+        pytest.param(
+            "echo pytest ${SKIP_BUILD:+'a b''c d'}",
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "a bc d"],
+            id="alt_value_concat_two_quoted",
+        ),
+        #
+        # ---- Possibly related issues ----
+        #
+        # Backslash-escaped space inside an unquoted operator argument should
+        # bind the two halves into a single token, just like in bash.
+        # Validated in bash 5.2: <pytest><-m><not build>
+        pytest.param(
+            r"echo pytest ${SKIP_BUILD:+ -m not\ build}",
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "-m", "not build"],
+            id="alt_value_backslash_escaped_space",
+        ),
+        # Nested expansion in a double-quoted region inside the operator argument:
+        # the inner expansion is performed and the result remains a single token
+        # (because the inner is double-quoted).
+        # Validated in bash 5.2: <pytest><-m><not build>
+        pytest.param(
+            'echo pytest ${SKIP_BUILD:+ -m "${MARKER:-not build}"}',
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "-m", "not build"],
+            id="alt_value_nested_double_quoted",
+        ),
+        # Nested expansion in a single-quoted region inside the operator argument:
+        # the inner ${...} is NOT expanded, it is taken literally.
+        # Validated in bash 5.2: <pytest><-m><${MARKER:-not build}>
+        pytest.param(
+            "echo pytest ${SKIP_BUILD:+ -m '${MARKER:-not build}'}",
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "-m", "${MARKER:-not build}"],
+            id="alt_value_nested_single_quoted_literal",
+        ),
+        # A bare $VAR inside a single-quoted operator argument is literal.
+        # Validated in bash 5.2: <pytest><-m><$MARKER is empty>
+        pytest.param(
+            "echo pytest ${SKIP_BUILD:+ -m '$MARKER is empty'}",
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "-m", "$MARKER is empty"],
+            id="alt_value_dollar_in_single_quotes_literal",
+        ),
+        # Glob characters inside a quoted operator argument must not be expanded
+        # nor cause the token to be treated as a glob pattern.
+        # Validated in bash 5.2: <pytest><*.py>
+        pytest.param(
+            "echo pytest ${SKIP_BUILD:+ '*.py'}",
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "*.py"],
+            id="alt_value_quoted_glob_literal",
+        ),
+        # A tab inside a quoted operator argument is preserved verbatim, not
+        # collapsed to a space and not used as a word break.
+        # Validated in bash 5.2: <pytest><-m><a\tb>
+        pytest.param(
+            "echo pytest ${SKIP_BUILD:+ -m 'a\tb'}",
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "-m", "a\tb"],
+            id="alt_value_quoted_tab_preserved",
+        ),
+        # Quoted whitespace-only argument should produce a token containing
+        # exactly that whitespace, not a single collapsed space.
+        # Validated in bash 5.2: <pytest><  >
+        pytest.param(
+            "echo pytest ${SKIP_BUILD:+ '  '}",
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "  "],
+            id="alt_value_quoted_whitespace_only",
+        ),
+        #
+        # ---- Existing behavior captured as regression tests ----
+        #
+        # Outer-quoted expansion: the entire expansion is a single token.
+        # Validated in bash 5.2: <pytest><a b c>
+        pytest.param(
+            'echo pytest "${SKIP_BUILD:+a b c}"',
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "a b c"],
+            id="outer_quoted_expansion_single_token",
+        ),
+        # Unquoted whitespace inside an unquoted expansion is subject to word
+        # splitting, exactly as in bash.
+        # Validated in bash 5.2: <pytest><-m><not><build>
+        pytest.param(
+            "echo pytest ${SKIP_BUILD:+ -m not build}",
+            {"SKIP_BUILD": "1"},
+            ["echo", "pytest", "-m", "not", "build"],
+            id="alt_value_unquoted_word_split",
+        ),
+        # Empty :+ expansion (variable unset) drops the whole substitution.
+        # Validated in bash 5.2: <pytest>
+        pytest.param(
+            "echo pytest ${SKIP_BUILD:+ -m 'not build'}",
+            {},
+            ["echo", "pytest"],
+            id="alt_value_unset_drops_substitution",
+        ),
+    ],
+)
+def test_param_expansion_argument_tokenization(
+    cmd_content, env, expected_tokens, run_poe, temp_pyproject
+):
+    """
+    Verify that the tokenization of cmd tasks containing parameter expansion
+    operators (`${VAR:+...}` / `${VAR:-...}`) matches bash semantics, in
+    particular that quoted regions inside the operator argument suppress word
+    splitting and that quote characters themselves are stripped from the
+    resulting tokens.
+
+    Each expected_tokens value in this parametrization has been validated
+    against GNU bash 5.2 using `printf '<%s>' "$@"` to make token boundaries
+    visible.
+    """
+    project_toml = f"""
+    [tool.poe.tasks.run]
+    cmd = '''{cmd_content}'''
+    """
+    project_path = temp_pyproject(project_toml)
+    result = run_poe("run", cwd=project_path, env=env)
+
+    assert result.code == 0, (
+        f"poe exited with {result.code}\n"
+        f"capture: {result.capture!r}\n"
+        f"stderr:  {result.stderr!r}"
+    )
+    expected_capture = f"Poe => {shlex.join(expected_tokens)}\n"
+    assert result.capture == expected_capture, (
+        "cmd task tokenization should match bash semantics\n"
+        f"  cmd:      {cmd_content!r}\n"
+        f"  env:      {env!r}\n"
+        f"  expected: {expected_capture!r}\n"
+        f"  actual:   {result.capture!r}"
+    )

--- a/tests/test_cmd_param_expansion.py
+++ b/tests/test_cmd_param_expansion.py
@@ -149,6 +149,16 @@ def test_param_expansion_operations(
             ["echo", "pytest", "-m", "not build"],
             id="alt_value_nested_double_quoted",
         ),
+        # Nested operator expansion in an unquoted context: the inner
+        # ${B:+...} must also preserve its quoted regions, not just the
+        # outermost level. This validates that the fix composes recursively.
+        # Validated in bash 5.2: <echo><pytest><-m><not build>
+        pytest.param(
+            "echo pytest ${A:+ ${B:+ -m 'not build'}}",
+            {"A": "1", "B": "1"},
+            ["echo", "pytest", "-m", "not build"],
+            id="alt_value_nested_unquoted_operator",
+        ),
         # Nested expansion in a single-quoted region inside the operator argument:
         # the inner ${...} is NOT expanded, it is taken literally.
         # Validated in bash 5.2: <pytest><-m><${MARKER:-not build}>


### PR DESCRIPTION
## Summary

Fixes #333 — the alternate-value operator (`${VAR:+...}`) and default-value operator (`${VAR:-...}`) were stripping quotes from substituted values, causing incorrect word splitting.

For example, `${SKIP_BUILD:+ -m 'not build'}` produced three tokens (`-m`, `not`, `build`) instead of two (`-m`, `not build`).

## The fix

The root cause was in `resolve_command_tokens` (`helpers/command/__init__.py`). When a `:+` or `:-` operation applied, its argument was flattened to a plain string via `resolve_param_argument`, discarding the AST's quoting structure. The flat string was then word-split, breaking quoted content apart.

The fix changes `resolve_param_value` to return the `ParamArgument` AST node directly when an operation applies. In unquoted contexts, the argument's segments are processed inline via a new `resolve_argument_tokens` function that respects each segment's `is_quoted` property. In quoted contexts, the argument is still flattened to a string (matching bash behavior where outer quotes suppress word splitting).

The unquoted param value word-splitting logic was also extracted into `_emit_unquoted_param_value` to share between the main loop and argument processing.

## Tests

- **Integration tests** (`test_cmd_param_expansion.py`): 18 parametrized cases covering core regressions, edge cases (backslash escapes, nested expansions, literal `$` in single quotes, globs, tabs, whitespace-only), and existing behavior. Each validated against bash 5.2.
- **Unit tests** (`test_command_parsing.py`): 6 cases testing `resolve_command_tokens` directly for scenarios not covered by integration tests: `:-` not applied, expansion embedded in a word, nested expansion word-splitting, outer double quotes with nested `$`, nested `:-` inside `:+`, and empty alternate value.

## Docs

Added a note to `docs/tasks/task_types/cmd.rst` documenting that glob patterns inside `:-` and `:+` arguments are treated as literal text (a known divergence from bash).

## Pre-merge Checklist

- [x] New features (if any) are covered by new feature tests
- [x] Bug fixes (if any) are accompanied by a test (if not too complicated to do so)
- [x] This PR targets the *development* branch for code changes