### PR TITLE
fix: handle ctrl+c attempt on windows if running bat/cmd scripts

### DIFF
--- a/poethepoet/context.py
+++ b/poethepoet/context.py
@@ -11,12 +11,12 @@ from .io import PoeIO
 from .shutdown import ShutdownManager
 
 if TYPE_CHECKING:
-    from asyncio.subprocess import Process
     from collections.abc import Mapping
     from pathlib import Path
 
     from .config import PoeConfig
     from .env.task_env import TaskEnv
+    from .executor.base import PoeProcess
     from .ui import PoeUi
 
 
@@ -140,7 +140,7 @@ class RunContext:
         finally:
             context._shutdown_manager.restore_handler()
 
-    def register_subprocess(self, proc: Process):
+    def register_subprocess(self, proc: PoeProcess):
         self._shutdown_manager.processes.add(proc)
 
     def register_async_task(self, task: asyncio.Task[Any]):

--- a/poethepoet/executor/base.py
+++ b/poethepoet/executor/base.py
@@ -278,6 +278,13 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         else:
             proc = await asyncio.create_subprocess_exec(*cmd, **popen_kwargs)
 
+        if self._is_windows:
+            # Fix for issue #379 since ctrl+c can leave shell in a weird state
+            # so disable ctrl+c handling for subprocesses launched from batch files
+            cast("Any", proc)._poe_disable_console_ctrl = (
+                cmd[0].lower().endswith((".bat", ".cmd"))
+            )
+
         if input is not None:
             # TODO: Track the write task so we can cancel it if needed, and prevent GC
             #       from cleaning it up too early

--- a/poethepoet/executor/base.py
+++ b/poethepoet/executor/base.py
@@ -20,6 +20,41 @@ if TYPE_CHECKING:
     from ..io import PoeIO
 
 
+class PoeProcess:
+    """
+    Wraps asyncio.subprocess.Process with poe-specific metadata for shutdown handling.
+    """
+
+    def __init__(self, process: Process, *, no_console_ctrl: bool = False):
+        self._process = process
+        self.no_console_ctrl = no_console_ctrl
+
+    @property
+    def pid(self) -> int:
+        return self._process.pid
+
+    @property
+    def returncode(self) -> int | None:
+        return self._process.returncode
+
+    @property
+    def stdout(self) -> asyncio.StreamReader | None:
+        return self._process.stdout
+
+    @property
+    def stdin(self) -> asyncio.StreamWriter | None:
+        return self._process.stdin
+
+    async def wait(self) -> int:
+        return await self._process.wait()
+
+    def send_signal(self, signal: int) -> None:
+        self._process.send_signal(signal)
+
+    def kill(self) -> None:
+        self._process.kill()
+
+
 class MetaPoeExecutor(type):
     """
     This metaclass makes all descendants of PoeExecutor (task types) register themselves
@@ -152,7 +187,7 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
 
     async def execute(
         self, cmd: Sequence[str], input: bytes | None = None, use_exec: bool = False
-    ) -> Process:
+    ) -> PoeProcess:
         """
         Execute the given cmd.
         """
@@ -168,7 +203,7 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         env: Mapping[str, str] | None = None,
         shell: bool = False,
         use_exec: bool = False,
-    ) -> Process:
+    ) -> PoeProcess:
         """
         Execute the given cmd either as a subprocess or use exec to replace the current
         process. Using exec supports fewer options, and doesn't work on windows.
@@ -236,12 +271,14 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         input: bytes | None = None,
         env: Mapping[str, str] | None = None,
         shell: bool = False,
-    ) -> Process:
+    ) -> PoeProcess:
         from subprocess import PIPE
 
         if self.dry:
             # A dry run doesn't execute the command, so we just return a dummy process
-            return await asyncio.create_subprocess_exec(sys.executable, "-c", "")
+            return PoeProcess(
+                await asyncio.create_subprocess_exec(sys.executable, "-c", "")
+            )
         popen_kwargs: MutableMapping[str, Any] = {}
         popen_kwargs["env"] = dict(
             (self.env.get_subprocess_env_vars() if env is None else env),
@@ -278,13 +315,6 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
         else:
             proc = await asyncio.create_subprocess_exec(*cmd, **popen_kwargs)
 
-        if self._is_windows:
-            # Fix for issue #379 since ctrl+c can leave shell in a weird state
-            # so disable ctrl+c handling for subprocesses launched from batch files
-            cast("Any", proc)._poe_disable_console_ctrl = (
-                cmd[0].lower().endswith((".bat", ".cmd"))
-            )
-
         if input is not None:
             # TODO: Track the write task so we can cancel it if needed, and prevent GC
             #       from cleaning it up too early
@@ -294,7 +324,10 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
             captured_stdout = await proc.stdout.read() if proc.stdout else b""
             self.context.save_task_output(self.invocation, captured_stdout)
 
-        return proc
+        no_console_ctrl = (
+            self._is_windows and not shell and cmd[0].lower().endswith((".bat", ".cmd"))
+        )
+        return PoeProcess(proc, no_console_ctrl=no_console_ctrl)
 
     async def _pass_input_to_proc(self, proc: Process, input: bytes):
         if not proc.stdin:

--- a/poethepoet/executor/poetry.py
+++ b/poethepoet/executor/poetry.py
@@ -9,10 +9,10 @@ from ..exceptions import ExecutionError
 from .base import PoeExecutor
 
 if TYPE_CHECKING:
-    from asyncio.subprocess import Process
     from collections.abc import Sequence
 
     from ..context import ContextProtocol
+    from .base import PoeProcess
 
 
 class PoetryExecutor(PoeExecutor):
@@ -31,7 +31,7 @@ class PoetryExecutor(PoeExecutor):
 
     async def execute(
         self, cmd: Sequence[str], input: bytes | None = None, use_exec: bool = False
-    ) -> Process:
+    ) -> PoeProcess:
         """
         Execute the given cmd as a subprocess inside the poetry managed dev environment
         """

--- a/poethepoet/executor/task_run.py
+++ b/poethepoet/executor/task_run.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 from poethepoet.helpers.eventloop import async_iter_merge, async_noop
 
 if TYPE_CHECKING:
-    from asyncio.subprocess import Process
     from collections.abc import (
         AsyncIterable,
         Awaitable,
@@ -16,6 +15,8 @@ if TYPE_CHECKING:
         Collection,
         Coroutine,
     )
+
+    from .base import PoeProcess
 
 
 class PoeTaskRunEvent:
@@ -73,7 +74,7 @@ class PoeTaskRun:
             )
         )
         self._children: list[PoeTaskRun] = []
-        self._processes: list[Process] = []
+        self._processes: list[PoeProcess] = []
         self._update_condition = asyncio.Condition()
         self._force_failure = False
         self._finalized = False
@@ -81,7 +82,7 @@ class PoeTaskRun:
         self._done_callbacks: list[
             Callable[[PoeTaskRunEvent], None] | Callable[[PoeTaskRunEvent], Awaitable]
         ] = []
-        self._new_process_callbacks: list[Callable[[Process], None]] = []
+        self._new_process_callbacks: list[Callable[[PoeProcess], None]] = []
 
     @property
     def parent(self) -> PoeTaskRun | None:
@@ -152,7 +153,7 @@ class PoeTaskRun:
             unsubscribe()
 
     def add_new_process_callback(
-        self, callback: Callable[[Process], None]
+        self, callback: Callable[[PoeProcess], None]
     ) -> Callable[[], None]:
         """
         Add a callback to be called when a new process is added to this task run.
@@ -166,7 +167,7 @@ class PoeTaskRun:
 
         return cancel_callback
 
-    def _notify_new_process(self, process: Process) -> None:
+    def _notify_new_process(self, process: PoeProcess) -> None:
         for callback in self._new_process_callbacks:
             callback(process)
 
@@ -272,7 +273,9 @@ class PoeTaskRun:
             self._force_failure
         )
 
-    async def add_process(self, process: Process, finalize: bool = False) -> PoeTaskRun:
+    async def add_process(
+        self, process: PoeProcess, finalize: bool = False
+    ) -> PoeTaskRun:
         if self._finalized:
             raise RuntimeError("Cannot add process to completed PoeTaskRun")
         self._processes.append(process)
@@ -351,7 +354,7 @@ class PoeTaskRun:
 
         return unsubscribe
 
-    async def processes(self) -> AsyncIterable[tuple[PoeTaskRun, Process]]:
+    async def processes(self) -> AsyncIterable[tuple[PoeTaskRun, PoeProcess]]:
         """
         Yield (task name, process) tuples for all processes involved in this task run or
         any child task runs.
@@ -380,7 +383,7 @@ class PoeTaskRun:
             else:
                 await self._wait_for_update()
 
-    async def _iter_processes(self) -> AsyncIterable[tuple[PoeTaskRun, Process]]:
+    async def _iter_processes(self) -> AsyncIterable[tuple[PoeTaskRun, PoeProcess]]:
         cursor = 0
         while cursor < len(self._processes) or not self.finalized():
             if cursor < len(self._processes):

--- a/poethepoet/executor/uv.py
+++ b/poethepoet/executor/uv.py
@@ -6,10 +6,10 @@ from ..options.annotations import Metadata
 from .base import PoeExecutor
 
 if TYPE_CHECKING:
-    from asyncio.subprocess import Process
     from collections.abc import Sequence
 
     from ..context import ContextProtocol
+    from .base import PoeProcess
 
 
 class UvExecutor(PoeExecutor):
@@ -46,7 +46,7 @@ class UvExecutor(PoeExecutor):
 
     async def execute(
         self, cmd: Sequence[str], input: bytes | None = None, use_exec: bool = False
-    ) -> Process:
+    ) -> PoeProcess:
         """
         Execute the given cmd as a subprocess via `uv run`.
         """

--- a/poethepoet/executor/virtualenv.py
+++ b/poethepoet/executor/virtualenv.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ..exceptions import ExecutionError
-from .base import PoeExecutor
+from .base import PoeExecutor, PoeProcess
 
 if TYPE_CHECKING:
-    from asyncio.subprocess import Process
     from collections.abc import Sequence
 
     from ..context import ContextProtocol
@@ -31,7 +30,7 @@ class VirtualenvExecutor(PoeExecutor):
 
     async def execute(
         self, cmd: Sequence[str], input: bytes | None = None, use_exec: bool = False
-    ) -> Process:
+    ) -> PoeProcess:
         """
         Execute the given cmd as a subprocess inside the configured virtualenv
         """

--- a/poethepoet/shutdown.py
+++ b/poethepoet/shutdown.py
@@ -63,10 +63,21 @@ class ShutdownManager:
         if self._is_windows:
             for proc in tuple(self.processes):
                 if proc.returncode is None:
-                    self._io.print_debug(
-                        " ! Sending CTRL_BREAK_EVENT to subprocess %s", proc.pid
-                    )
-                    proc.send_signal(signal.CTRL_BREAK_EVENT)
+                    if not bool(getattr(proc, "_poe_disable_console_ctrl", False)):
+                        self._io.print_debug(
+                            " ! Sending CTRL_BREAK_EVENT to subprocess %s", proc.pid
+                        )
+                        proc.send_signal(signal.CTRL_BREAK_EVENT)
+                    else:
+                        self._io.print_debug(
+                            " ! Force-terminating subprocess %s "
+                            "to avoid console corruption",
+                            proc.pid,
+                        )
+                        subprocess.run(
+                            ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                            capture_output=True,
+                        )
                 else:
                     self.processes.discard(proc)
         else:
@@ -128,7 +139,7 @@ class ShutdownManager:
 
     def _send_signal_to_group(self, proc: Process, sig: int):
         with contextlib.suppress(ProcessLookupError):
-            os.killpg(os.getpgid(proc.pid), sig)
+            os.killpg(os.getpgid(proc.pid), sig)  # type: ignore[attr-defined]
 
     def _propagate_sighup(self, signum=None, frame=None):
         """

--- a/poethepoet/shutdown.py
+++ b/poethepoet/shutdown.py
@@ -10,8 +10,7 @@ from typing import TYPE_CHECKING
 from weakref import WeakSet
 
 if TYPE_CHECKING:
-    from asyncio.subprocess import Process
-
+    from .executor.base import PoeProcess
     from .io import PoeIO
 
 
@@ -24,7 +23,7 @@ class ShutdownManager:
         self._shutting_down = asyncio.Event()
         self._urgency = 0
         self.tasks: WeakSet[asyncio.Task] = WeakSet()
-        self.processes: WeakSet[Process] = WeakSet()
+        self.processes: WeakSet[PoeProcess] = WeakSet()
         self._backup_sighup = None
         self._backup_sigint = None
         self._backup_sigterm = None
@@ -63,21 +62,22 @@ class ShutdownManager:
         if self._is_windows:
             for proc in tuple(self.processes):
                 if proc.returncode is None:
-                    if not bool(getattr(proc, "_poe_disable_console_ctrl", False)):
+                    if proc.no_console_ctrl:
                         self._io.print_debug(
-                            " ! Sending CTRL_BREAK_EVENT to subprocess %s", proc.pid
-                        )
-                        proc.send_signal(signal.CTRL_BREAK_EVENT)
-                    else:
-                        self._io.print_debug(
-                            " ! Force-terminating subprocess %s "
-                            "to avoid console corruption",
+                            " ! Terminating subprocess tree %s"
+                            " to avoid console corruption",
                             proc.pid,
                         )
                         subprocess.run(
-                            ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                            ["taskkill", "/T", "/PID", str(proc.pid)],
                             capture_output=True,
                         )
+                    else:
+                        self._io.print_debug(
+                            " ! Sending CTRL_BREAK_EVENT to subprocess %s",
+                            proc.pid,
+                        )
+                        proc.send_signal(signal.CTRL_BREAK_EVENT)
                 else:
                     self.processes.discard(proc)
         else:
@@ -137,7 +137,7 @@ class ShutdownManager:
                     if proc.returncode is None:
                         self._send_signal_to_group(proc, signal.SIGKILL)
 
-    def _send_signal_to_group(self, proc: Process, sig: int):
+    def _send_signal_to_group(self, proc: PoeProcess, sig: int):
         with contextlib.suppress(ProcessLookupError):
             os.killpg(os.getpgid(proc.pid), sig)  # type: ignore[attr-defined]
 

--- a/poethepoet/task/parallel.py
+++ b/poethepoet/task/parallel.py
@@ -9,13 +9,13 @@ from ..helpers.eventloop import DynamicTaskSet
 from .base import PoeTask, TaskContext
 
 if TYPE_CHECKING:
-    from asyncio.subprocess import Process
     from collections.abc import Sequence
 
     from ..config import ConfigPartition, PoeConfig
     from ..config.partition import GroupConfig
     from ..context import RunContext
     from ..env.task_env import TaskEnv
+    from ..executor.base import PoeProcess
     from .base import TaskSpecFactory
 
 T = TypeVar("T")
@@ -271,7 +271,7 @@ class ParallelTask(PoeTask):
             )
 
     async def _format_output_lines(
-        self, task_name: str, subtask_index: int, subproc: Process
+        self, task_name: str, subtask_index: int, subproc: PoeProcess
     ):
         if not subproc.stdout:
             return

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,9 +1,14 @@
+import asyncio
 import os
 import signal
 import sys
 import time
+from typing import Any, cast
 
 import pytest
+
+from poethepoet.io import PoeIO
+from poethepoet.shutdown import ShutdownManager
 
 
 def _wait_for_proc_exit(proc, timeout: float = 5.0) -> bool:
@@ -35,6 +40,38 @@ def _pid_exists(pid: int) -> bool:
         return True
     except ProcessLookupError:
         return False
+
+
+def test_windows_shutdown_avoids_console_ctrl_for_batch_processes(monkeypatch):
+    class FakeProcess:
+        def __init__(self):
+            self.pid = 12345
+            self.returncode = None
+            self.signal_calls: list[int] = []
+            self._poe_disable_console_ctrl = True
+
+        def send_signal(self, sig: int):
+            self.signal_calls.append(sig)
+
+    taskkill_calls: list[list[str]] = []
+
+    def fake_taskkill(cmd: list[str], **_kwargs):
+        taskkill_calls.append(cmd)
+
+    monkeypatch.setattr("subprocess.run", fake_taskkill)
+
+    loop = asyncio.new_event_loop()
+    manager = ShutdownManager(loop, PoeIO(make_default=False))
+    manager._is_windows = True
+    process = FakeProcess()
+    manager.processes.add(cast("Any", process))
+
+    manager._urgency = 1
+    manager._shutdown()
+
+    assert process.signal_calls == []
+    assert taskkill_calls == [["taskkill", "/F", "/T", "/PID", str(process.pid)]]
+    loop.close()
 
 
 @pytest.fixture
@@ -121,7 +158,7 @@ def test_sighup_terminates_task_and_children(long_running_task):
     assert _pid_exists(child_pid), "child should be running"
 
     # Send SIGHUP
-    poe_handle.process.send_signal(signal.SIGHUP)
+    poe_handle.process.send_signal(cast("Any", signal).SIGHUP)
 
     # Both should exit (SIGHUP propagates to children and triggers shutdown)
     assert _wait_for_proc_exit(poe_handle.process), "poe should exit after SIGHUP"

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 import pytest
 
+from poethepoet.executor.base import PoeProcess
 from poethepoet.io import PoeIO
 from poethepoet.shutdown import ShutdownManager
 
@@ -43,12 +44,14 @@ def _pid_exists(pid: int) -> bool:
 
 
 def test_windows_shutdown_avoids_console_ctrl_for_batch_processes(monkeypatch):
+    ctrl_break_event = getattr(signal, "CTRL_BREAK_EVENT", 1)
+    monkeypatch.setattr(signal, "CTRL_BREAK_EVENT", ctrl_break_event, raising=False)
+
     class FakeProcess:
         def __init__(self):
             self.pid = 12345
             self.returncode = None
             self.signal_calls: list[int] = []
-            self._poe_disable_console_ctrl = True
 
         def send_signal(self, sig: int):
             self.signal_calls.append(sig)
@@ -63,14 +66,50 @@ def test_windows_shutdown_avoids_console_ctrl_for_batch_processes(monkeypatch):
     loop = asyncio.new_event_loop()
     manager = ShutdownManager(loop, PoeIO(make_default=False))
     manager._is_windows = True
-    process = FakeProcess()
-    manager.processes.add(cast("Any", process))
+    fake_proc = FakeProcess()
+    process = PoeProcess(cast("Any", fake_proc), no_console_ctrl=True)
+    manager.processes.add(process)
 
     manager._urgency = 1
     manager._shutdown()
 
-    assert process.signal_calls == []
-    assert taskkill_calls == [["taskkill", "/F", "/T", "/PID", str(process.pid)]]
+    assert fake_proc.signal_calls == []
+    assert taskkill_calls == [["taskkill", "/T", "/PID", str(process.pid)]]
+    loop.close()
+
+
+def test_windows_shutdown_sends_ctrl_break_for_normal_processes(monkeypatch):
+    ctrl_break_event = getattr(signal, "CTRL_BREAK_EVENT", 1)
+    monkeypatch.setattr(signal, "CTRL_BREAK_EVENT", ctrl_break_event, raising=False)
+
+    class FakeProcess:
+        def __init__(self):
+            self.pid = 12345
+            self.returncode = None
+            self.signal_calls: list[int] = []
+
+        def send_signal(self, sig: int):
+            self.signal_calls.append(sig)
+
+    taskkill_calls: list[list[str]] = []
+
+    def fake_taskkill(cmd: list[str], **_kwargs):
+        taskkill_calls.append(cmd)
+
+    monkeypatch.setattr("subprocess.run", fake_taskkill)
+
+    loop = asyncio.new_event_loop()
+    manager = ShutdownManager(loop, PoeIO(make_default=False))
+    manager._is_windows = True
+    fake_proc = FakeProcess()
+    process = PoeProcess(cast("Any", fake_proc))
+    manager.processes.add(process)
+
+    manager._urgency = 1
+    manager._shutdown()
+
+    assert fake_proc.signal_calls == [ctrl_break_event]
+    assert taskkill_calls == []
     loop.close()
 
 


### PR DESCRIPTION
fixes https://github.com/nat-n/poethepoet/issues/379

CTRL_BREAK_EVENT doesn't handle the weird behaviour with .bat/.cmd files, where it asks for confirmation before continuing, but the event does something weird, resulting in corruption of the shell.

Thanks to @NSPC911 for diagnosing the issue.
