### PR TITLE
feat: add support for forwarding free arguments via $POE_EXTRA_ARGS

### DIFF
--- a/docs/guides/args_guide.rst
+++ b/docs/guides/args_guide.rst
@@ -334,3 +334,87 @@ will result in poe parsing the target_dir cli option, but appending the :sh:`--f
 .. note::
 
    Passing :sh:`--` in the arguments list to any other task type will simply result in any subsequent arguments being ignored.
+
+
+.. _forwarding-free-arguments-via-poe-extra-args:
+
+Forwarding free arguments via ``$POE_EXTRA_ARGS``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a task receives free arguments (i.e. arguments not matched by any named arg definition, or arguments passed after :sh:`--`), poe sets a special environment variable ``$POE_EXTRA_ARGS`` containing those arguments as a shell-quoted, space-delimited string. This variable is inherited by all subtasks and can be referenced explicitly wherever an environment variable can be used.
+
+``$POE_EXTRA_ARGS`` can be used in any task type that supports environment variable expansion: :doc:`cmd<../tasks/task_types/cmd>`, :doc:`ref<../tasks/task_types/ref>`, :doc:`shell<../tasks/task_types/shell>`. In :doc:`script<../tasks/task_types/script>` and :doc:`expr<../tasks/task_types/expr>` tasks free arguments are also accessible as the ``_extra_args`` variable (a ``list[str]``).
+
+
+Sequence, parallel and switch tasks
+""""""""""""""""""""""""""""""""""""
+
+Free arguments passed to a :doc:`sequence<../tasks/task_types/sequence>`, :doc:`parallel<../tasks/task_types/parallel>`, or :doc:`switch<../tasks/task_types/switch>` task are not forwarded to subtasks automatically. By referencing ``$POE_EXTRA_ARGS`` in individual subtask definitions you can choose which subtasks in the group receive the extra arguments:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.test-py39]
+  cmd = "pytest tests"
+  executor = { type = "uv", isolated = true, python = "3.9" }
+
+  [tool.poe.tasks.test-py310]
+  cmd = "pytest tests"
+  executor = { type = "uv", isolated = true, python = "3.10" }
+
+  [tool.poe.tasks.lint]
+  cmd = "ruff check ."
+
+  [tool.poe.tasks.test-all]
+  sequence = ["test-py39 $POE_EXTRA_ARGS", "test-py310 $POE_EXTRA_ARGS", "lint"]
+
+Calling this like:
+
+.. code-block:: sh
+
+  poe test-all --cov=mypackage -v
+
+forwards ``--cov=mypackage -v`` to ``test-py39`` and ``test-py310``, but not to ``lint``.
+
+``$POE_EXTRA_ARGS`` can appear anywhere in the subtask command string — including between other arguments — so it is possible to add fixed options before *and* after the forwarded arguments:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.test-all]
+  sequence = [
+    "test-py39 --timeout=30 $POE_EXTRA_ARGS --tb=short",
+    "test-py310 --timeout=30 $POE_EXTRA_ARGS --tb=short",
+    "lint",
+  ]
+
+
+Cmd tasks
+"""""""""
+
+For :doc:`cmd<../tasks/task_types/cmd>` tasks, free arguments are appended to the end of the command by default. By referencing ``$POE_EXTRA_ARGS`` explicitly in the command string, poe expands it in place and does *not* additionally append the extra args at the end. This is useful when fixed options must follow the free arguments:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.coverage]
+  cmd = "pytest $POE_EXTRA_ARGS --cov=mypackage"
+
+Calling :sh:`poe coverage tests/unit -x` produces ``pytest tests/unit -x --cov=mypackage`` instead of ``pytest --cov=mypackage tests/unit -x``.
+
+
+Script and expr tasks
+"""""""""""""""""""""
+
+In :doc:`script<../tasks/task_types/script>` tasks free arguments are available as the ``_extra_args`` variable (a ``list[str]``) that can be referenced directly in the function call expression:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.run-tests]
+  script = "pytest:main(_extra_args)"
+
+Calling :sh:`poe run-tests tests/unit -x -v` will call ``pytest.main(["tests/unit", "-x", "-v"])``.
+
+:doc:`Expr<../tasks/task_types/expr>` tasks work the same way — ``_extra_args`` is available as a Python variable inside the expression:
+
+.. code-block:: toml
+
+  [tool.poe.tasks.count-args]
+  expr = "len(_extra_args)"

--- a/docs/tasks/task_types/cmd.rst
+++ b/docs/tasks/task_types/cmd.rst
@@ -154,3 +154,11 @@ You can also ignore task failures just in case of one or more specific exit code
   [tool.poe.tasks.serve]
   cmd        = "pytest"
   ignore_fail = [4, 5] # don't fail if no tests are found
+
+
+Controlling placement of free arguments via ``$POE_EXTRA_ARGS``
+---------------------------------------------------------------
+
+By default, any free arguments passed to a ``cmd`` task are appended to the end of the command. However, if you reference ``$POE_EXTRA_ARGS`` explicitly in the command string, poe will expand it in place instead, and *not* additionally append the extra args at the end. This is useful when fixed options must follow the free arguments.
+
+See the :ref:`forwarding-free-arguments-via-poe-extra-args` section of the args guide for details and examples.

--- a/docs/tasks/task_types/expr.rst
+++ b/docs/tasks/task_types/expr.rst
@@ -120,6 +120,14 @@ Expr tasks can reference the results of other tasks by leveraging the :doc:`uses
   imports = ["json"]
 
 
+Accessing free arguments via ``_extra_args``
+--------------------------------------------
+
+Free arguments (arguments not matched by any named arg definition, or arguments passed after :sh:`--`) are available inside expr tasks as the ``_extra_args`` variable — a ``list[str]``.
+
+See the :ref:`forwarding-free-arguments-via-poe-extra-args` section of the args guide for details and examples.
+
+
 .. |sys_module_link| raw:: html
 
    <a href="https://docs.python.org/3/library/sys.html" target="_blank">sys module</a>

--- a/docs/tasks/task_types/parallel.rst
+++ b/docs/tasks/task_types/parallel.rst
@@ -87,6 +87,14 @@ Alternatively you can declare other task types inline like so:
   An array within a parallel task is interpreted as a :doc:`sequence<sequence>` task, so you can run certain parallel subtasks :ref:`with strict ordering<Composing tasks to run in parallel>`.
 
 
+Forwarding free arguments to subtasks
+--------------------------------------
+
+By default, free arguments passed to a parallel task are not forwarded to any of its subtasks. However, they can be forwarded selectively by referencing the special ``$POE_EXTRA_ARGS`` environment variable in individual subtask definitions. Only subtasks that explicitly reference ``$POE_EXTRA_ARGS`` will receive them.
+
+See the :ref:`forwarding-free-arguments-via-poe-extra-args` section of the args guide for details and examples.
+
+
 Customize output prefixing
 --------------------------
 
@@ -129,7 +137,7 @@ For example:
 
 will result in output rendered like:
 
-.. code-block::
+.. code-block:: text
 
   [1:build] first task output line
   [2:test] second task output line

--- a/docs/tasks/task_types/script.rst
+++ b/docs/tasks/task_types/script.rst
@@ -127,3 +127,11 @@ As with other task types, script tasks support configuring named arguments via t
 - As **keyword arguments** when the script reference doesn't include explicit parentheses — in this case all declared args are passed as kwargs.
 
 See :ref:`Arguments for script tasks` for more details and examples.
+
+
+Accessing free arguments via ``_extra_args``
+--------------------------------------------
+
+Free arguments (arguments not matched by any named arg definition, or arguments passed after :sh:`--`) are available inside script tasks as the ``_extra_args`` variable — a ``list[str]`` — in addition to the ``$POE_EXTRA_ARGS`` environment variable.
+
+See the :ref:`forwarding-free-arguments-via-poe-extra-args` section of the args guide for details and examples.

--- a/docs/tasks/task_types/sequence.rst
+++ b/docs/tasks/task_types/sequence.rst
@@ -104,6 +104,14 @@ When declaring more complex sequences the following syntax is often preferred.
   Note that tasks defined inline within a sequence may not include some options that would otherwise be available to them, for example ``help`` and ``args`` are forbidden because they don't make sense in this context.
 
 
+Forwarding free arguments to subtasks
+--------------------------------------
+
+By default, free arguments passed to a sequence task are not forwarded to any of its subtasks. However, they can be forwarded selectively by referencing the special ``$POE_EXTRA_ARGS`` environment variable in individual subtask definitions. Only subtasks that explicitly reference ``$POE_EXTRA_ARGS`` will receive them.
+
+See the :ref:`forwarding-free-arguments-via-poe-extra-args` section of the args guide for details and examples.
+
+
 Sequence task as an array of inline tables
 ------------------------------------------
 

--- a/docs/tasks/task_types/shell.rst
+++ b/docs/tasks/task_types/shell.rst
@@ -113,3 +113,11 @@ See the :doc:`args guide<../../guides/args_guide>` for full details on configuri
 .. warning::
 
   Unlike cmd, script, or expr tasks, shell tasks only access variables from the environment at runtime via the shell interpreter. Therefore ``_private`` environment variables cannot be accessed from shell task content, unless they are remapped to a normal environment variable via the ``env`` option.
+
+
+Accessing free arguments via ``$POE_EXTRA_ARGS``
+------------------------------------------------
+
+Free arguments (arguments not matched by any named arg definition, or arguments passed after :sh:`--`) are available inside shell task scripts as the ``$POE_EXTRA_ARGS`` environment variable. The value is a shell-quoted, space-delimited string, ready to be expanded inline.
+
+See the :ref:`forwarding-free-arguments-via-poe-extra-args` section of the args guide for details and examples.

--- a/docs/tasks/task_types/switch.rst
+++ b/docs/tasks/task_types/switch.rst
@@ -126,3 +126,11 @@ So running this task would look like:
   Poe <= flavor
   Poe => make_chocolate_icecream
   ...
+
+
+Forwarding free arguments via ``$POE_EXTRA_ARGS``
+-------------------------------------------------
+
+Free arguments passed to a switch task are available as ``$POE_EXTRA_ARGS`` and are inherited by the selected subtask. This makes it possible to forward arbitrary extra arguments to whichever branch is executed.
+
+See the :ref:`forwarding-free-arguments-via-poe-extra-args` section of the args guide for details and examples.

--- a/poethepoet/env/task_env.py
+++ b/poethepoet/env/task_env.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 from collections.abc import (
     Callable,
     Iterable,
@@ -188,9 +189,13 @@ class TaskEnv(Mapping[str, str]):
                 self._private_vars.add(key)
             self._env_vars[key] = val
 
-    def register_task_args(self, args: Mapping[str, Any]):
+    def register_task_args(self, args: Mapping[str, Any], extra_args: Sequence[str]):
         """
         Track typed argument variables, and map to env vars.
+
+        extra_args are stored as a private _extra_args list (accessible in script &
+        expr tasks) and as POE_EXTRA_ARGS env var (accessible in all tasks as a
+        shell-quoted, space-delimited string), but only if non-empty.
         """
         for key, value in args.items():
             self._arg_vars[key] = value
@@ -202,6 +207,11 @@ class TaskEnv(Mapping[str, str]):
                 self.set(key, " ".join(str(item) for item in value))
             else:
                 self.set(key, str(value))
+
+        if extra_args:
+            self._arg_vars["_extra_args"] = list(extra_args)
+            self._private_vars.add("_extra_args")
+            self._env_vars["POE_EXTRA_ARGS"] = shlex.join(extra_args)
 
     def apply_env_config(
         self,

--- a/poethepoet/helpers/script.py
+++ b/poethepoet/helpers/script.py
@@ -44,8 +44,13 @@ def parse_script_reference(
         raise ExpressionParseError(f"Invalid script reference: {script_ref.strip()!r}")
 
     if target_ref.isidentifier():
-        if parsed_args:
-            function_call = FunctionCall(f"{target_ref}(**({parsed_args}))", target_ref)
+        # _extra_args is framework-managed; exclude it from auto-kwargs so it
+        # doesn't pollute functions that use no explicit arg list
+        auto_kwargs = {
+            k: v for k, v in (parsed_args or {}).items() if k != "_extra_args"
+        }
+        if auto_kwargs:
+            function_call = FunctionCall(f"{target_ref}(**({auto_kwargs}))", target_ref)
         else:
             function_call = FunctionCall(f"{target_ref}()", target_ref)
     else:

--- a/poethepoet/task/base.py
+++ b/poethepoet/task/base.py
@@ -443,6 +443,17 @@ class PoeTask(metaclass=MetaPoeTask):
 
         return None
 
+    def _content_uses_extra_args(self) -> bool:
+        """
+        Check if task content explicitly references $POE_EXTRA_ARGS.
+
+        If the content includes a reference to $POE_EXTRA_ARGS that means that the
+        task content is already designed to include extra arguments, and that we
+        should not append extra arguments automatically to the end of the content.
+        """
+        content = self.spec.content
+        return "$POE_EXTRA_ARGS" in content or "${POE_EXTRA_ARGS" in content
+
     def get_parsed_arguments(
         self, env: TaskEnv
     ) -> tuple[dict[str, Any], tuple[str, ...]]:

--- a/poethepoet/task/base.py
+++ b/poethepoet/task/base.py
@@ -586,7 +586,8 @@ class PoeTask(metaclass=MetaPoeTask):
 
         if self.__upstream_invocations is None:
             env = self.spec.get_task_env(context.env, io=self.ctx.io)
-            env.register_task_args(self.get_parsed_arguments(env)[0])
+            parsed_args, extra_args = self.get_parsed_arguments(env)
+            env.register_task_args(parsed_args, extra_args)
 
             self.__upstream_invocations = {
                 "deps": [

--- a/poethepoet/task/cmd.py
+++ b/poethepoet/task/cmd.py
@@ -64,7 +64,7 @@ class CmdTask(PoeTask):
 
         executor = self._get_executor(context, env)
 
-        if "POE_EXTRA_ARGS" in self.spec.content:
+        if self._content_uses_extra_args():
             cmd = tuple(self._resolve_commandline(context, env))
         else:
             cmd = (*self._resolve_commandline(context, env), *extra_args)

--- a/poethepoet/task/cmd.py
+++ b/poethepoet/task/cmd.py
@@ -60,11 +60,14 @@ class CmdTask(PoeTask):
             task_state.ignore_failure(ignore_fail)
 
         named_arg_values, extra_args = self.get_parsed_arguments(env)
-        env.register_task_args(named_arg_values)
+        env.register_task_args(named_arg_values, extra_args)
 
         executor = self._get_executor(context, env)
 
-        cmd = (*self._resolve_commandline(context, env), *extra_args)
+        if "POE_EXTRA_ARGS" in self.spec.content:
+            cmd = tuple(self._resolve_commandline(context, env))
+        else:
+            cmd = (*self._resolve_commandline(context, env), *extra_args)
 
         self._print_action(shlex.join(cmd), context.dry)
 

--- a/poethepoet/task/expr.py
+++ b/poethepoet/task/expr.py
@@ -63,8 +63,8 @@ class ExprTask(PoeTask):
         if ignore_fail := self.spec.options.ignore_fail:
             task_state.ignore_failure(ignore_fail)
 
-        named_arg_values, _ = self.get_parsed_arguments(env)
-        env.register_task_args(named_arg_values)
+        named_arg_values, extra_args = self.get_parsed_arguments(env)
+        env.register_task_args(named_arg_values, extra_args)
         named_arg_values = env.get_args()
 
         imports = self.spec.options.imports

--- a/poethepoet/task/parallel.py
+++ b/poethepoet/task/parallel.py
@@ -172,13 +172,6 @@ class ParallelTask(PoeTask):
         named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.register_task_args(named_arg_values, extra_args)
 
-        if (
-            not named_arg_values
-            and not extra_args
-            and any(arg.strip() for arg in self.invocation[1:])
-        ):
-            raise PoeException(f"Parallel task {self.name!r} does not accept arguments")
-
         if len(self._subtasks) > 1:
             # Indicate on the global context that there are multiple stages
             context.multistage = True

--- a/poethepoet/task/parallel.py
+++ b/poethepoet/task/parallel.py
@@ -169,10 +169,14 @@ class ParallelTask(PoeTask):
     async def _handle_run(
         self, context: RunContext, env: TaskEnv, task_state: PoeTaskRun
     ):
-        named_arg_values, _ = self.get_parsed_arguments(env)
-        env.register_task_args(named_arg_values)
+        named_arg_values, extra_args = self.get_parsed_arguments(env)
+        env.register_task_args(named_arg_values, extra_args)
 
-        if not named_arg_values and any(arg.strip() for arg in self.invocation[1:]):
+        if (
+            not named_arg_values
+            and not extra_args
+            and any(arg.strip() for arg in self.invocation[1:])
+        ):
             raise PoeException(f"Parallel task {self.name!r} does not accept arguments")
 
         if len(self._subtasks) > 1:

--- a/poethepoet/task/ref.py
+++ b/poethepoet/task/ref.py
@@ -88,7 +88,7 @@ class RefTask(PoeTask):
         invocation_tokens = tuple(
             env.fill_template(token) for token in shlex.split(expanded_content)
         )
-        if "POE_EXTRA_ARGS" in self.spec.content:
+        if self._content_uses_extra_args():
             ref_invocation = invocation_tokens
         else:
             ref_invocation = (*invocation_tokens, *extra_args)

--- a/poethepoet/task/ref.py
+++ b/poethepoet/task/ref.py
@@ -82,15 +82,16 @@ class RefTask(PoeTask):
             task_state.ignore_failure(ignore_fail)
 
         named_arg_values, extra_args = self.get_parsed_arguments(env)
-        env.register_task_args(named_arg_values)
+        env.register_task_args(named_arg_values, extra_args)
 
-        ref_invocation = (
-            *(
-                env.fill_template(token)
-                for token in shlex.split(env.fill_template(self.spec.content.strip()))
-            ),
-            *extra_args,
+        expanded_content = env.fill_template(self.spec.content.strip())
+        invocation_tokens = tuple(
+            env.fill_template(token) for token in shlex.split(expanded_content)
         )
+        if "POE_EXTRA_ARGS" in self.spec.content:
+            ref_invocation = invocation_tokens
+        else:
+            ref_invocation = (*invocation_tokens, *extra_args)
 
         task_spec = self.ctx.specs.get(ref_invocation[0])
         task = task_spec.create_task(

--- a/poethepoet/task/script.py
+++ b/poethepoet/task/script.py
@@ -66,11 +66,9 @@ class ScriptTask(PoeTask):
         if ignore_fail := self.spec.options.ignore_fail:
             task_state.ignore_failure(ignore_fail)
 
-        named_arg_values, _ = self.get_parsed_arguments(env)
-        env.register_task_args(named_arg_values)
+        named_arg_values, extra_args = self.get_parsed_arguments(env)
+        env.register_task_args(named_arg_values, extra_args)
         named_arg_values = env.get_args()
-
-        # TODO: do something about extra_args, like raise an error?
 
         if ":" not in self.spec.content:
             return await self._run_module(context, env, task_state)

--- a/poethepoet/task/sequence.py
+++ b/poethepoet/task/sequence.py
@@ -143,13 +143,6 @@ class SequenceTask(PoeTask):
         named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.register_task_args(named_arg_values, extra_args)
 
-        if (
-            not named_arg_values
-            and not extra_args
-            and any(arg.strip() for arg in self.invocation[1:])
-        ):
-            raise PoeException(f"Sequence task {self.name!r} does not accept arguments")
-
         if len(self._subtasks) > 1:
             # Indicate on the global context that there are multiple stages
             context.multistage = True

--- a/poethepoet/task/sequence.py
+++ b/poethepoet/task/sequence.py
@@ -140,10 +140,14 @@ class SequenceTask(PoeTask):
     async def _handle_run(
         self, context: RunContext, env: TaskEnv, task_state: PoeTaskRun
     ):
-        named_arg_values, _ = self.get_parsed_arguments(env)
-        env.register_task_args(named_arg_values)
+        named_arg_values, extra_args = self.get_parsed_arguments(env)
+        env.register_task_args(named_arg_values, extra_args)
 
-        if not named_arg_values and any(arg.strip() for arg in self.invocation[1:]):
+        if (
+            not named_arg_values
+            and not extra_args
+            and any(arg.strip() for arg in self.invocation[1:])
+        ):
             raise PoeException(f"Sequence task {self.name!r} does not accept arguments")
 
         if len(self._subtasks) > 1:

--- a/poethepoet/task/shell.py
+++ b/poethepoet/task/shell.py
@@ -71,15 +71,6 @@ class ShellTask(PoeTask):
         named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.register_task_args(named_arg_values, extra_args)
 
-        if (
-            not named_arg_values
-            and "POE_EXTRA_ARGS" not in self.spec.content
-            and any(arg.strip() for arg in self.invocation[1:])
-        ):
-            raise PoeException(
-                f"Shell task {self.spec.name!r} does not accept arguments"
-            )
-
         interpreter_cmd = self.resolve_interpreter_cmd()
         if not interpreter_cmd:
             config_value = self._get_interpreter_config()

--- a/poethepoet/task/shell.py
+++ b/poethepoet/task/shell.py
@@ -68,10 +68,14 @@ class ShellTask(PoeTask):
         if ignore_fail := self.spec.options.ignore_fail:
             task_state.ignore_failure(ignore_fail)
 
-        named_arg_values, _ = self.get_parsed_arguments(env)
-        env.register_task_args(named_arg_values)
+        named_arg_values, extra_args = self.get_parsed_arguments(env)
+        env.register_task_args(named_arg_values, extra_args)
 
-        if not named_arg_values and any(arg.strip() for arg in self.invocation[1:]):
+        if (
+            not named_arg_values
+            and "POE_EXTRA_ARGS" not in self.spec.content
+            and any(arg.strip() for arg in self.invocation[1:])
+        ):
             raise PoeException(
                 f"Shell task {self.spec.name!r} does not accept arguments"
             )

--- a/poethepoet/task/switch.py
+++ b/poethepoet/task/switch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
-from ..exceptions import ConfigValidationError, ExecutionError, PoeException
+from ..exceptions import ConfigValidationError, ExecutionError
 from .base import PoeTask, TaskContext
 
 if TYPE_CHECKING:
@@ -201,13 +201,6 @@ class SwitchTask(PoeTask):
     ):
         named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.register_task_args(named_arg_values, extra_args)
-
-        if (
-            not named_arg_values
-            and not extra_args
-            and any(arg.strip() for arg in self.invocation[1:])
-        ):
-            raise PoeException(f"Switch task {self.name!r} does not accept arguments")
 
         # Indicate on the global context that there are multiple stages to this task
         context.multistage = True

--- a/poethepoet/task/switch.py
+++ b/poethepoet/task/switch.py
@@ -199,10 +199,14 @@ class SwitchTask(PoeTask):
     async def _handle_run(
         self, context: RunContext, env: TaskEnv, task_state: PoeTaskRun
     ):
-        named_arg_values, _ = self.get_parsed_arguments(env)
-        env.register_task_args(named_arg_values)
+        named_arg_values, extra_args = self.get_parsed_arguments(env)
+        env.register_task_args(named_arg_values, extra_args)
 
-        if not named_arg_values and any(arg.strip() for arg in self.invocation[1:]):
+        if (
+            not named_arg_values
+            and not extra_args
+            and any(arg.strip() for arg in self.invocation[1:])
+        ):
             raise PoeException(f"Switch task {self.name!r} does not accept arguments")
 
         # Indicate on the global context that there are multiple stages to this task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ ignore_messages  = [
   "Hyperlink target \"ref-env-vars\" is not referenced.",
   "Hyperlink target \"sequence-composition\" is not referenced.",
   "Hyperlink target \"graph-composition\" is not referenced.",
+  "Hyperlink target \"forwarding-free-arguments-via-poe-extra-args\" is not referenced.",
   "No directive entry for \"autoclass\" in module \"docutils.parsers.rst.languages.en\""
 ]
 ignore_directives = [

--- a/tests/fixtures/cmds_project/pyproject.toml
+++ b/tests/fixtures/cmds_project/pyproject.toml
@@ -121,3 +121,13 @@ args = ["_secret", "_PUBLIC"]
 [tool.poe.tasks.private_explicit_option]
 cmd = "poe_test_echo ${_secret}"
 args = [{ name = "_secret", options = ["--_secret"] }]
+
+[tool.poe.tasks.echo-extra-args]
+cmd = "poe_test_echo extra: $POE_EXTRA_ARGS"
+
+[tool.poe.tasks.echo-extra-args-trailing]
+cmd = "poe_test_echo before: $POE_EXTRA_ARGS :after"
+
+[tool.poe.tasks.echo-extra-args-with-named]
+cmd = "poe_test_echo ${prefix} extra: $POE_EXTRA_ARGS"
+args = [{ name = "prefix", default = "result" }]

--- a/tests/fixtures/expr_project/pyproject.toml
+++ b/tests/fixtures/expr_project/pyproject.toml
@@ -83,3 +83,10 @@ args = [
 [tool.poe.tasks.bool_env_access_expr]
 expr = "{'typed': MY_FLAG, 'templated': ([${MY_FLAG}] or [''])[0]}"
 args = [{ name = "MY_FLAG", type = "boolean", default = true }]
+
+[tool.poe.tasks.count-extra-args]
+expr = "len(_extra_args)"
+
+[tool.poe.tasks.label-extra-args]
+expr = "f'{label}: {_extra_args}'"
+args = [{ name = "label", default = "Files" }]

--- a/tests/fixtures/parallel_project/pyproject.toml
+++ b/tests/fixtures/parallel_project/pyproject.toml
@@ -74,3 +74,19 @@ parallel = [
   { cmd = "poe_test_echo \"3 going to the void\"", capture_stdout = "/dev/null" },
   { cmd = "poe_test_echo \"4 going to stdout 4\"" },
 ]
+
+[tool.poe.tasks.echo-extra]
+cmd = "poe_test_echo extra: $POE_EXTRA_ARGS"
+
+[tool.poe.tasks.extra-args-parallel]
+parallel = [
+  "echo-extra $POE_EXTRA_ARGS",
+  "words-of-wisdom",
+]
+
+[tool.poe.tasks.extra-args-parallel-trailing]
+parallel = [
+  "echo-extra before $POE_EXTRA_ARGS after",
+  "words-of-wisdom",
+]
+

--- a/tests/fixtures/scripts_project/pyproject.toml
+++ b/tests/fixtures/scripts_project/pyproject.toml
@@ -282,6 +282,9 @@ args = [
 script = """pkg:echo_script(typed=MY_FLAG, present=('MY_FLAG' in environ), value=(environ['MY_FLAG'] if 'MY_FLAG' in environ else None))"""
 args = [{ name = "MY_FLAG", type = "boolean", default = true }]
 
+[tool.poe.tasks.echo-extra-args-script]
+script = "pkg:describe_args(*_extra_args)"
+
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/tests/fixtures/sequences_project/pyproject.toml
+++ b/tests/fixtures/sequences_project/pyproject.toml
@@ -141,3 +141,18 @@ args = [{ name = "_secret", default = "hidden" }]
 sequence = [
   { cmd = "poe_test_env", env = { public = "${_secret}" } },
 ]
+
+[tool.poe.tasks.echo-args]
+cmd = "poe_test_echo $POE_EXTRA_ARGS"
+
+[tool.poe.tasks.extra-args-via-ref]
+sequence = ["echo-args $POE_EXTRA_ARGS", "say --thing done"]
+
+[tool.poe.tasks.extra-args-trailing]
+sequence = ["echo-args before $POE_EXTRA_ARGS after", "say --thing done"]
+
+[tool.poe.tasks.extra-args-via-env]
+sequence = [
+  { cmd = "poe_test_echo ${POE_EXTRA_ARGS}" },
+  "say --thing done",
+]

--- a/tests/fixtures/shells_project/pyproject.toml
+++ b/tests/fixtures/shells_project/pyproject.toml
@@ -110,3 +110,10 @@ $fallback = if ($null -ne $env:MY_FLAG) { $env:MY_FLAG } else { "fallback" }
 poe_test_echo "$present|$value|$fallback"
 """
 args = [{ name = "MY_FLAG", type = "boolean", default = true }]
+
+[tool.poe.tasks.echo-extra-args]
+shell = "poe_test_echo $target $POE_EXTRA_ARGS"
+args = [{ name = "target", default = "default" }]
+
+[tool.poe.tasks.echo-extra-args-no-named]
+shell = "poe_test_echo $POE_EXTRA_ARGS"

--- a/tests/fixtures/switch_project/pyproject.toml
+++ b/tests/fixtures/switch_project/pyproject.toml
@@ -120,6 +120,26 @@ args = [
   [[tool.poe.tasks.booleans-cmd.switch]]
   expr = """{'non':non, 'tru':tru, 'fal':fal, 'txt':txt}"""
 
+[tool.poe.tasks.echo-extra-branch]
+control.cmd = "poe_test_echo match"
+
+  [[tool.poe.tasks.echo-extra-branch.switch]]
+  case = "match"
+  cmd = "poe_test_echo matched: $POE_EXTRA_ARGS"
+
+  [[tool.poe.tasks.echo-extra-branch.switch]]
+  cmd = "poe_test_echo default: $POE_EXTRA_ARGS"
+
+[tool.poe.tasks.echo-extra-branch-trailing]
+control.cmd = "poe_test_echo match"
+
+  [[tool.poe.tasks.echo-extra-branch-trailing.switch]]
+  case = "match"
+  cmd = "poe_test_echo before: $POE_EXTRA_ARGS :after"
+
+  [[tool.poe.tasks.echo-extra-branch-trailing.switch]]
+  cmd = "poe_test_echo default: $POE_EXTRA_ARGS :after"
+
 [tool.poe.tasks.booleans-expr]
 control.expr = "tru"
 args = [

--- a/tests/test_cmd_tasks.py
+++ b/tests/test_cmd_tasks.py
@@ -444,3 +444,34 @@ def test_multi_value_provided_empty(run_poe):
     """Multiple arg provided with no values (--items with nothing): env var is unset"""
     result = run_poe("multi_value_env", "--items", project="cmds")
     assert result.stdout.strip() == "False None"
+
+
+def test_cmd_task_with_poe_extra_args(run_poe):
+    """A cmd task referencing $POE_EXTRA_ARGS expands them rather than appending"""
+    result = run_poe("echo-extra-args", "foo", "bar", project="cmds")
+    assert result.capture == "Poe => poe_test_echo extra: foo bar\n"
+    assert result.stdout == "extra: foo bar\n"
+    assert result.stderr == ""
+
+
+def test_cmd_task_with_poe_extra_args_and_named_arg(run_poe):
+    """A cmd task with both named args and $POE_EXTRA_ARGS references works correctly"""
+    result = run_poe(
+        "echo-extra-args-with-named",
+        "--prefix=hello",
+        "--",
+        "foo",
+        "bar",
+        project="cmds",
+    )
+    assert result.capture == "Poe => poe_test_echo hello extra: foo bar\n"
+    assert result.stdout == "hello extra: foo bar\n"
+    assert result.stderr == ""
+
+
+def test_cmd_task_with_poe_extra_args_and_trailing_args(run_poe):
+    """$POE_EXTRA_ARGS in a cmd task can have args both before and after"""
+    result = run_poe("echo-extra-args-trailing", "foo", "bar", project="cmds")
+    assert result.capture == "Poe => poe_test_echo before: foo bar :after\n"
+    assert result.stdout == "before: foo bar :after\n"
+    assert result.stderr == ""

--- a/tests/test_expr_task.py
+++ b/tests/test_expr_task.py
@@ -161,3 +161,21 @@ def test_expr_env_access_uses_typed_and_templated_channels(run_poe):
 def test_expr_env_access_unset_bool_arg_preserves_typed_false(run_poe):
     result = run_poe("bool_env_access_expr", "--MY_FLAG", project="expr")
     assert result.stdout == "{'typed': False, 'templated': ''}\n"
+
+
+def test_expr_task_extra_args_available_as_list(run_poe):
+    """Free args are available as _extra_args (list[str]) in expr tasks"""
+    result = run_poe("count-extra-args", "foo", "bar", "baz", project="expr")
+    assert result.capture == "Poe => len(_extra_args)\n"
+    assert result.stdout == "3\n"
+    assert result.stderr == ""
+
+
+def test_expr_task_extra_args_combined_with_named_arg(run_poe):
+    """_extra_args can be used alongside named args in expr tasks"""
+    result = run_poe(
+        "label-extra-args", "--label=Sources", "--", "a.py", "b.py", project="expr"
+    )
+    assert result.capture == "Poe => f'{label}: {_extra_args}'\n"
+    assert result.stdout == "Sources: ['a.py', 'b.py']\n"
+    assert result.stderr == ""

--- a/tests/test_ignore_fail.py
+++ b/tests/test_ignore_fail.py
@@ -534,11 +534,14 @@ def test_ref_parallel_return_non_zero(generate_composed_pyproject, run_poe):
     project_path = generate_composed_pyproject()
     result = run_poe("ref_par_return_non_zero", cwd=project_path)
     assert result.code == 1, "Expected non-zero result"
-    assert "Subtasks 'child_fail_a', 'child_fail_b' returned non-zero exit status" in (
-        result.capture
-    ) or "Subtasks 'child_fail_b', 'child_fail_a' returned non-zero exit status" in (
-        result.capture
+    possible_msgs = (
+        "Subtasks 'child_fail_a', 'child_fail_b' returned non-zero exit status",
+        "Subtasks 'child_fail_b', 'child_fail_a' returned non-zero exit status",
+        # Only one subtask may complete before the parallel task is aborted
+        "Subtask 'child_fail_a' returned non-zero exit status",
+        "Subtask 'child_fail_b' returned non-zero exit status",
     )
+    assert any(msg in result.capture for msg in possible_msgs)
 
 
 def test_ref_parallel_return_non_zero_ignore(generate_composed_pyproject, run_poe):

--- a/tests/test_parallel_tasks.py
+++ b/tests/test_parallel_tasks.py
@@ -575,6 +575,23 @@ def test_parallel_bool_negate(run_poe):
     assert "{'flag': False, 'val': False}" in result.stdout
 
 
+def test_parallel_task_forwards_extra_args_via_poe_extra_args(run_poe):
+    """Extra args passed to a parallel task are forwarded to subtasks via POE_EXTRA_ARGS"""
+    result = run_poe("extra-args-parallel", "hello", "world", project="parallel")
+    assert "extra: hello world" in result.stdout
+    assert "Let it be" in result.stdout
+    assert result.stderr == ""
+
+
+def test_parallel_task_forwards_extra_args_with_trailing_args(run_poe):
+    """$POE_EXTRA_ARGS in a parallel subtask can have args both before and after"""
+    result = run_poe(
+        "extra-args-parallel-trailing", "hello", "world", project="parallel"
+    )
+    assert "extra: before hello world after" in result.stdout
+    assert result.stderr == ""
+
+
 def filter_capture_lines(capture_lines: list[str], *prefixes: str) -> list[str]:
     return [
         line for line in capture_lines if not any(line.startswith(p) for p in prefixes)

--- a/tests/test_parallel_tasks.py
+++ b/tests/test_parallel_tasks.py
@@ -269,17 +269,29 @@ def test_parallel_fail_all(run_poe_subproc, generate_pyproject, delay_factor):
 
     # fast_success from lvl1_seq (running as a parallel subtask) may arrive before
     # or after fast_fail depending on timing, so accept 2 or 3 fast_success lines.
-    assert result.stdout.startswith(
-        "Great success!\n"
-        "fast_success | Great success!\n"
-        "fast_success | Great success!\n"
-        "fast_fail | failing fast with error\n"
-    ) or result.stdout.startswith(
-        "Great success!\n"
-        "fast_success | Great success!\n"
-        "fast_success | Great success!\n"
-        "fast_success | Great success!\n"
-        "fast_fail | failing fast with error\n"
+    # slow_success may also complete before fast_fail on slower systems.
+    assert (
+        result.stdout.startswith(
+            "Great success!\n"
+            "fast_success | Great success!\n"
+            "fast_success | Great success!\n"
+            "fast_fail | failing fast with error\n"
+        )
+        or result.stdout.startswith(
+            "Great success!\n"
+            "fast_success | Great success!\n"
+            "fast_success | Great success!\n"
+            "fast_success | Great success!\n"
+            "fast_fail | failing fast with error\n"
+        )
+        or result.stdout.startswith(
+            "Great success!\n"
+            "fast_success | Great success!\n"
+            "fast_success | Great success!\n"
+            "fast_success | Great success!\n"
+            "slow_success | Eventual success!\n"
+            "fast_fail | failing fast with error\n"
+        )
     )
     assert result.code == 1
 

--- a/tests/test_parallel_tasks.py
+++ b/tests/test_parallel_tasks.py
@@ -177,29 +177,45 @@ def test_parallel_fail_all(run_poe_subproc, generate_pyproject, delay_factor):
     assert result.code == 1
 
     result = run_poe_subproc("lvl1_para", cwd=project_path)
-    assert sequences_are_similar(
-        result.capture_lines,
-        [
-            f"Poe => poe_test_delayed_echo {slow_delay} 'Eventual success!'",
-            "Poe => echo 'Great success!'",
-            "Poe => echo 'failing fast with error'; exit 1;",
-            "Poe => echo 'Great success!'",
-            "Poe => echo 'Great success!'",
-            "Poe => echo 'failing fast with error'; exit 1;",
-            "Warning: Parallel subtask 'fast_fail' failed with non-zero exit status",
-            "Error: Parallel task 'lvl1_para' aborted after failed subtask 'fast_fail'",
-        ],
-    ) or sequences_are_similar(
-        result.capture_lines,
-        [
-            f"Poe => poe_test_delayed_echo {slow_delay} 'Eventual success!'",
-            "Poe => echo 'Great success!'",
-            "Poe => echo 'failing fast with error'; exit 1;",
-            "Poe => echo 'Great success!'",
-            "Poe => echo 'Great success!'",
-            "Warning: Parallel subtask 'fast_fail' failed with non-zero exit status",
-            "Error: Parallel task 'lvl1_para' aborted after failed subtask 'fast_fail'",
-        ],
+    assert (
+        sequences_are_similar(
+            result.capture_lines,
+            [
+                f"Poe => poe_test_delayed_echo {slow_delay} 'Eventual success!'",
+                "Poe => echo 'Great success!'",
+                "Poe => echo 'failing fast with error'; exit 1;",
+                "Poe => echo 'Great success!'",
+                "Poe => echo 'Great success!'",
+                "Poe => echo 'failing fast with error'; exit 1;",
+                "Warning: Parallel subtask 'fast_fail' failed with non-zero exit status",
+                "Error: Parallel task 'lvl1_para' aborted after failed subtask 'fast_fail'",
+            ],
+        )
+        or sequences_are_similar(
+            result.capture_lines,
+            [
+                f"Poe => poe_test_delayed_echo {slow_delay} 'Eventual success!'",
+                "Poe => echo 'Great success!'",
+                "Poe => echo 'failing fast with error'; exit 1;",
+                "Poe => echo 'Great success!'",
+                "Poe => echo 'Great success!'",
+                "Warning: Parallel subtask 'fast_fail' failed with non-zero exit status",
+                "Error: Parallel task 'lvl1_para' aborted after failed subtask 'fast_fail'",
+            ],
+        )
+        or sequences_are_similar(
+            result.capture_lines,
+            [
+                f"Poe => poe_test_delayed_echo {slow_delay} 'Eventual success!'",
+                "Poe => echo 'Great success!'",
+                "Poe => echo 'failing fast with error'; exit 1;",
+                "Poe => echo 'Great success!'",
+                "Poe => echo 'Great success!'",
+                "Warning: Parallel subtask 'fast_fail' failed with non-zero exit status",
+                "Error: Parallel task 'lvl1_para' aborted after failed subtask 'fast_fail'",
+                "Poe => echo 'failing fast with error'; exit 1;",
+            ],
+        )
     )
     assert set(result.output_lines) in (
         {

--- a/tests/test_script_tasks.py
+++ b/tests/test_script_tasks.py
@@ -461,3 +461,13 @@ def test_script_env_access_unset_bool_arg_preserves_typed_false(run_poe):
     assert result.stdout == (
         "args ()\n" "kwargs {'typed': False, 'present': False, 'value': None}\n"
     )
+
+
+def test_script_task_extra_args_available_as_list_via_extra_args_var(run_poe):
+    """Free args are available as _extra_args (list[str]) in script task expressions"""
+    result = run_poe(
+        "echo-extra-args-script", "foo", "bar", project="scripts", env=no_venv
+    )
+    assert result.capture == "Poe => echo-extra-args-script foo bar\n"
+    assert result.stdout == "str: foo\nstr: bar\n"
+    assert result.stderr == ""

--- a/tests/test_sequence_tasks.py
+++ b/tests/test_sequence_tasks.py
@@ -204,3 +204,33 @@ def test_private_arg_inherited_can_be_remapped_public(run_poe, is_windows):
     if not is_windows:
         assert "_secret=hidden" not in result.stdout
     assert "public=hidden" in stdout_lower
+
+
+def test_sequence_task_forwards_extra_args_via_poe_extra_args_in_ref(run_poe):
+    """Extra args passed to a sequence task are forwarded via $POE_EXTRA_ARGS in ref"""
+    result = run_poe("extra-args-via-ref", "hello", "world", project="sequences")
+    assert result.capture == (
+        "Poe => poe_test_echo hello world\nPoe => poe_test_echo done\n"
+    )
+    assert result.stdout == "hello world\ndone\n"
+    assert result.stderr == ""
+
+
+def test_sequence_task_forwards_extra_args_via_poe_extra_args_env(run_poe):
+    """Inline subtasks can access POE_EXTRA_ARGS set by the parent sequence task"""
+    result = run_poe("extra-args-via-env", "hello", "world", project="sequences")
+    assert result.capture == (
+        "Poe => poe_test_echo hello world\nPoe => poe_test_echo done\n"
+    )
+    assert result.stdout == "hello world\ndone\n"
+    assert result.stderr == ""
+
+
+def test_sequence_task_forwards_extra_args_with_trailing_args(run_poe):
+    """$POE_EXTRA_ARGS in a sequence subtask can have args both before and after"""
+    result = run_poe("extra-args-trailing", "hello", "world", project="sequences")
+    assert result.capture == (
+        "Poe => poe_test_echo before hello world after\nPoe => poe_test_echo done\n"
+    )
+    assert result.stdout == "before hello world after\ndone\n"
+    assert result.stderr == ""

--- a/tests/test_shell_task.py
+++ b/tests/test_shell_task.py
@@ -22,10 +22,14 @@ def test_shell_task(run_poe):
     assert result.stderr == ""
 
 
-def test_shell_task_raises_given_extra_args(run_poe):
+def test_shell_task_given_extra_args(run_poe):
+    """Extra args passed to a shell task without $POE_EXTRA_ARGS are silently ignored"""
     result = run_poe("count", "bla", project="shells")
-    assert "\n\nError: Shell task 'count' does not accept arguments" in result.capture
-    assert result.stdout == ""
+    assert result.capture == (
+        "Poe => poe_test_echo 1 && poe_test_echo 2 "
+        "&& poe_test_echo $(python -c 'print(1 + 2)')\n"
+    )
+    assert result.stdout == "1\n2\n3\n"
     assert result.stderr == ""
 
 

--- a/tests/test_shell_task.py
+++ b/tests/test_shell_task.py
@@ -241,3 +241,19 @@ def test_shell_unset_semantics_pwsh_true(run_poe):
 def test_shell_unset_semantics_pwsh_false(run_poe):
     result = run_poe("bool_unset_semantics_pwsh", "--MY_FLAG", project="shells")
     assert _clean_shell_output(result.stdout) == "False|unset|fallback"
+
+
+def test_shell_task_extra_args_via_poe_extra_args(run_poe):
+    """Free args passed after -- are available in shell scripts via $POE_EXTRA_ARGS"""
+    result = run_poe("echo-extra-args", "--", "foo", "bar", project="shells")
+    assert result.capture == "Poe => poe_test_echo $target $POE_EXTRA_ARGS\n"
+    assert result.stdout == "default foo bar\n"
+    assert result.stderr == ""
+
+
+def test_shell_task_extra_args_via_poe_extra_args_without_named_args(run_poe):
+    """Shell task with $POE_EXTRA_ARGS but no named args accepts free args directly"""
+    result = run_poe("echo-extra-args-no-named", "foo", "bar", project="shells")
+    assert result.capture == "Poe => poe_test_echo $POE_EXTRA_ARGS\n"
+    assert result.stdout == "foo bar\n"
+    assert result.stderr == ""

--- a/tests/test_switch_task.py
+++ b/tests/test_switch_task.py
@@ -195,3 +195,23 @@ ${txt}=text ${txt:+plus}=plus ${txt:-minus}=text
         result.stdout
         == "{'case': True, 'non': False, 'tru': True, 'fal': False, 'txt': 'text'}\n"
     )
+
+
+def test_switch_task_forwards_extra_args_via_poe_extra_args(run_poe):
+    """Switch task forwards free args to selected branch via POE_EXTRA_ARGS"""
+    result = run_poe("echo-extra-branch", "foo", "bar", project="switch")
+    assert result.capture == (
+        "Poe <= poe_test_echo match\nPoe => poe_test_echo matched: foo bar\n"
+    )
+    assert result.stdout == "matched: foo bar\n"
+    assert result.stderr == ""
+
+
+def test_switch_task_forwards_extra_args_with_trailing_args(run_poe):
+    """$POE_EXTRA_ARGS in a switch branch can have args both before and after"""
+    result = run_poe("echo-extra-branch-trailing", "foo", "bar", project="switch")
+    assert result.capture == (
+        "Poe <= poe_test_echo match\nPoe => poe_test_echo before: foo bar :after\n"
+    )
+    assert result.stdout == "before: foo bar :after\n"
+    assert result.stderr == ""


### PR DESCRIPTION
## Description of changes

When a task receives free arguments — either positional arguments not matched by any named arg definition, or arguments passed after `--` — poe now sets a `$POE_EXTRA_ARGS` environment variable containing those arguments as a shell-quoted, space-delimited string. This variable is inherited by all subtasks and can be referenced anywhere environment variable expansion is supported.

Previously, cmd tasks silently appended extra args to the end of the command and most other task types discarded them. `$POE_EXTRA_ARGS` gives full control over placement — it can appear anywhere in a subtask string, including between fixed options:

```
[tool.poe.tasks.test-all]
sequence = [
  "pytest --timeout=30 $POE_EXTRA_ARGS --tb=short",
  "lint",
]
```

For `script` and `expr` tasks, free args are also available as `_extra_args` (a `list[str]`) directly inside the Python expression:

```
[tool.poe.tasks.run-tests]
script = "pytest:main(_extra_args)"
```

For `cmd` tasks, referencing `$POE_EXTRA_ARGS` explicitly opts out of the default auto-append behavior so extra args are only placed where specified.

(Note: This code was largely generated with AI assistance and manually reviewed.)

Fixes #155 
Fixes #374 

## Pre-merge Checklist

- [x] New features (if any) are covered by new feature tests
- [x] New features (if any) are documented
- [ ] Bug fixes (if any) are accompanied by a test (if not too complicated to do so)
- [x] `poe check` executed successfully
- [x] This PR targets the *development* branch for code changes or *main* if only documentation is updated
