### PR TITLE
fix: handle ctrl+c attempt on windows if running bat/cmd scripts

### DIFF
--- a/poethepoet/executor/base.py
+++ b/poethepoet/executor/base.py
@@ -278,6 +278,13 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         else:
             proc = await asyncio.create_subprocess_exec(*cmd, **popen_kwargs)
 
+        if self._is_windows:
+            # Fix for issue #379 since ctrl+c can leave shell in a weird state
+            # so disable ctrl+c handling for subprocesses launched from batch files
+            cast("Any", proc)._poe_disable_console_ctrl = (
+                cmd[0].lower().endswith((".bat", ".cmd"))
+            )
+
         if input is not None:
             # TODO: Track the write task so we can cancel it if needed, and prevent GC
             #       from cleaning it up too early

--- a/poethepoet/shutdown.py
+++ b/poethepoet/shutdown.py
@@ -63,10 +63,21 @@ class ShutdownManager:
         if self._is_windows:
             for proc in tuple(self.processes):
                 if proc.returncode is None:
-                    self._io.print_debug(
-                        " ! Sending CTRL_BREAK_EVENT to subprocess %s", proc.pid
-                    )
-                    proc.send_signal(signal.CTRL_BREAK_EVENT)
+                    if not bool(getattr(proc, "_poe_disable_console_ctrl", False)):
+                        self._io.print_debug(
+                            " ! Sending CTRL_BREAK_EVENT to subprocess %s", proc.pid
+                        )
+                        proc.send_signal(signal.CTRL_BREAK_EVENT)
+                    else:
+                        self._io.print_debug(
+                            " ! Force-terminating subprocess %s "
+                            "to avoid console corruption",
+                            proc.pid,
+                        )
+                        subprocess.run(
+                            ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                            capture_output=True,
+                        )
                 else:
                     self.processes.discard(proc)
         else:
@@ -128,7 +139,7 @@ class ShutdownManager:
 
     def _send_signal_to_group(self, proc: Process, sig: int):
         with contextlib.suppress(ProcessLookupError):
-            os.killpg(os.getpgid(proc.pid), sig)
+            os.killpg(os.getpgid(proc.pid), sig)  # type: ignore[attr-defined]
 
     def _propagate_sighup(self, signum=None, frame=None):
         """

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,9 +1,14 @@
+import asyncio
 import os
 import signal
 import sys
 import time
+from typing import Any, cast
 
 import pytest
+
+from poethepoet.io import PoeIO
+from poethepoet.shutdown import ShutdownManager
 
 
 def _wait_for_proc_exit(proc, timeout: float = 5.0) -> bool:
@@ -35,6 +40,38 @@ def _pid_exists(pid: int) -> bool:
         return True
     except ProcessLookupError:
         return False
+
+
+def test_windows_shutdown_avoids_console_ctrl_for_batch_processes(monkeypatch):
+    class FakeProcess:
+        def __init__(self):
+            self.pid = 12345
+            self.returncode = None
+            self.signal_calls: list[int] = []
+            self._poe_disable_console_ctrl = True
+
+        def send_signal(self, sig: int):
+            self.signal_calls.append(sig)
+
+    taskkill_calls: list[list[str]] = []
+
+    def fake_taskkill(cmd: list[str], **_kwargs):
+        taskkill_calls.append(cmd)
+
+    monkeypatch.setattr("subprocess.run", fake_taskkill)
+
+    loop = asyncio.new_event_loop()
+    manager = ShutdownManager(loop, PoeIO(make_default=False))
+    manager._is_windows = True
+    process = FakeProcess()
+    manager.processes.add(cast("Any", process))
+
+    manager._urgency = 1
+    manager._shutdown()
+
+    assert process.signal_calls == []
+    assert taskkill_calls == [["taskkill", "/F", "/T", "/PID", str(process.pid)]]
+    loop.close()
 
 
 @pytest.fixture
@@ -121,7 +158,7 @@ def test_sighup_terminates_task_and_children(long_running_task):
     assert _pid_exists(child_pid), "child should be running"
 
     # Send SIGHUP
-    poe_handle.process.send_signal(signal.SIGHUP)
+    poe_handle.process.send_signal(cast("Any", signal).SIGHUP)
 
     # Both should exit (SIGHUP propagates to children and triggers shutdown)
     assert _wait_for_proc_exit(poe_handle.process), "poe should exit after SIGHUP"


### PR DESCRIPTION
## Description of changes

fixes #379 

`CTRL_BREAK_EVENT` doesn't handle the weird behaviour with `.bat`/`.cmd` files, where it asks for confirmation before continuing, but the event does something weird, resulting in corruption of the shell. This should solve the issue.

AI was used in this PR. I can't get OpenCode to share the session, though.

## Pre-merge Checklist

- [ ] New features (if any) are covered by new feature tests
- [ ] New features (if any) are documented
- [x] Bug fixes (if any) are accompanied by a test (if not too complicated to do so)
- [x] `poe check` executed successfully
- [x] This PR targets the *development* branch for code changes or *main* if only documentation is updated
