### PR TITLE
Fix executor config validation to reject unknown keys

### DIFF
--- a/poethepoet/executor/base.py
+++ b/poethepoet/executor/base.py
@@ -393,7 +393,7 @@ class PoeExecutor(metaclass=MetaPoeExecutor):
             )
 
         else:
-            cls.__executor_types[executor_type].ExecutorOptions.parse(config)
+            next(cls.__executor_types[executor_type].ExecutorOptions.parse(config))
 
 
 def _stop_coverage():

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -247,3 +247,32 @@ def test_global_executor_config_rejects_unknown_keys(temp_pyproject, run_poe):
     # would mean PoeExecutor.get() caught it instead of validate_config.
     assert "Couldn't parse executor options" not in result.capture
     assert result.stdout == ""
+
+
+def test_global_executor_config_rejects_wrong_value_type(temp_pyproject, run_poe):
+    """
+    The same generator-not-consumed bug that hid unknown keys also hid the
+    per-field value_type.validate(...) checks inside PoeOptions.parse. This
+    locks in that value-type errors on executor configs surface from
+    validate_config too (companion to #390).
+
+    Uses a bool value for `location` — accepted by the outer ConfigOptions
+    schema (which allows str/list[str]/bool for executor option values) but
+    invalid against the inner virtualenv ExecutorOptions schema (str | None).
+    Without the fix, the inner check is skipped and the error never surfaces.
+    """
+    project_path = temp_pyproject(
+        """
+            [tool.poe.executor]
+            type = "virtualenv"
+            location = true
+
+            [tool.poe.tasks]
+            greet = "poe_test_echo hi"
+        """
+    )
+    result = run_poe("-d", "greet", cwd=project_path)
+    assert result.code == 1
+    assert "Option 'location' must have a value of type" in result.capture
+    assert "Couldn't parse executor options" not in result.capture
+    assert result.stdout == ""

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -217,3 +217,33 @@ def test_global_executor_config(run_poe):
     assert result.capture == "Poe => poe_test_env\n"
     assert "POE_ACTIVE=simple" in result.stdout
     assert result.stderr == ""
+
+
+def test_global_executor_config_rejects_unknown_keys(temp_pyproject, run_poe):
+    """
+    Unknown keys in tool.poe.executor must be rejected by validate_config at
+    config-parse time (regression test for #390).
+
+    Before the fix, validate_config silently accepted the bogus key (the
+    generator returned by ExecutorOptions.parse was never iterated) and the
+    error only surfaced later — wrapped — when PoeExecutor.get() finally
+    consumed the generator. The cleaner unwrapped error message confirms
+    validate_config itself raised.
+    """
+    project_path = temp_pyproject(
+        """
+            [tool.poe.executor]
+            type = "simple"
+            extra_bogus = "should be rejected"
+
+            [tool.poe.tasks]
+            greet = "poe_test_echo hi"
+        """
+    )
+    result = run_poe("-d", "greet", cwd=project_path)
+    assert result.code == 1
+    assert "Error: Unrecognized option 'extra_bogus'" in result.capture
+    # The wrapped form would be "Couldn't parse executor options …" — that
+    # would mean PoeExecutor.get() caught it instead of validate_config.
+    assert "Couldn't parse executor options" not in result.capture
+    assert result.stdout == ""


### PR DESCRIPTION
## Description of changes

This PR fixes a regression in executor configuration validation where unknown keys in `tool.poe.executor` were silently accepted instead of being rejected at config-parse time.

### The Problem

The `validate_config` method in `executor/base.py` was calling `ExecutorOptions.parse()` but not consuming the returned generator. Since generators are lazy, the validation logic inside `parse()` was never executed. This meant invalid configuration keys were only caught later (and wrapped in an error) when `PoeExecutor.get()` finally consumed the generator.

### The Fix

Changed line 396 in `executor/base.py` to consume the generator by calling `next()` on it:
```python
# Before
cls.__executor_types[executor_type].ExecutorOptions.parse(config)

# After
next(cls.__executor_types[executor_type].ExecutorOptions.parse(config))
```

This ensures validation happens immediately during config parsing, providing cleaner error messages to users.

### Testing

Added a regression test `test_global_executor_config_rejects_unknown_keys` that verifies:
- Unknown keys in executor config are rejected with a clear error message
- The error is raised during config validation (not wrapped later)
- The task execution fails cleanly with exit code 1

## Pre-merge Checklist

- [x] Bug fix is accompanied by a regression test
- [x] `poe check` executed successfully
- [x] This PR targets the *development* branch

https://claude.ai/code/session_01Aza7YdEvFAh1Avci1j8pag