### PR TITLE
Remove phase-structure references from comments

### DIFF
--- a/poethepoet/schema/translate.py
+++ b/poethepoet/schema/translate.py
@@ -72,9 +72,8 @@ def _translate_primitive(annotation: PrimitiveType) -> dict[str, Any]:
     py_type = annotation._annotation
     schema: dict[str, Any] = {"type": _PRIMITIVE_TYPE_MAP[py_type]}
 
-    # Layer in constraint metadata. Each is `None` if unset (the
-    # Phase 1 metadata_get bug fix ensures explicitly-zero values
-    # like minimum=0 are NOT silently dropped here).
+    # Layer in constraint metadata. Each is `None` if unset (explicitly-zero
+    # values like minimum=0 are preserved, not silently dropped).
     if py_type is str:
         if (pattern := annotation.metadata_get("pattern")) is not None:
             schema["pattern"] = pattern

--- a/tests/schema/conftest.py
+++ b/tests/schema/conftest.py
@@ -8,7 +8,6 @@ so they continue to run under the default `poe test` invocation.
 import pytest
 
 # Filenames containing parity tests (slow, require the full schema build).
-# Phase 3 will configure `poe test-quick` to exclude the `schema` marker.
 _PARITY_TEST_FILES = frozenset(
     {
         "test_meta.py",

--- a/tests/schema/test_smoke.py
+++ b/tests/schema/test_smoke.py
@@ -1,5 +1,5 @@
 """
-Phase 2 smoke test — verifies the schema package layout is importable.
+Smoke tests — verifies the schema package layout is importable.
 This file is intentionally not marked `schema` (it's a fast smoke check).
 """
 

--- a/tests/schema/test_translate.py
+++ b/tests/schema/test_translate.py
@@ -70,8 +70,8 @@ def test_int_with_minimum_maximum(ctx: SchemaContext) -> None:
 
 def test_int_with_zero_minimum_not_dropped(ctx: SchemaContext) -> None:
     """
-    Guards against the falsy-value regression that Phase 1 fixed in
-    metadata_get; minimum=0 must appear in the output.
+    Guards against falsy-value handling in metadata_get;
+    minimum=0 must appear in the output, not be silently dropped.
     """
     annotation = TypeAnnotation.parse(Annotated[int, Metadata(minimum=0)])
     schema = translate_type(annotation, ctx)
@@ -135,9 +135,9 @@ def test_none_translates_to_null_schema(ctx: SchemaContext) -> None:
 
 def test_shell_interpreter_literal_alias_translates(ctx: SchemaContext) -> None:
     """
-    Verifies the register_type_alias mechanism from Phase 1 works
-    end-to-end: ShellInterpreter is a registered alias for a Literal,
-    and translation should produce the expected enum schema.
+    Verifies the register_type_alias mechanism works end-to-end:
+    ShellInterpreter is a registered alias for a Literal, and translation
+    should produce the expected enum schema.
     """
     from poethepoet.config.partition import ShellInterpreter
 


### PR DESCRIPTION
$(cat <<'EOF'
Stacked on #392.

Implementation-era "Phase 1/2/3" references in comments and docstrings are no longer meaningful now that all phases are merged. Replaces each with a description of the actual invariant or behaviour.

## Changes

- `poethepoet/schema/translate.py` — inline comment describing the `None`-if-unset contract no longer needs to credit "Phase 1"
- `tests/schema/conftest.py` — remove stale "Phase 3 will configure..." note (already done)
- `tests/schema/test_smoke.py` — module docstring was "Phase 2 smoke test"; now just "Smoke tests"
- `tests/schema/test_translate.py` — two docstrings referencing "Phase 1" rewording to describe the behaviour directly
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017bT8YwvqhjYtmCBWYjfwMG)_