### PR TITLE
fix: Strip underscore prefix in documentation for private positional args

### DIFF
--- a/docs/guides/args_guide.rst
+++ b/docs/guides/args_guide.rst
@@ -62,7 +62,7 @@ This example can be invoked as
 
     poe cook --food eggs
 
-Note that the leading underscore is stripped from the inferred CLI option.
+Note that the leading underscore is stripped from the inferred CLI option. The same stripping applies to positional args: a private positional arg called ``_food`` is displayed as ``food`` in help while still being treated as a private variable inside the task.
 
 
 Array of inline tables

--- a/docs/guides/migrations.rst
+++ b/docs/guides/migrations.rst
@@ -48,6 +48,6 @@ It seems unlikely that anyone would specifically need to pass variables like thi
 
 Using private variables is now encouraged as a best practice to avoid unintentionally setting environment variables on task subprocesses.
 
-Arg names are typically referenced within task content, and normally set as environment variables. However if an arg name is prefixed with an underscore to make it private, and there are no options explicitly configured for that arg, then any leading underscores will be stripped from the name when generating an option name from it. For example the arg name ``_flag`` will result in the cli option ``--flag``.
+Arg names are typically referenced within task content, and normally set as environment variables. However if an arg name is prefixed with an underscore to make it private, and there are no options explicitly configured for that arg, then any leading underscores will be stripped from the name when generating an option name from it. For example the arg name ``_flag`` will result in the cli option ``--flag``. The same applies to positional args: a private positional arg called ``_target`` will be displayed as ``target`` in help, while still being treated as a private variable inside the task.
 
 Since this can cause collisions between options, there is now a config validation to prevent collisions between cli options.

--- a/poethepoet/task/args.py
+++ b/poethepoet/task/args.py
@@ -99,6 +99,7 @@ class ArgSpec(PoeOptions):
         if strict:
             arg_names = set()
             option_args: dict[str, str] = {}
+            positional_dests: dict[str, str] = {}
             positional_multiple = None
             for arg in result:
                 if arg.name in arg_names:
@@ -119,6 +120,16 @@ class ArgSpec(PoeOptions):
                         option_args[option] = arg.name
 
                 if arg.positional:
+                    dest = arg.options[0]
+                    if dest in positional_dests:
+                        raise ConfigValidationError(
+                            f"Arguments {positional_dests[dest]!r} and"
+                            f" {arg.name!r} generate the same positional"
+                            f" identifier {dest!r}",
+                            context=f"Invalid argument {arg.name!r} declared",
+                        )
+                    positional_dests[dest] = arg.name
+
                     if positional_multiple:
                         raise ConfigValidationError(
                             f"Only the last positional arg of task may accept"
@@ -141,10 +152,13 @@ class ArgSpec(PoeOptions):
                 raise ConfigValidationError(
                     f"Positional argument {name!r} may not declare options"
                 )
-            # Fill in the options param in a way that makes sense for argparse
+            # Fill in the options param in a way that makes sense for argparse.
+            # Underscores are stripped from the dest so private positional args
+            # don't render as ``_foo`` in help; the original name is restored
+            # after parsing in PoeTaskArgs.parse so the var stays private.
             if isinstance(positional, str):
                 return [positional]
-            return [name]
+            return [stripped or name]
         return tuple(arg.get("options", [f"--{stripped}"]))
 
     def validate(self):
@@ -369,11 +383,11 @@ class PoeTaskArgs:
                     f"Invalid arguments for task {self._task_name!r}"
                 ) from error
 
-        # Ensure positional args are still exposed by name even if they were parsed with
-        # alternate identifiers
+        # Ensure positional args are still exposed by name even if they were parsed
+        # with alternate identifiers (via positional alias or stripped underscore)
         for arg in self._args:
-            if isinstance(arg.positional, str):
-                parsed_args[arg.name] = parsed_args[arg.positional]
-                del parsed_args[arg.positional]
+            if arg.positional and (dest := arg.options[0]) != arg.name:
+                parsed_args[arg.name] = parsed_args[dest]
+                del parsed_args[dest]
         # args named with dash case are converted to snake case before being exposed
         return {name.replace("-", "_"): value for name, value in parsed_args.items()}

--- a/tests/test_private_positional_args.py
+++ b/tests/test_private_positional_args.py
@@ -51,14 +51,16 @@ def test_private_positional_arg_value_remains_private(
 
 def test_private_positional_dest_collision_is_rejected(temp_pyproject, run_poe):
     """Two positional args that strip to the same identifier are rejected."""
-    project_path = temp_pyproject("""
+    project_path = temp_pyproject(
+        """
             [tool.poe.tasks.bad]
             cmd = "poe_test_echo ok"
             args = [
               { name = "_target", positional = true },
               { name = "target", positional = true },
             ]
-        """)
+        """
+    )
     result = run_poe("bad", "a", "b", cwd=project_path)
     assert result.code == 1
     assert "same positional identifier 'target'" in result.capture

--- a/tests/test_private_positional_args.py
+++ b/tests/test_private_positional_args.py
@@ -1,0 +1,66 @@
+import pytest
+
+
+@pytest.fixture
+def private_positional_pyproject(temp_pyproject):
+    project_tmpl = """
+        [tool.poe.tasks.greet]
+        cmd = "poe_test_echo ${_target}!"
+
+        [[tool.poe.tasks.greet.args]]
+        name = "_target"
+        positional = true
+        required = true
+        help = "who to greet"
+    """
+    return temp_pyproject(project_tmpl)
+
+
+def test_private_positional_arg_strips_underscore_in_help(
+    private_positional_pyproject, run_poe
+):
+    """Help for a private positional arg shows the stripped name."""
+    result = run_poe("-h", "greet", cwd=private_positional_pyproject)
+    assert "target" in result.capture
+    assert "_target" not in result.capture
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_private_positional_arg_strips_underscore_in_summary(
+    private_positional_pyproject, run_poe
+):
+    """The task summary view also shows the stripped name for private positionals."""
+    result = run_poe(cwd=private_positional_pyproject)
+    assert "target" in result.capture
+    assert "_target" not in result.capture
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_private_positional_arg_value_remains_private(
+    private_positional_pyproject, run_poe
+):
+    """The arg value drives the private template var, not a public env var."""
+    result = run_poe("greet", "world", cwd=private_positional_pyproject)
+    assert result.code == 0
+    assert result.capture == "Poe => poe_test_echo 'world!'\n"
+    assert result.stdout == "world!\n"
+    assert result.stderr == ""
+
+
+def test_private_positional_dest_collision_is_rejected(temp_pyproject, run_poe):
+    """Two positional args that strip to the same identifier are rejected."""
+    project_path = temp_pyproject("""
+            [tool.poe.tasks.bad]
+            cmd = "poe_test_echo ok"
+            args = [
+              { name = "_target", positional = true },
+              { name = "target", positional = true },
+            ]
+        """)
+    result = run_poe("bad", "a", "b", cwd=project_path)
+    assert result.code == 1
+    assert "same positional identifier 'target'" in result.capture
+    assert result.stdout == ""
+    assert result.stderr == ""


### PR DESCRIPTION
## Description of changes

This PR extends the private variable feature to positional arguments. Previously, only optional arguments (those with `--` prefix) supported the underscore stripping convention for private variables. Now positional arguments can also be marked as private by prefixing their name with an underscore, and the underscore will be stripped from the CLI display while the variable remains private internally.

### Key changes:

1. **Positional argument underscore stripping**: When a positional argument name starts with an underscore (e.g., `_target`), the underscore is stripped when displaying the argument in help text and task summaries, but the variable is still treated as private and not exposed as an environment variable.

2. **Collision detection**: Added validation to detect when multiple positional arguments would generate the same identifier after underscore stripping (e.g., `_target` and `target`), which is now rejected with a clear error message.

3. **Argument parsing restoration**: Updated the argument parsing logic to properly restore the original argument name after parsing, handling both positional aliases and underscore-stripped names.

4. **Documentation updates**: Updated guides to clarify that underscore stripping applies to both optional and positional arguments.

### Motivation:

This change promotes the use of private variables as a best practice by making it consistent across all argument types. It allows task authors to avoid unintentionally setting environment variables on task subprocesses, regardless of whether they're using optional or positional arguments.

## Pre-merge Checklist

- [x] New features are covered by new feature tests (added `tests/test_private_positional_args.py` with 4 comprehensive test cases)
- [x] New features are documented (updated `docs/guides/args_guide.rst` and `docs/guides/migrations.rst`)
- [x] Changes include validation with appropriate error handling for edge cases
- [x] This PR targets the development branch

https://claude.ai/code/session_01F8qV8D47SPr3S2xmzAAaPW