### PR TITLE
fix: handle cancelled tasks correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - development
     tags:
       - v*
+  workflow_dispatch:
 
 jobs:
   code-quality:

--- a/poethepoet/executor/task_run.py
+++ b/poethepoet/executor/task_run.py
@@ -200,17 +200,18 @@ class PoeTaskRun:
     async def _watch_completion(self) -> None:
         await self.wait()
 
-        if not self.has_failure:
-            event = PoeTaskRunCompletion(self.name)
-        else:
-            event = PoeTaskRunError(
+        event = (
+            PoeTaskRunCompletion(self.name)
+            if not self.has_failure
+            else PoeTaskRunError(
                 self.name,
                 exception=(
                     None
                     if self.asyncio_task.cancelled()
                     else self.asyncio_task.exception()
-                )
+                ),
             )
+        )
 
         await self._notify_and_clear_done_callbacks(event)
         self._clear_completion_watcher()

--- a/poethepoet/executor/task_run.py
+++ b/poethepoet/executor/task_run.py
@@ -200,11 +200,17 @@ class PoeTaskRun:
     async def _watch_completion(self) -> None:
         await self.wait()
 
-        event = (
-            PoeTaskRunCompletion(self.name)
-            if not self.has_failure
-            else PoeTaskRunError(self.name, exception=self.asyncio_task.exception())
-        )
+        if not self.has_failure:
+            event = PoeTaskRunCompletion(self.name)
+        else:
+            event = PoeTaskRunError(
+                self.name,
+                exception=(
+                    None
+                    if self.asyncio_task.cancelled()
+                    else self.asyncio_task.exception()
+                )
+            )
 
         await self._notify_and_clear_done_callbacks(event)
         self._clear_completion_watcher()

--- a/poethepoet/executor/task_run.py
+++ b/poethepoet/executor/task_run.py
@@ -194,7 +194,7 @@ class PoeTaskRun:
 
     async def _handle_asyncio_task_done(self):
         await self.finalize()
-        if self.asyncio_task.exception():
+        if self.asyncio_task.cancelled() or self.asyncio_task.exception():
             await self.kill()
 
     async def _watch_completion(self) -> None:

--- a/tests/test_ignore_fail.py
+++ b/tests/test_ignore_fail.py
@@ -545,13 +545,14 @@ def test_ref_parallel_return_non_zero_ignore(generate_composed_pyproject, run_po
     project_path = generate_composed_pyproject()
     result = run_poe("ref_par_return_non_zero_ignore", cwd=project_path)
     assert result.code == 0, "Expected zero result"
-    assert (
-        "Warning: Subtasks 'child_fail_a', 'child_fail_b' returned non-zero exit status"
-        in result.capture
-    ) or (
-        "Warning: Subtasks 'child_fail_b', 'child_fail_a' returned non-zero exit status"
-        in result.capture
+    possible_msgs = (
+        "Warning: Subtasks 'child_fail_a', 'child_fail_b' returned non-zero exit status",  # noqa: E501
+        "Warning: Subtasks 'child_fail_b', 'child_fail_a' returned non-zero exit status",  # noqa: E501
+        # On Windows only one subtask may complete before the parallel task is aborted
+        "Warning: Subtask 'child_fail_a' returned non-zero exit status",
+        "Warning: Subtask 'child_fail_b' returned non-zero exit status",
     )
+    assert any(msg in result.capture for msg in possible_msgs)
 
 
 def test_task_graph_dep_ignore(generate_composed_pyproject, run_poe):

--- a/tests/test_parallel_tasks.py
+++ b/tests/test_parallel_tasks.py
@@ -201,10 +201,17 @@ def test_parallel_fail_all(run_poe_subproc, generate_pyproject, delay_factor):
             "Error: Parallel task 'lvl1_para' aborted after failed subtask 'fast_fail'",
         ],
     )
-    assert set(result.output_lines) == {
-        "fast_success | Great success!",
-        "fast_fail | failing fast with error",
-    }
+    assert set(result.output_lines) in (
+        {
+            "fast_success | Great success!",
+            "fast_fail | failing fast with error",
+        },
+        {  # Sometimes the task takes longer to quit and we get more output
+            "fast_success | Great success!",
+            "fast_fail | failing fast with error",
+            "slow_success | Eventual success!",
+        },
+    )
     assert result.code == 1
 
     result = run_poe_subproc("lvl2_seq", cwd=project_path)

--- a/tests/test_parallel_tasks.py
+++ b/tests/test_parallel_tasks.py
@@ -244,12 +244,19 @@ def test_parallel_fail_all(run_poe_subproc, generate_pyproject, delay_factor):
         ),
     )
 
+    # fast_success from lvl1_seq (running as a parallel subtask) may arrive before
+    # or after fast_fail depending on timing, so accept 2 or 3 fast_success lines.
     assert result.stdout.startswith(
         "Great success!\n"
         "fast_success | Great success!\n"
         "fast_success | Great success!\n"
         "fast_fail | failing fast with error\n"
-        # "fast_success | Great success!\n" # fast_success from lvl1_seq might get there
+    ) or result.stdout.startswith(
+        "Great success!\n"
+        "fast_success | Great success!\n"
+        "fast_success | Great success!\n"
+        "fast_success | Great success!\n"
+        "fast_fail | failing fast with error\n"
     )
     assert result.code == 1
 

--- a/tests/test_parallel_tasks.py
+++ b/tests/test_parallel_tasks.py
@@ -163,7 +163,6 @@ def generate_pyproject(temp_pyproject):
     return generator
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_parallel_fail_all(run_poe_subproc, generate_pyproject, delay_factor):
     slow_delay = 5 * 100 * delay_factor
     project_path = generate_pyproject(delay_factor=delay_factor)
@@ -209,8 +208,15 @@ def test_parallel_fail_all(run_poe_subproc, generate_pyproject, delay_factor):
     assert result.code == 1
 
     result = run_poe_subproc("lvl2_seq", cwd=project_path)
+
+    # Sporadically there are warnings like:
+    #    Warning: Exception while closing stdin for 25569: [Errno 32] Broken pipe
+    # These need to be filtered out, as it is timing dependent if they occur or not.
+    lvl2_seq_capture_lines = filter_capture_lines(
+        result.capture_lines, "Warning: Exception while closing stdin"
+    )
     assert sequences_are_similar(
-        result.capture_lines,
+        lvl2_seq_capture_lines,
         (
             "Poe => echo 'Great success!'",
             f"Poe => poe_test_delayed_echo {slow_delay} 'Eventual success!'",
@@ -224,7 +230,7 @@ def test_parallel_fail_all(run_poe_subproc, generate_pyproject, delay_factor):
             "     | From: ExecutionError(\"Parallel task 'lvl1_para' aborted after failed subtask 'fast_fail'\")",
         ),
     ) or sequences_are_similar(
-        result.capture_lines,
+        lvl2_seq_capture_lines,
         (
             "Poe => echo 'Great success!'",
             f"Poe => poe_test_delayed_echo {slow_delay} 'Eventual success!'",
@@ -248,8 +254,11 @@ def test_parallel_fail_all(run_poe_subproc, generate_pyproject, delay_factor):
     assert result.code == 1
 
     result = run_poe_subproc("lvl2_para", cwd=project_path)
+    lvl2_para_capture_lines = filter_capture_lines(
+        result.capture_lines, "Warning: Exception while closing stdin"
+    )
     assert sequences_are_similar(
-        result.capture_lines,
+        lvl2_para_capture_lines,
         (
             f"Poe => poe_test_delayed_echo {slow_delay} 'Eventual success!'",
             "Poe => echo 'Great success!'",
@@ -265,7 +274,7 @@ def test_parallel_fail_all(run_poe_subproc, generate_pyproject, delay_factor):
             "Error: Parallel task 'lvl2_para' aborted after failed subtask 'lvl2_seq'",
         ),
     ) or sequences_are_similar(
-        result.capture_lines,
+        lvl2_para_capture_lines,
         (
             f"Poe => poe_test_delayed_echo {slow_delay} 'Eventual success!'",
             "Poe => echo 'Great success!'",
@@ -550,6 +559,12 @@ def test_parallel_bool_negate(run_poe):
     result = run_poe("bool_parallel", "--val", project="parallel")
     assert "cmd:unset:unset" in result.stdout
     assert "{'flag': False, 'val': False}" in result.stdout
+
+
+def filter_capture_lines(capture_lines: list[str], *prefixes: str) -> list[str]:
+    return [
+        line for line in capture_lines if not any(line.startswith(p) for p in prefixes)
+    ]
 
 
 def sequences_are_similar(seq1: Sequence, seq2: Sequence, distance: int = 1):


### PR DESCRIPTION
## Description of changes
When working on https://github.com/nat-n/poethepoet/pull/375 I had a sporadic CI error in `test_parallel_fail_all` that was unrelated to my changes (see [this pipeline run](https://github.com/nat-n/poethepoet/actions/runs/24188199358/job/70935014348?pr=375)). So I started investigating and found this error:

According to [the `asyncio.Task.exception` docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.exception)

> If the Task has been cancelled, this method raises a CancelledError exception.

So it is necessary to check for cancelled task before accessing the exception object.

With this change I cannot reproduce this error on my Mac in 100 pytest runs with

```
for i in $(seq 100); do pytest tests/test_parallel_tasks.py::test_parallel_fail_all -x || break; done
```

So I removed the flaky marker for this test. Maybe some other flaky markers are now also obsolet, but `test_parallel_fail_all` was the only one I could reproduce locally before my change and cant reproduce after it.

## Pre-merge Checklist

- [ ] New features (if any) are covered by new feature tests
- [ ] New features (if any) are documented
- [ ] Bug fixes (if any) are accompanied by a test (if not too complicated to do so)
- [x] `poe check` executed successfully
- [x] This PR targets the *development* branch for code changes or *main* if only documentation is updated
