### PR TITLE
feat: support declared args on script tasks targeting modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,15 @@ Tests use fixture projects in `tests/fixtures/*_project/`. The `run_poe` fixture
       """
   ```
 
+### Schema/runtime validation parity
+
+Runtime validation and the generated JSON Schema (`poethepoet/schema/`) are kept in parity by `tests/schema/test_invalid_corpus.py` ("if the runtime rejects it, the schema should too"). When you add or change validation in `PoeOptions.validate()`, `_task_validations`, or `PoeOptions.parse`:
+
+- prefer expressing simple constraints (pattern, min/max, length, item count, etc.) via `Annotated[T, Metadata(...)]` on the field — `PoeOptions.parse` enforces these at runtime AND the schema generator picks them up from the same annotation, so parity is automatic. Reserve bespoke `validate()` overrides for cross-field rules or constraints that don't fit `Metadata`.
+- when bespoke validation is needed, update the matching `__schema_fragment__` (or generator logic) to encode the same constraint
+- add a fixture to `tests/schema/fixtures/invalid/` with a `# expected_error:` header so the parity test pins the new case
+- check `tests/schema/test_mutation.py` for intentional structural gaps before assuming any mismatch is a bug
+
 ## Development tasks
 
 - This project uses poe tasks to manage project tasks. Always check if there is an applicable poe task for a common action, e.g. running servers, tests or other quality checks.

--- a/docs/_static/partial-poe.json
+++ b/docs/_static/partial-poe.json
@@ -1067,10 +1067,22 @@
     },
     "script_task": {
       "additionalProperties": false,
-      "if": {
-        "properties": { "use_exec": { "const": true } },
-        "required": ["use_exec"]
-      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "use_exec": { "const": true } },
+            "required": ["use_exec"]
+          },
+          "then": { "not": { "required": ["capture_stdout"] } }
+        },
+        {
+          "if": {
+            "properties": { "script": { "pattern": "^[^:]*$" } },
+            "required": ["script"]
+          },
+          "then": { "not": { "required": ["print_result"] } }
+        }
+      ],
       "properties": {
         "args": { "$ref": "#/definitions/args_option" },
         "capture_stdout": {
@@ -1133,15 +1145,26 @@
         }
       },
       "required": ["script"],
-      "then": { "not": { "required": ["capture_stdout"] } },
       "type": "object"
     },
     "script_task_with_case": {
       "additionalProperties": false,
-      "if": {
-        "properties": { "use_exec": { "const": true } },
-        "required": ["use_exec"]
-      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "use_exec": { "const": true } },
+            "required": ["use_exec"]
+          },
+          "then": { "not": { "required": ["capture_stdout"] } }
+        },
+        {
+          "if": {
+            "properties": { "script": { "pattern": "^[^:]*$" } },
+            "required": ["script"]
+          },
+          "then": { "not": { "required": ["print_result"] } }
+        }
+      ],
       "properties": {
         "args": { "$ref": "#/definitions/args_option" },
         "capture_stdout": {
@@ -1225,7 +1248,6 @@
         }
       },
       "required": ["script"],
-      "then": { "not": { "required": ["capture_stdout"] } },
       "type": "object"
     },
     "sequence_task": {

--- a/docs/_static/partial-poe.json
+++ b/docs/_static/partial-poe.json
@@ -6,6 +6,27 @@
   "definitions": {
     "args_item": {
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": { "type": { "const": "boolean" } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  { "type": "boolean" },
+                  {
+                    "pattern": "^(\\s*([Tt]([Rr][Uu][Ee])?|[Ff]([Aa][Ll][Ss][Ee])?|0|1)?\\s*|.*\\$\\{.*)$",
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
       "properties": {
         "choices": {
           "anyOf": [
@@ -65,6 +86,27 @@
     },
     "args_item_no_name": {
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": { "type": { "const": "boolean" } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "default": {
+                "anyOf": [
+                  { "type": "boolean" },
+                  {
+                    "pattern": "^(\\s*([Tt]([Rr][Uu][Ee])?|[Ff]([Aa][Ll][Ss][Ee])?|0|1)?\\s*|.*\\$\\{.*)$",
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
       "properties": {
         "choices": {
           "anyOf": [

--- a/docs/guides/args_guide.rst
+++ b/docs/guides/args_guide.rst
@@ -193,7 +193,9 @@ Named arguments support the following configuration options:
    If true then not providing the argument will result in an error. Arguments are not required by default.
 
 - **type** : ``Literal["string", "float", "integer", "boolean"]``
-   The type that the provided value will be cast to. If not provided then the default behaviour is to keep values as strings. Setting the type to ``"boolean"`` makes the resulting argument a flag that if provided will set the value to the boolean opposite of the default value – i.e. :toml:`"true"` if no default value is given, or :toml:`false` if :toml:`default = true`.
+   The type that the provided value will be cast to. If not provided then the default behaviour is to keep values as strings. Setting the type to ``"boolean"`` makes the resulting argument a flag that if provided will set the value to the boolean opposite of the default value – i.e. :toml:`true` if no default value is given, or :toml:`false` if :toml:`default = true`.
+
+   When ``type = "boolean"``, the ``default`` option (if set) must be a TOML boolean, or one of the following case-insensitive string literals (also accepting surrounding whitespace): ``"t"``, ``"true"``, ``"1"`` for true, and ``"f"``, ``"false"``, ``"0"``, ``""`` for false. A templated string (e.g. ``"${SOME_VAR}"``) is also accepted and re-checked against this same set once the template has been resolved.
 
 .. note::
 

--- a/docs/tasks/task_types/script.rst
+++ b/docs/tasks/task_types/script.rst
@@ -60,7 +60,9 @@ For example, the following task will run the ``http.server`` module as a script 
     { name = "bind", options = ["-b", "--bind"], default = "127.0.0.1" },
   ]
 
-When :doc:`args <../options>` are declared on the task, the parsed values (with defaults applied) are re-emitted onto the module's :python:`sys.argv`.
+When :doc:`args <../options>` are declared on the task, the parsed values (with defaults applied) are re-emitted onto the module's :python:`sys.argv`. CLI tokens that aren't matched by a declared arg, and any tokens that follow :sh:`--`, are forwarded to the module verbatim.
+
+Like the callable form, the module form also implicitly adds :sh:`<project_root>/src` to the subprocess :sh:`PYTHONPATH` so that modules placed in a ``src/`` directory at the project root are importable without extra configuration.
 
 
 Output the return value

--- a/docs/tasks/task_types/script.rst
+++ b/docs/tasks/task_types/script.rst
@@ -47,14 +47,20 @@ This is fine if functions for poe tasks are defined alongside other source in a 
 Run a ``__main__`` module as a script task
 ------------------------------------------
 
-A script task may reference a package instead of a specific callable, in which case the package's ``__main__.py`` module will be executed as a script task. This is useful for running a package that has been designed to be run as a script.
+A script task may reference a package instead of a specific callable, in which case the package's ``__main__.py`` module will be executed as a script task, or th module itself if it's not a package (the usual behavior from ``python -m``). This is useful for running a package or module that has been designed to be run as a script.
 
 For example, the following task will run the ``http.server`` module as a script task, which will start a simple HTTP server. Any command line arguments passed to the task will be forwarded to the script.
 
 .. code-block:: toml
 
-  [tool.poe.tasks]
-  fetch-assets.script = "http.server"
+  [tool.poe.tasks.serve]
+  script = "http.server"
+  args = [
+    { name = "port", options = ["-p"], default = "8000" },
+    { name = "bind", options = ["-b", "--bind"], default = "127.0.0.1" },
+  ]
+
+When :doc:`args <../options>` are declared on the task, the parsed values (with defaults applied) are re-emitted onto the module's :python:`sys.argv`.
 
 
 Output the return value

--- a/docs/tasks/task_types/script.rst
+++ b/docs/tasks/task_types/script.rst
@@ -47,7 +47,7 @@ This is fine if functions for poe tasks are defined alongside other source in a 
 Run a ``__main__`` module as a script task
 ------------------------------------------
 
-A script task may reference a package instead of a specific callable, in which case the package's ``__main__.py`` module will be executed as a script task, or th module itself if it's not a package (the usual behavior from ``python -m``). This is useful for running a package or module that has been designed to be run as a script.
+A script task may reference a package instead of a specific callable, in which case the package's ``__main__.py`` module will be executed as a script task, or the module itself if it's not a package (the usual behavior from ``python -m``). This is useful for running a package or module that has been designed to be run as a script.
 
 For example, the following task will run the ``http.server`` module as a script task, which will start a simple HTTP server. Any command line arguments passed to the task will be forwarded to the script.
 

--- a/poethepoet/skills/poethepoet/references/args-reference.md
+++ b/poethepoet/skills/poethepoet/references/args-reference.md
@@ -135,6 +135,7 @@ args = [{ name = "_target", positional = true }]
 | `shell`                | `${name}` environment variable (public args only)                                  |
 | `script`               | As kwargs when no parens: `script = "module:fn"` with `args = ["x"]` → `fn(x=val)` |
 | `script` (with parens) | Explicitly in call: `"module:fn(_x, y=_y)"`                                        |
+| `script` (module form) | Re-emitted on the module's `sys.argv` (with defaults applied)                      |
 | `expr`                 | As Python variables: `name` is directly accessible                                 |
 | `sequence`/`parallel`  | Via env vars, or forwarded via `$POE_EXTRA_ARGS`                                   |
 

--- a/poethepoet/skills/poethepoet/references/args-reference.md
+++ b/poethepoet/skills/poethepoet/references/args-reference.md
@@ -95,6 +95,8 @@ args = [{ name = "verbose", options = ["-v", "--verbose"], type = "boolean" }]
 
 Usage: `poe test --verbose` (true) or `poe test` (false / default)
 
+The `default` for a boolean arg must be a TOML bool, or a case-insensitive string literal (with optional surrounding whitespace) from `"t"`/`"true"`/`"1"` (true) or `"f"`/`"false"`/`"0"`/`""` (false). Templated strings (e.g. `"${VAR}"`) are also accepted and re-checked once resolved.
+
 In script/expr tasks the resulting pythonic variable will have type the declared type (e.g. boolean). However when accessed via parameter expansion or as an environment variable at runtime, the variable will be `"True"` if truthy, or unset of falsey, so that `:-` and `:+` parameter expansion operators work seamlessly, and for consistent semantics across interpreters in shell tasks.
 
 ---

--- a/poethepoet/skills/poethepoet/references/task-types.md
+++ b/poethepoet/skills/poethepoet/references/task-types.md
@@ -82,7 +82,7 @@ args = [
 
 **Options**:
 
-- `print_result = true` — print return value to stdout (useful for computed outputs)
+- `print_result = true` — print return value to stdout (callable form only; rejected on module form, since `python -m` has no return value)
 - Async functions are automatically run with `asyncio.run()`
 
 ---

--- a/poethepoet/task/args.py
+++ b/poethepoet/task/args.py
@@ -266,6 +266,16 @@ class ArgSpec(PoeOptions):
                 "Argument with type 'boolean' may not declare option 'multiple'"
             )
 
+        # Templated defaults are checked at runtime once the template has
+        # been resolved (see _get_argument_params).
+        if (
+            self.type == "boolean"
+            and self.default is not None
+            and not isinstance(self.default, bool)
+            and not (isinstance(self.default, str) and "${" in self.default)
+        ):
+            _coerce_bool(self.default)
+
         # Ensure choices are compatible with type
         if self.choices is not None:
             arg_type = arg_types.get(self.type, str)
@@ -407,8 +417,16 @@ class PoeTaskArgs:
             result["choices"] = arg.choices
 
         if arg_type == "boolean":
-            if default:
+            try:
+                coerced_default = (
+                    _coerce_bool(default) if default is not None else False
+                )
+            except ConfigValidationError as error:
+                error.context = f"Invalid default for argument {arg.name!r}"
+                raise
+            if coerced_default:
                 result["action"] = "store_false"
+                result["default"] = True
             else:
                 result["action"] = "store_true"
                 result["default"] = False
@@ -442,7 +460,7 @@ class PoeTaskArgs:
         # args named with dash case are converted to snake case before being exposed
         return {name.replace("-", "_"): value for name, value in parsed_args.items()}
 
-    def format_argv(self, values: Mapping[str, Any]) -> list[str]:
+    def format_argv(self, values: Mapping[str, Any], env: TaskEnv) -> list[str]:
         """
         Re-emit parsed argument values as CLI tokens — the inverse of
         :meth:`parse`. Used to forward declared args (with defaults already
@@ -464,10 +482,17 @@ class PoeTaskArgs:
             value = values[arg.name]
 
             if arg.type == "boolean":
-                # bool() mirrors the parser builder's coercion (args.py
-                # "if default:"), so an undeclared default is treated as
-                # False — matching the argparse store_true default.
-                if value != bool(arg.default):
+                raw_default = arg.get("default")
+                if isinstance(raw_default, str):
+                    raw_default = env.fill_template(raw_default)
+                try:
+                    default_bool = (
+                        _coerce_bool(raw_default) if raw_default is not None else False
+                    )
+                except ConfigValidationError as error:
+                    error.context = f"Invalid default for argument {arg.name!r}"
+                    raise
+                if value != default_bool:
                     result.append(arg.options[0])
                 continue
 
@@ -488,3 +513,30 @@ class PoeTaskArgs:
                 result.append(str(value))
 
         return result
+
+
+_BOOL_TRUE_LITERALS = frozenset({"t", "true", "1"})
+_BOOL_FALSE_LITERALS = frozenset({"f", "false", "0", ""})
+
+
+def _coerce_bool(value: Any) -> bool:
+    """
+    Coerce a config-supplied value to a real bool.
+
+    Accepts Python bools as-is, and a small set of case-insensitive string
+    literals (stripped of surrounding whitespace): ``t``/``true``/``1`` for
+    True and ``f``/``false``/``0``/``""`` for False. Anything else raises
+    ``ConfigValidationError``.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _BOOL_TRUE_LITERALS:
+            return True
+        if normalized in _BOOL_FALSE_LITERALS:
+            return False
+    raise ConfigValidationError(
+        f"Cannot interpret {value!r} as a boolean — expected a boolean or one of "
+        "'true'/'1'/'t' or 'false'/'0'/'f'/'' (case-insensitive)"
+    )

--- a/poethepoet/task/args.py
+++ b/poethepoet/task/args.py
@@ -441,3 +441,50 @@ class PoeTaskArgs:
                 del parsed_args[dest]
         # args named with dash case are converted to snake case before being exposed
         return {name.replace("-", "_"): value for name, value in parsed_args.items()}
+
+    def format_argv(self, values: Mapping[str, Any]) -> list[str]:
+        """
+        Re-emit parsed argument values as CLI tokens — the inverse of
+        :meth:`parse`. Used to forward declared args (with defaults already
+        applied by the parser) into a subprocess that does its own CLI
+        parsing, e.g. ``python -m some_module``.
+
+        Conventions: positionals are emitted in declared order; option args
+        use the first entry of their ``options`` list as the flag name;
+        boolean flags are emitted iff the resolved value differs from the
+        declared default (i.e. the user provided the flag on the CLI);
+        multi-value args are emitted space-separated, matching argparse's
+        ``nargs="+"`` style.
+        """
+
+        result: list[str] = []
+        for arg in self._args:
+            if arg.name not in values:
+                continue
+            value = values[arg.name]
+
+            if arg.type == "boolean":
+                # bool() mirrors the parser builder's coercion (args.py
+                # "if default:"), so an undeclared default is treated as
+                # False — matching the argparse store_true default.
+                if value != bool(arg.default):
+                    result.append(arg.options[0])
+                continue
+
+            if arg.positional:
+                if arg.multiple:
+                    result.extend(str(item) for item in value)
+                elif value is not None:
+                    result.append(str(value))
+                continue
+
+            flag = arg.options[0]
+            if arg.multiple:
+                if value:
+                    result.append(flag)
+                    result.extend(str(item) for item in value)
+            elif value is not None:
+                result.append(flag)
+                result.append(str(value))
+
+        return result

--- a/poethepoet/task/args.py
+++ b/poethepoet/task/args.py
@@ -204,11 +204,44 @@ class ArgSpec(PoeOptions):
         """
         Override: `options` is normalizer-supplied (derived from `name`
         if not provided), so it shouldn't be required in the schema.
+
+        Also encode the runtime constraint that boolean defaults must be
+        either a real bool or a recognised string literal — the same set
+        accepted by ``_coerce_bool``. Template-shaped strings (containing
+        ``${``) are passed through; their resolved value is re-checked at
+        runtime. The pattern uses explicit case alternation rather than
+        ``(?i)`` because JSON Schema mandates ECMA-262 regex, which does
+        not support inline flags.
         """
         fragment = super().__schema_fragment__(ctx)
         fragment["required"] = sorted(
             key for key in fragment.get("required", []) if key != "options"
         )
+        fragment["allOf"] = [
+            {
+                "if": {
+                    "properties": {"type": {"const": "boolean"}},
+                    "required": ["type"],
+                },
+                "then": {
+                    "properties": {
+                        "default": {
+                            "anyOf": [
+                                {"type": "boolean"},
+                                {
+                                    "type": "string",
+                                    "pattern": (
+                                        r"^(\s*([Tt]([Rr][Uu][Ee])?"
+                                        r"|[Ff]([Aa][Ll][Ss][Ee])?|0|1)?\s*"
+                                        r"|.*\$\{.*)$"
+                                    ),
+                                },
+                            ]
+                        }
+                    }
+                },
+            }
+        ]
         return fragment
 
     def validate(self):

--- a/poethepoet/task/base.py
+++ b/poethepoet/task/base.py
@@ -437,6 +437,8 @@ class PoeTask(metaclass=MetaPoeTask):
 
     spec: TaskSpec
     ctx: TaskContext
+
+    _task_args: PoeTaskArgs | None = None
     _parsed_args: tuple[dict[str, str], tuple[str, ...]] | None = None
     _parsed_content: AstNode | None = None
 
@@ -530,6 +532,17 @@ class PoeTask(metaclass=MetaPoeTask):
         content = self.spec.content
         return "$POE_EXTRA_ARGS" in content or "${POE_EXTRA_ARGS" in content
 
+    @property
+    def task_args(self) -> PoeTaskArgs | None:
+        """
+        Lazily-resolved ``PoeTaskArgs`` for this task — ``None`` if no args
+        are declared. Cached per task run so the parse and re-emit paths
+        share one instance.
+        """
+        if self._task_args is None:
+            self._task_args = self.spec.get_args(self.ctx.io)
+        return self._task_args
+
     def get_parsed_arguments(
         self, env: TaskEnv
     ) -> tuple[dict[str, Any], tuple[str, ...]]:
@@ -543,7 +556,7 @@ class PoeTask(metaclass=MetaPoeTask):
         if self._parsed_args is None:
             all_args = self.invocation[1:]
 
-            if task_args := self.spec.get_args(self.ctx.io):
+            if task_args := self.task_args:
                 try:
                     split_index = all_args.index("--")
                     option_args = all_args[:split_index]

--- a/poethepoet/task/script.py
+++ b/poethepoet/task/script.py
@@ -189,7 +189,7 @@ class ScriptTask(PoeTask):
         # in-process for `python -m`, so it has to be set on the subprocess env.
         # TODO: only do this when the project actually uses src layout
         #       (same caveat as the callable path).
-        existing_pythonpath = env.to_dict().get("PYTHONPATH", "")
+        existing_pythonpath = env.get("PYTHONPATH", "")
         env.set(
             "PYTHONPATH",
             f"src{os.pathsep}{existing_pythonpath}" if existing_pythonpath else "src",

--- a/poethepoet/task/script.py
+++ b/poethepoet/task/script.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import shlex
 from typing import TYPE_CHECKING, Any
 
@@ -67,19 +68,22 @@ class ScriptTask(PoeTask):
 
             validate_script_or_module_reference(self.content)
 
-            if ":" not in self.content and self.has_args:
+            if ":" not in self.content and self.options.get("print_result"):
                 raise ConfigValidationError(
-                    "Script task referencing a module (instead of a function) cannot "
-                    "declare arguments."
+                    "'print_result' is not supported on a script task that "
+                    "references a module (it only makes sense when the task "
+                    "calls a python callable that returns a value)."
                 )
 
     @classmethod
     def __schema_fragment__(cls, ctx: Any) -> dict:
         """
         Override: attach python-callable examples on the ``script``
-        discriminator field, and forbid the ``use_exec`` +
-        ``capture_stdout`` combination (runtime ``TaskOptions.validate``
-        rejects it too).
+        discriminator field, and encode two mutually-exclusive option
+        combinations that the runtime also rejects:
+        ``use_exec`` + ``capture_stdout`` (``TaskOptions.validate``);
+        and ``print_result`` on a module-style script — recognised by the
+        ``script`` reference containing no ``:`` (``_task_validations``).
         """
         fragment = super().__schema_fragment__(ctx)
         fragment["properties"]["script"]["examples"] = [
@@ -87,11 +91,22 @@ class ScriptTask(PoeTask):
             "my_pkg.my_module:main",
             "my_pkg.my_module:main(only='images', log_env={'LOG_PATH':'/var/log'})",
         ]
-        fragment["if"] = {
-            "properties": {"use_exec": {"const": True}},
-            "required": ["use_exec"],
-        }
-        fragment["then"] = {"not": {"required": ["capture_stdout"]}}
+        fragment["allOf"] = [
+            {
+                "if": {
+                    "properties": {"use_exec": {"const": True}},
+                    "required": ["use_exec"],
+                },
+                "then": {"not": {"required": ["capture_stdout"]}},
+            },
+            {
+                "if": {
+                    "properties": {"script": {"pattern": "^[^:]*$"}},
+                    "required": ["script"],
+                },
+                "then": {"not": {"required": ["print_result"]}},
+            },
+        ]
         return fragment
 
     spec: TaskSpec
@@ -166,8 +181,24 @@ class ScriptTask(PoeTask):
         Execute the python module referenced by the task content
         """
 
+        named_arg_values, extra_args = self.get_parsed_arguments(env)
+        env.register_task_args(named_arg_values, extra_args)
+
+        # Mirror the callable path's sys.path.append('src') by prepending
+        # 'src' to PYTHONPATH. Unlike a sys.path append it can't be done
+        # in-process for `python -m`, so it has to be set on the subprocess env.
+        # TODO: only do this when the project actually uses src layout
+        #       (same caveat as the callable path).
+        existing_pythonpath = env.to_dict().get("PYTHONPATH", "")
+        env.set(
+            "PYTHONPATH",
+            f"src{os.pathsep}{existing_pythonpath}" if existing_pythonpath else "src",
+        )
+
+        declared_args = self.spec.get_args(self.ctx.io)
         argv = [
-            *(env.fill_template(token) for token in self.invocation[1:]),
+            *(declared_args.format_argv(named_arg_values) if declared_args else ()),
+            *extra_args,
         ]
         cmd = ("python", "-m", self.spec.content, *argv)
 

--- a/poethepoet/task/script.py
+++ b/poethepoet/task/script.py
@@ -184,20 +184,33 @@ class ScriptTask(PoeTask):
         named_arg_values, extra_args = self.get_parsed_arguments(env)
         env.register_task_args(named_arg_values, extra_args)
 
-        # Mirror the callable path's sys.path.append('src') by prepending
-        # 'src' to PYTHONPATH. Unlike a sys.path append it can't be done
-        # in-process for `python -m`, so it has to be set on the subprocess env.
+        # Approximate the callable path's sys.path.append('src') by appending
+        # '<project_root>/src' to PYTHONPATH. The absolute form means a task
+        # with its own cwd (or invoking poe from a subdirectory) still resolves
+        # to the project's src/, rather than the subprocess's cwd-relative src/.
+        # All PYTHONPATH entries collectively precede site-packages in sys.path
+        # regardless of internal order, so an installed package can still be
+        # shadowed by a local src/ — fully mirroring append semantics would
+        # require a wrapper script.
         # TODO: only do this when the project actually uses src layout
         #       (same caveat as the callable path).
+        src_path = str(self.ctx.config.project_dir / "src")
         existing_pythonpath = env.get("PYTHONPATH", "")
         env.set(
             "PYTHONPATH",
-            f"src{os.pathsep}{existing_pythonpath}" if existing_pythonpath else "src",
+            (
+                f"{existing_pythonpath}{os.pathsep}{src_path}"
+                if existing_pythonpath
+                else src_path
+            ),
         )
 
-        declared_args = self.spec.get_args(self.ctx.io)
         argv = [
-            *(declared_args.format_argv(named_arg_values) if declared_args else ()),
+            *(
+                task_args.format_argv(named_arg_values, env)
+                if (task_args := self.task_args)
+                else ()
+            ),
             *extra_args,
         ]
         cmd = ("python", "-m", self.spec.content, *argv)

--- a/tests/fixtures/cmds_project/pyproject.toml
+++ b/tests/fixtures/cmds_project/pyproject.toml
@@ -72,7 +72,7 @@ args = [
     { name = "non", type = "boolean" },
     { name = "tru", type = "boolean", default = true },
     { name = "fal", type = "boolean", default = false },
-    { name = "txt", type = "boolean", default = "text" },
+    { name = "txt", type = "boolean", default = "true" },
 ]
 
 [tool.poe.tasks.int_zero_default]

--- a/tests/fixtures/expr_project/pyproject.toml
+++ b/tests/fixtures/expr_project/pyproject.toml
@@ -63,7 +63,7 @@ args = [
   { name = "non", type = "boolean" },
   { name = "tru", type = "boolean", default = true },
   { name = "fal", type = "boolean", default = false },
-  { name = "txt", type = "boolean", default = "text" },
+  { name = "txt", type = "boolean", default = "true" },
 ]
 
 [tool.poe.tasks.multi_value_expr]

--- a/tests/fixtures/scripts_project/pyproject.toml
+++ b/tests/fixtures/scripts_project/pyproject.toml
@@ -267,7 +267,7 @@ args = [
   { name = "non", type = "boolean" },
   { name = "tru", type = "boolean", default = true },
   { name = "fal", type = "boolean", default = false },
-  { name = "txt", type = "boolean", default = "text" },
+  { name = "txt", type = "boolean", default = "true" },
 ]
 
 [tool.poe.tasks.bool_partial]

--- a/tests/fixtures/sequences_project/pyproject.toml
+++ b/tests/fixtures/sequences_project/pyproject.toml
@@ -97,7 +97,7 @@ args = [
   { name = "non", type = "boolean" },
   { name = "tru", type = "boolean", default = true },
   { name = "fal", type = "boolean", default = false },
-  { name = "txt", type = "boolean", default = "text" },
+  { name = "txt", type = "boolean", default = "true" },
 ]
 sequence = [
   { cmd = """poe_test_echo \\

--- a/tests/fixtures/shells_project/pyproject.toml
+++ b/tests/fixtures/shells_project/pyproject.toml
@@ -84,7 +84,7 @@ args = [
     { name = "non", type = "boolean" },
     { name = "tru", type = "boolean", default = true },
     { name = "fal", type = "boolean", default = false },
-    { name = "txt", type = "boolean", default = "text" },
+    { name = "txt", type = "boolean", default = "true" },
 ]
 
 [tool.poe.tasks.bool_env_collision]

--- a/tests/fixtures/switch_project/pyproject.toml
+++ b/tests/fixtures/switch_project/pyproject.toml
@@ -105,12 +105,12 @@ args = [
   { name = "non", type = "boolean" },
   { name = "tru", type = "boolean", default = true },
   { name = "fal", type = "boolean", default = false },
-  { name = "txt", type = "boolean", default = "text" },
+  { name = "txt", type = "boolean", default = "true" },
 ]
 
   [[tool.poe.tasks.booleans-cmd.switch]]
-  case = "text"
-  cmd = """poe_test_echo case=text\\
+  case = "True"
+  cmd = """poe_test_echo case=True\\
 \\${non}=${non} \\${non:+plus}=${non:+plus} \\${non:-minus}=${non:-minus}\\
 \\${fal}=${fal} \\${fal:+plus}=${fal:+plus} \\${fal:-minus}=${fal:-minus}\\
 \\${tru}=${tru} \\${tru:+plus}=${tru:+plus} \\${tru:-minus}=${tru:-minus}\\
@@ -146,7 +146,7 @@ args = [
   { name = "non", type = "boolean" },
   { name = "tru", type = "boolean", default = true },
   { name = "fal", type = "boolean", default = false },
-  { name = "txt", type = "boolean", default = "text" },
+  { name = "txt", type = "boolean", default = "true" },
 ]
 
   [[tool.poe.tasks.booleans-expr.switch]]

--- a/tests/schema/fixtures/invalid/boolean_default_unrecognised.toml
+++ b/tests/schema/fixtures/invalid/boolean_default_unrecognised.toml
@@ -1,0 +1,4 @@
+# expected_error: Cannot interpret 'yes' as a boolean
+[tool.poe.tasks.bad]
+cmd = "poe_test_echo ${flag}"
+args = [{ name = "flag", type = "boolean", default = "yes" }]

--- a/tests/schema/fixtures/invalid/script_module_print_result.toml
+++ b/tests/schema/fixtures/invalid/script_module_print_result.toml
@@ -1,0 +1,4 @@
+# expected_error: 'print_result' is not supported on a script task that references a module
+[tool.poe.tasks.bad]
+script = "some_module"
+print_result = true

--- a/tests/schema/fixtures/invalid/use_exec_and_capture_stdout.toml
+++ b/tests/schema/fixtures/invalid/use_exec_and_capture_stdout.toml
@@ -1,0 +1,5 @@
+# expected_error: 'use_exec' and 'capture_stdout' options cannot be both provided
+[tool.poe.tasks.bad]
+cmd = "echo hi"
+use_exec = true
+capture_stdout = "out.log"

--- a/tests/schema/test_invalid_corpus.py
+++ b/tests/schema/test_invalid_corpus.py
@@ -1,18 +1,29 @@
 """
 Parity: each curated invalid config in tests/schema/fixtures/invalid/
-is rejected by BOTH the runtime PoeOptions parser AND the generated
-schema. Both validators must reject; otherwise the schema is too lax.
+is rejected by BOTH the full runtime config-load-and-validate pipeline
+AND the generated schema. Both validators must reject; otherwise the
+schema is too lax.
 
 Each fixture file's first line is `# expected_error: <substring>` —
 the runtime's ConfigValidationError message must contain that substring.
+
+The runtime check runs the same flow as ``PoeThePoet._call`` (config
+load + ``task_spec.validate``), so it covers both options-level errors
+caught by ``PoeOptions.parse`` and task-level errors caught by
+``TaskSpec._task_validations`` (e.g. content+option restrictions).
 """
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
 from jsonschema import Draft7Validator
+
+from poethepoet.app import PoeThePoet
+from poethepoet.exceptions import ConfigValidationError
+from poethepoet.schema import build_schema
 
 # Match the project-wide pattern (tests/conftest.py:21-25) — `tomllib`
 # is stdlib only in Python 3.11+, but the project supports 3.10.
@@ -20,9 +31,6 @@ try:
     import tomllib as tomli
 except ImportError:
     import tomli  # type: ignore[no-redef]
-
-from poethepoet.exceptions import ConfigValidationError
-from poethepoet.schema import build_schema
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 INVALID_DIR = REPO_ROOT / "tests" / "schema" / "fixtures" / "invalid"
@@ -47,6 +55,25 @@ def _discover_invalid_fixtures() -> list[tuple[str, Path, str]]:
     return results
 
 
+def _run_runtime_validation(fixture_path: Path, tmp_path: Path) -> None:
+    """
+    Mirror PoeThePoet._call's load-and-validate flow against the fixture.
+    Raises ConfigValidationError if either config load or
+    task_spec.validate rejects the config.
+    """
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_bytes(fixture_path.read_bytes())
+
+    poe = PoeThePoet(cwd=tmp_path)
+
+    async def load_and_validate() -> None:
+        await poe.config.load(target_path=tmp_path)
+        for task_spec in poe.task_specs.load_all():
+            task_spec.validate(poe.config, poe.task_specs)
+
+    asyncio.run(load_and_validate())
+
+
 @pytest.fixture(scope="session")
 def validator() -> Draft7Validator:
     """
@@ -65,6 +92,7 @@ def test_invalid_fixture_rejected_by_both_validators(
     fixture_path: Path,
     expected_error: str,
     validator: Draft7Validator,
+    tmp_path: Path,
 ) -> None:
     """
     Both runtime and schema must reject the fixture's [tool.poe] block.
@@ -73,11 +101,10 @@ def test_invalid_fixture_rejected_by_both_validators(
     data = tomli.loads(raw.decode())
     poe_config = data.get("tool", {}).get("poe", data)
 
-    # 1. Runtime rejects with the expected error substring.
-    from poethepoet.config.partition import ProjectConfig
-
+    # 1. Runtime rejects with the expected error substring — via the same
+    #    load+validate flow that PoeThePoet runs on real configs.
     with pytest.raises(ConfigValidationError) as runtime_excinfo:
-        list(ProjectConfig.ConfigOptions.parse(poe_config, strict=True))
+        _run_runtime_validation(fixture_path, tmp_path)
     runtime_message = str(runtime_excinfo.value)
     assert expected_error in runtime_message, (
         f"Runtime error {runtime_message!r} does not contain "

--- a/tests/schema/test_smoke.py
+++ b/tests/schema/test_smoke.py
@@ -171,18 +171,48 @@ def test_build_schema_use_exec_and_capture_stdout_are_mutex() -> None:
     mutual exclusion at runtime
     (``cmd.py:58``, ``script.py:51``, ``expr.py:59``). The schema mirrors
     this via an if/then constraint that forbids ``capture_stdout`` when
-    ``use_exec`` is true.
+    ``use_exec`` is true. Some task variants encode multiple such
+    constraints via ``allOf``; collect the conditional clauses uniformly.
     """
     schema = build_schema()
-    for key in ("cmd", "script", "expr"):
-        variant = schema["definitions"][f"{key}_task"]
-        assert variant.get("if") == {
+    expected_clause = {
+        "if": {
             "properties": {"use_exec": {"const": True}},
             "required": ["use_exec"],
-        }, f"{key} missing if-clause"
-        assert variant.get("then") == {
-            "not": {"required": ["capture_stdout"]}
-        }, f"{key} missing then-clause"
+        },
+        "then": {"not": {"required": ["capture_stdout"]}},
+    }
+    for key in ("cmd", "script", "expr"):
+        variant = schema["definitions"][f"{key}_task"]
+        clauses = (
+            variant["allOf"]
+            if "allOf" in variant
+            else [{"if": variant.get("if"), "then": variant.get("then")}]
+        )
+        assert (
+            expected_clause in clauses
+        ), f"{key} missing use_exec/capture_stdout mutex clause"
+
+
+def test_build_schema_script_module_forbids_print_result() -> None:
+    """
+    ``print_result`` is meaningless on a module-style script task (the
+    runtime rejects it in ``_task_validations``). The schema encodes the
+    same restriction with an if/then clause that triggers when the
+    ``script`` reference contains no ``:``.
+    """
+    schema = build_schema()
+    variant = schema["definitions"]["script_task"]
+    expected_clause = {
+        "if": {
+            "properties": {"script": {"pattern": "^[^:]*$"}},
+            "required": ["script"],
+        },
+        "then": {"not": {"required": ["print_result"]}},
+    }
+    assert expected_clause in variant.get(
+        "allOf", []
+    ), "script_task missing module/print_result clause"
 
 
 def test_build_schema_ref_task_forbids_executor() -> None:

--- a/tests/test_cmd_tasks.py
+++ b/tests/test_cmd_tasks.py
@@ -233,85 +233,58 @@ def test_cmd_with_empty_glob_fail(run_poe):
     assert result.stderr == ""
 
 
-def test_cmd_boolean_flag(run_poe):
-    result = run_poe(
-        "booleans",
-        "--non",
-        "--tru",
-        "--fal",
-        "--txt",
-        project="cmds",
-    )
-    assert result.capture == (
-        r"""Poe => poe_test_echo '
-${non}=True' '${non:+plus}=plus' '${non:-minus}=True
-${fal}=True' '${fal:+plus}=plus' '${fal:-minus}=True
-${tru}=' '${tru:+plus}=' '${tru:-minus}=minus
-${txt}=' '${txt:+plus}=' '${txt:-minus}=minus'
-"""
-    )
-    assert result.stdout.endswith(
-        """
-${non}=True ${non:+plus}=plus ${non:-minus}=True
+@pytest.mark.parametrize(
+    ("cli_args", "expected_env_lines"),
+    [
+        pytest.param(
+            (),
+            """${non}= ${non:+plus}= ${non:-minus}=minus
+${fal}= ${fal:+plus}= ${fal:-minus}=minus
+${tru}=True ${tru:+plus}=plus ${tru:-minus}=True
+${txt}=True ${txt:+plus}=plus ${txt:-minus}=True
+""",
+            id="defaults",
+        ),
+        pytest.param(
+            ("--non", "--tru", "--fal", "--txt"),
+            """${non}=True ${non:+plus}=plus ${non:-minus}=True
 ${fal}=True ${fal:+plus}=plus ${fal:-minus}=True
 ${tru}= ${tru:+plus}= ${tru:-minus}=minus
 ${txt}= ${txt:+plus}= ${txt:-minus}=minus
-""".lstrip()
-    )
-
-
-def test_cmd_boolean_flag_default_value(run_poe):
-    result = run_poe("booleans", project="cmds")
-    assert result.capture == (
-        r"""Poe => poe_test_echo '
-${non}=' '${non:+plus}=' '${non:-minus}=minus
-${fal}=' '${fal:+plus}=' '${fal:-minus}=minus
-${tru}=True' '${tru:+plus}=plus' '${tru:-minus}=True
-${txt}=text' '${txt:+plus}=plus' '${txt:-minus}=text'
-"""
-    )
-    assert result.stdout.endswith(
-        """
-${non}= ${non:+plus}= ${non:-minus}=minus
-${fal}= ${fal:+plus}= ${fal:-minus}=minus
-${tru}=True ${tru:+plus}=plus ${tru:-minus}=True
-${txt}=text ${txt:+plus}=plus ${txt:-minus}=text
-""".lstrip()
-    )
-
-
-def test_cmd_boolean_flag_partial_negate_true(run_poe):
-    """Only --tru passed: negates default=true to False (unset), others keep defaults"""
-    result = run_poe(
-        "booleans",
-        "--tru",
-        project="cmds",
-    )
-    assert result.stdout.endswith(
-        """
-${non}= ${non:+plus}= ${non:-minus}=minus
+""",
+            id="all_toggled",
+        ),
+        pytest.param(
+            ("--tru",),
+            """${non}= ${non:+plus}= ${non:-minus}=minus
 ${fal}= ${fal:+plus}= ${fal:-minus}=minus
 ${tru}= ${tru:+plus}= ${tru:-minus}=minus
-${txt}=text ${txt:+plus}=plus ${txt:-minus}=text
-""".lstrip()
-    )
-
-
-def test_cmd_boolean_flag_partial_negate_string(run_poe):
-    """--txt negates default="text" to False (unset), others keep defaults"""
-    result = run_poe(
-        "booleans",
-        "--txt",
-        project="cmds",
-    )
-    assert result.stdout.endswith(
-        """
-${non}= ${non:+plus}= ${non:-minus}=minus
+${txt}=True ${txt:+plus}=plus ${txt:-minus}=True
+""",
+            id="negate_tru",
+        ),
+        pytest.param(
+            ("--txt",),
+            """${non}= ${non:+plus}= ${non:-minus}=minus
 ${fal}= ${fal:+plus}= ${fal:-minus}=minus
 ${tru}=True ${tru:+plus}=plus ${tru:-minus}=True
 ${txt}= ${txt:+plus}= ${txt:-minus}=minus
-""".lstrip()
-    )
+""",
+            id="negate_txt",
+        ),
+    ],
+)
+def test_cmd_boolean_flag(
+    run_poe, cli_args: tuple[str, ...], expected_env_lines: str
+) -> None:
+    """
+    Boolean args toggle: --flag flips a default-truthy value to False (env
+    var unset) and a default-falsy value to True (env var "True"). Holds
+    regardless of whether the default was written as a TOML bool (``tru``)
+    or as a recognised string literal (``txt`` → ``"true"``).
+    """
+    result = run_poe("booleans", *cli_args, project="cmds")
+    assert result.stdout.endswith(expected_env_lines)
 
 
 def test_cmd_int_zero_default(run_poe):

--- a/tests/test_expr_task.py
+++ b/tests/test_expr_task.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_expr_with_args(run_poe):
     result = run_poe("expr_with_args", project="expr")
     assert result.capture == (
@@ -102,23 +105,37 @@ def test_christmas_tree_expr(run_poe):
     assert result.code == 0
 
 
-def test_expr_boolean_flag(run_poe):
-    result = run_poe("booleans", "--non", "--tru", "--fal", "--txt", project="expr")
+@pytest.mark.parametrize(
+    ("cli_args", "expected_dict"),
+    [
+        pytest.param(
+            (),
+            "{'non': False, 'tru': True, 'fal': False, 'txt': True}",
+            id="defaults",
+        ),
+        pytest.param(
+            ("--non", "--tru", "--fal", "--txt"),
+            "{'non': True, 'tru': False, 'fal': True, 'txt': False}",
+            id="all_toggled",
+        ),
+        pytest.param(
+            ("--non", "--tru"),
+            "{'non': True, 'tru': False, 'fal': False, 'txt': True}",
+            id="partial",
+        ),
+    ],
+)
+def test_expr_boolean_flag(
+    run_poe, cli_args: tuple[str, ...], expected_dict: str
+) -> None:
+    """
+    Boolean args reach an expr task as real Python bools — the parser
+    coerces both TOML bools (``tru``) and recognised string literals
+    (``txt`` → ``"true"``) to True/False before the expr is evaluated.
+    """
+    result = run_poe("booleans", *cli_args, project="expr")
     assert result.capture == "Poe => {'non':non, 'tru':tru, 'fal':fal, 'txt':txt}\n"
-    assert result.stdout == "{'non': True, 'tru': False, 'fal': True, 'txt': False}\n"
-
-
-def test_expr_boolean_flag_default_value(run_poe):
-    result = run_poe("booleans", project="expr")
-    assert result.capture == "Poe => {'non':non, 'tru':tru, 'fal':fal, 'txt':txt}\n"
-    assert result.stdout == "{'non': False, 'tru': True, 'fal': False, 'txt': 'text'}\n"
-
-
-def test_expr_boolean_flag_partial(run_poe):
-    """--non toggles False->True, --tru negates True->False, fal/txt keep defaults"""
-    result = run_poe("booleans", "--non", "--tru", project="expr")
-    assert result.capture == "Poe => {'non':non, 'tru':tru, 'fal':fal, 'txt':txt}\n"
-    assert result.stdout == "{'non': True, 'tru': False, 'fal': False, 'txt': 'text'}\n"
+    assert result.stdout == f"{expected_dict}\n"
 
 
 def test_expr_multi_value_typed_list(run_poe):

--- a/tests/test_format_argv.py
+++ b/tests/test_format_argv.py
@@ -1,0 +1,138 @@
+"""
+Unit tests for ``PoeTaskArgs.format_argv`` — the inverse of ``parse``, used
+when a module-style script task needs to forward declared args (with defaults
+applied) into a ``python -m`` subprocess.
+"""
+
+import pytest
+
+from poethepoet.io import PoeIO
+from poethepoet.task.args import PoeTaskArgs
+
+
+def _args(args_def):
+    return PoeTaskArgs(args_def, "task", PoeIO(make_default=False))
+
+
+def test_positional_emits_value():
+    args = _args([{"name": "x", "positional": True}])
+    assert args.format_argv({"x": "hello"}) == ["hello"]
+
+
+def test_positional_multi_value_emits_inline():
+    args = _args([{"name": "items", "positional": True, "multiple": True}])
+    assert args.format_argv({"items": ["a", "b", "c"]}) == ["a", "b", "c"]
+
+
+def test_option_emits_flag_and_value():
+    args = _args([{"name": "out", "options": ["--out"]}])
+    assert args.format_argv({"out": "build"}) == ["--out", "build"]
+
+
+@pytest.mark.parametrize(
+    ("options", "expected_flag"),
+    [
+        (["-o", "--out"], "-o"),
+        (["--out", "-o"], "--out"),
+    ],
+)
+def test_option_first_declared_name_wins(options, expected_flag):
+    args = _args([{"name": "out", "options": options}])
+    assert args.format_argv({"out": "build"}) == [expected_flag, "build"]
+
+
+def test_option_multi_value_space_separated():
+    args = _args([{"name": "files", "options": ["--files"], "multiple": True}])
+    assert args.format_argv({"files": ["a", "b"]}) == ["--files", "a", "b"]
+
+
+def test_option_multi_value_empty_omits_flag():
+    args = _args([{"name": "files", "options": ["--files"], "multiple": True}])
+    assert args.format_argv({"files": []}) == []
+
+
+@pytest.mark.parametrize(
+    ("default", "value", "expected"),
+    [
+        (False, False, []),
+        (False, True, ["--flag"]),
+        (True, True, []),
+        (True, False, ["--flag"]),
+    ],
+)
+def test_boolean_emit_iff_value_differs_from_default(default, value, expected):
+    args = _args(
+        [
+            {
+                "name": "flag",
+                "options": ["--flag"],
+                "type": "boolean",
+                "default": default,
+            }
+        ]
+    )
+    assert args.format_argv({"flag": value}) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # Boolean declared with no explicit default — poe's parser treats
+        # absent default as False (store_true action), so the "emit iff value
+        # differs from default" rule must use that same coercion.
+        (False, []),
+        (True, ["--flag"]),
+    ],
+)
+def test_boolean_without_explicit_default_treats_default_as_false(value, expected):
+    args = _args([{"name": "flag", "options": ["--flag"], "type": "boolean"}])
+    assert args.format_argv({"flag": value}) == expected
+
+
+def test_integer_value_serialized_as_string():
+    args = _args([{"name": "n", "options": ["-n"], "type": "integer"}])
+    assert args.format_argv({"n": 42}) == ["-n", "42"]
+
+
+def test_float_value_serialized_as_string():
+    args = _args([{"name": "r", "options": ["-r"], "type": "float"}])
+    assert args.format_argv({"r": 1.5}) == ["-r", "1.5"]
+
+
+def test_omits_args_not_present_in_values():
+    args = _args(
+        [
+            {"name": "x", "positional": True},
+            {"name": "y", "options": ["--y"]},
+        ]
+    )
+    assert args.format_argv({"x": "value"}) == ["value"]
+
+
+def test_omits_options_with_none_value():
+    args = _args([{"name": "out", "options": ["--out"]}])
+    assert args.format_argv({"out": None}) == []
+
+
+def test_preserves_declaration_order_for_positionals():
+    args = _args(
+        [
+            {"name": "a", "positional": True},
+            {"name": "b", "positional": True},
+        ]
+    )
+    assert args.format_argv({"a": "1", "b": "2"}) == ["1", "2"]
+
+
+def test_mixed_positional_and_option():
+    args = _args(
+        [
+            {"name": "target", "positional": True},
+            {"name": "out", "options": ["--out"]},
+        ]
+    )
+    assert args.format_argv({"target": "alice", "out": "build"}) == [
+        "alice",
+        "--out",
+        "build",
+    ]

--- a/tests/test_format_argv.py
+++ b/tests/test_format_argv.py
@@ -4,29 +4,50 @@ when a module-style script task needs to forward declared args (with defaults
 applied) into a ``python -m`` subprocess.
 """
 
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
 import pytest
 
+from poethepoet.env.cache import EnvFileCache
+from poethepoet.env.task_env import TaskEnv
+from poethepoet.exceptions import ConfigValidationError
 from poethepoet.io import PoeIO
 from poethepoet.task.args import PoeTaskArgs
 
 
-def _args(args_def):
+def _args(args_def: Any) -> PoeTaskArgs:
     return PoeTaskArgs(args_def, "task", PoeIO(make_default=False))
 
 
-def test_positional_emits_value():
+def _env(env_vars: Mapping[str, str] | None = None) -> TaskEnv:
+    """
+    Minimal TaskEnv for unit tests. The format_argv tests never touch
+    envfiles or lazy vars, so a stub cache is sufficient.
+    """
+    return TaskEnv(
+        env=dict(env_vars or {}),
+        args={},
+        envfiles=EnvFileCache(Path.cwd(), PoeIO(make_default=False)),
+        lazy_vars={},
+        private_vars=set(),
+    )
+
+
+def test_positional_emits_value() -> None:
     args = _args([{"name": "x", "positional": True}])
-    assert args.format_argv({"x": "hello"}) == ["hello"]
+    assert args.format_argv({"x": "hello"}, _env()) == ["hello"]
 
 
-def test_positional_multi_value_emits_inline():
+def test_positional_multi_value_emits_inline() -> None:
     args = _args([{"name": "items", "positional": True, "multiple": True}])
-    assert args.format_argv({"items": ["a", "b", "c"]}) == ["a", "b", "c"]
+    assert args.format_argv({"items": ["a", "b", "c"]}, _env()) == ["a", "b", "c"]
 
 
-def test_option_emits_flag_and_value():
+def test_option_emits_flag_and_value() -> None:
     args = _args([{"name": "out", "options": ["--out"]}])
-    assert args.format_argv({"out": "build"}) == ["--out", "build"]
+    assert args.format_argv({"out": "build"}, _env()) == ["--out", "build"]
 
 
 @pytest.mark.parametrize(
@@ -36,19 +57,21 @@ def test_option_emits_flag_and_value():
         (["--out", "-o"], "--out"),
     ],
 )
-def test_option_first_declared_name_wins(options, expected_flag):
+def test_option_first_declared_name_wins(
+    options: list[str], expected_flag: str
+) -> None:
     args = _args([{"name": "out", "options": options}])
-    assert args.format_argv({"out": "build"}) == [expected_flag, "build"]
+    assert args.format_argv({"out": "build"}, _env()) == [expected_flag, "build"]
 
 
-def test_option_multi_value_space_separated():
+def test_option_multi_value_space_separated() -> None:
     args = _args([{"name": "files", "options": ["--files"], "multiple": True}])
-    assert args.format_argv({"files": ["a", "b"]}) == ["--files", "a", "b"]
+    assert args.format_argv({"files": ["a", "b"]}, _env()) == ["--files", "a", "b"]
 
 
-def test_option_multi_value_empty_omits_flag():
+def test_option_multi_value_empty_omits_flag() -> None:
     args = _args([{"name": "files", "options": ["--files"], "multiple": True}])
-    assert args.format_argv({"files": []}) == []
+    assert args.format_argv({"files": []}, _env()) == []
 
 
 @pytest.mark.parametrize(
@@ -60,7 +83,9 @@ def test_option_multi_value_empty_omits_flag():
         (True, False, ["--flag"]),
     ],
 )
-def test_boolean_emit_iff_value_differs_from_default(default, value, expected):
+def test_boolean_emit_iff_value_differs_from_default(
+    default: bool, value: bool, expected: list[str]
+) -> None:
     args = _args(
         [
             {
@@ -71,7 +96,7 @@ def test_boolean_emit_iff_value_differs_from_default(default, value, expected):
             }
         ]
     )
-    assert args.format_argv({"flag": value}) == expected
+    assert args.format_argv({"flag": value}, _env()) == expected
 
 
 @pytest.mark.parametrize(
@@ -84,54 +109,183 @@ def test_boolean_emit_iff_value_differs_from_default(default, value, expected):
         (True, ["--flag"]),
     ],
 )
-def test_boolean_without_explicit_default_treats_default_as_false(value, expected):
+def test_boolean_without_explicit_default_treats_default_as_false(
+    value: bool, expected: list[str]
+) -> None:
     args = _args([{"name": "flag", "options": ["--flag"], "type": "boolean"}])
-    assert args.format_argv({"flag": value}) == expected
+    assert args.format_argv({"flag": value}, _env()) == expected
 
 
-def test_integer_value_serialized_as_string():
+@pytest.mark.parametrize(
+    ("default_literal", "value", "expected"),
+    [
+        # String literals must coerce to the same bool the parser uses, so
+        # "emit iff value != coerced(default)" holds regardless of how the
+        # user spelled the default.
+        ("true", True, []),
+        ("true", False, ["--flag"]),
+        ("True", True, []),
+        ("1", True, []),
+        ("t", True, []),
+        ("false", False, []),
+        ("false", True, ["--flag"]),
+        ("False", False, []),
+        ("FALSE", False, []),
+        ("0", False, []),
+        ("f", False, []),
+        ("", False, []),
+        ("  TRUE  ", True, []),
+    ],
+)
+def test_boolean_string_default_coerced_for_emit_decision(
+    default_literal: str, value: bool, expected: list[str]
+) -> None:
+    args = _args(
+        [
+            {
+                "name": "flag",
+                "options": ["--flag"],
+                "type": "boolean",
+                "default": default_literal,
+            }
+        ]
+    )
+    assert args.format_argv({"flag": value}, _env()) == expected
+
+
+@pytest.mark.parametrize(
+    ("template", "env_vars", "value", "expected"),
+    [
+        ("${BOOL_DEFAULT}", {"BOOL_DEFAULT": "true"}, True, []),
+        ("${BOOL_DEFAULT}", {"BOOL_DEFAULT": "true"}, False, ["--flag"]),
+        ("${BOOL_DEFAULT}", {"BOOL_DEFAULT": "false"}, False, []),
+        ("${BOOL_DEFAULT}", {"BOOL_DEFAULT": "false"}, True, ["--flag"]),
+        ("${BOOL_DEFAULT}", {"BOOL_DEFAULT": ""}, False, []),
+    ],
+)
+def test_boolean_templated_default_resolved_via_env(
+    template: str, env_vars: dict[str, str], value: bool, expected: list[str]
+) -> None:
+    args = _args(
+        [
+            {
+                "name": "flag",
+                "options": ["--flag"],
+                "type": "boolean",
+                "default": template,
+            }
+        ]
+    )
+    assert args.format_argv({"flag": value}, _env(env_vars)) == expected
+
+
+def test_boolean_templated_default_resolving_to_garbage_raises() -> None:
+    args = _args(
+        [
+            {
+                "name": "flag",
+                "options": ["--flag"],
+                "type": "boolean",
+                "default": "${BOOL_DEFAULT}",
+            }
+        ]
+    )
+    with pytest.raises(ConfigValidationError, match="Cannot interpret"):
+        args.format_argv({"flag": False}, _env({"BOOL_DEFAULT": "maybe"}))
+
+
+@pytest.mark.parametrize(
+    "default_value",
+    [True, False, "true", "TRUE", "false", "0", "1", "t", "f", "", "  TRUE  "],
+)
+def test_validator_accepts_recognised_boolean_defaults(default_value: Any) -> None:
+    _args(
+        [
+            {
+                "name": "flag",
+                "options": ["--flag"],
+                "type": "boolean",
+                "default": default_value,
+            }
+        ]
+    )
+
+
+@pytest.mark.parametrize("default_value", ["yes", "no", "maybe", "2", "off", "on"])
+def test_validator_rejects_unrecognised_boolean_string_defaults(
+    default_value: str,
+) -> None:
+    with pytest.raises(ConfigValidationError, match="Cannot interpret"):
+        _args(
+            [
+                {
+                    "name": "flag",
+                    "options": ["--flag"],
+                    "type": "boolean",
+                    "default": default_value,
+                }
+            ]
+        )
+
+
+def test_validator_defers_templated_boolean_default_to_runtime() -> None:
+    # Template-shaped strings can only be checked once a TaskEnv is in scope,
+    # so the validator lets them through.
+    _args(
+        [
+            {
+                "name": "flag",
+                "options": ["--flag"],
+                "type": "boolean",
+                "default": "${BOOL_DEFAULT}",
+            }
+        ]
+    )
+
+
+def test_integer_value_serialized_as_string() -> None:
     args = _args([{"name": "n", "options": ["-n"], "type": "integer"}])
-    assert args.format_argv({"n": 42}) == ["-n", "42"]
+    assert args.format_argv({"n": 42}, _env()) == ["-n", "42"]
 
 
-def test_float_value_serialized_as_string():
+def test_float_value_serialized_as_string() -> None:
     args = _args([{"name": "r", "options": ["-r"], "type": "float"}])
-    assert args.format_argv({"r": 1.5}) == ["-r", "1.5"]
+    assert args.format_argv({"r": 1.5}, _env()) == ["-r", "1.5"]
 
 
-def test_omits_args_not_present_in_values():
+def test_omits_args_not_present_in_values() -> None:
     args = _args(
         [
             {"name": "x", "positional": True},
             {"name": "y", "options": ["--y"]},
         ]
     )
-    assert args.format_argv({"x": "value"}) == ["value"]
+    assert args.format_argv({"x": "value"}, _env()) == ["value"]
 
 
-def test_omits_options_with_none_value():
+def test_omits_options_with_none_value() -> None:
     args = _args([{"name": "out", "options": ["--out"]}])
-    assert args.format_argv({"out": None}) == []
+    assert args.format_argv({"out": None}, _env()) == []
 
 
-def test_preserves_declaration_order_for_positionals():
+def test_preserves_declaration_order_for_positionals() -> None:
     args = _args(
         [
             {"name": "a", "positional": True},
             {"name": "b", "positional": True},
         ]
     )
-    assert args.format_argv({"a": "1", "b": "2"}) == ["1", "2"]
+    assert args.format_argv({"a": "1", "b": "2"}, _env()) == ["1", "2"]
 
 
-def test_mixed_positional_and_option():
+def test_mixed_positional_and_option() -> None:
     args = _args(
         [
             {"name": "target", "positional": True},
             {"name": "out", "options": ["--out"]},
         ]
     )
-    assert args.format_argv({"target": "alice", "out": "build"}) == [
+    assert args.format_argv({"target": "alice", "out": "build"}, _env()) == [
         "alice",
         "--out",
         "build",

--- a/tests/test_script_tasks.py
+++ b/tests/test_script_tasks.py
@@ -1,5 +1,7 @@
 import difflib
 
+import pytest
+
 no_venv = {"POETRY_VIRTUALENVS_CREATE": "false"}
 
 
@@ -471,3 +473,134 @@ def test_script_task_extra_args_available_as_list_via_extra_args_var(run_poe):
     assert result.capture == "Poe => echo-extra-args-script foo bar\n"
     assert result.stdout == "str: foo\nstr: bar\n"
     assert result.stderr == ""
+
+
+@pytest.fixture(scope="module")
+def module_script_project(tmp_path_factory):
+    """
+    Project with a `mymod` package whose __main__ prints sys.argv[1:], plus a
+    matrix of module-style script tasks declaring different arg shapes. Shared
+    across the module-script argv-serialization tests so we pay the fixture
+    cost once per test module. Tests do not mutate the project dir and each
+    run_poe call uses a fresh PoeThePoet instance, so module scope preserves
+    isolation.
+    """
+    project_path = tmp_path_factory.mktemp("module_script_project")
+    (project_path / "pyproject.toml").write_text(
+        """
+        [tool.poe.tasks.positional]
+        script = "mymod"
+        args = [{ name = "target", positional = true, default = "world" }]
+
+        [tool.poe.tasks.pos_multi]
+        script = "mymod"
+        args = [{ name = "items", positional = true, multiple = true }]
+
+        [tool.poe.tasks.opt_default]
+        script = "mymod"
+        args = [{ name = "out", options = ["-o", "--out"], default = "build" }]
+
+        [tool.poe.tasks.opt_long_first]
+        script = "mymod"
+        args = [{ name = "out", options = ["--out", "-o"], default = "build" }]
+
+        [tool.poe.tasks.opt_multi]
+        script = "mymod"
+        args = [{ name = "files", options = ["-f", "--files"], multiple = true }]
+
+        [tool.poe.tasks.bool_default_false]
+        script = "mymod"
+        args = [
+          { name = "flag", options = ["--flag"], type = "boolean", default = false },
+        ]
+
+        [tool.poe.tasks.bool_default_true]
+        script = "mymod"
+        args = [
+          { name = "flag", options = ["--flag"], type = "boolean", default = true },
+        ]
+        """
+    )
+    module_dir = project_path / "mymod"
+    module_dir.mkdir()
+    (module_dir / "__init__.py").touch()
+    (module_dir / "__main__.py").write_text(
+        "import sys\nprint('argv:', sys.argv[1:])\n"
+    )
+    return project_path
+
+
+@pytest.mark.parametrize(
+    ("task", "cli", "expected_argv"),
+    [
+        ("positional", (), "['world']"),
+        ("positional", ("alice",), "['alice']"),
+        ("pos_multi", ("a", "b", "c"), "['a', 'b', 'c']"),
+        ("opt_default", (), "['-o', 'build']"),
+        ("opt_long_first", (), "['--out', 'build']"),
+        ("opt_multi", ("-f", "x", "y"), "['-f', 'x', 'y']"),
+        (
+            "positional",
+            ("alice", "--", "extra1", "extra2"),
+            "['alice', 'extra1', 'extra2']",
+        ),
+    ],
+)
+def test_module_script_argv_serialization(
+    task, cli, expected_argv, module_script_project, run_poe
+):
+    """
+    A module-style script task that declares args re-serializes the parsed
+    values (with defaults applied) into the module's sys.argv following the
+    conventions: positionals in declared order, options as
+    `<first-declared-name> value`, multi-value space-separated, post-`--`
+    extras appended verbatim.
+    """
+    result = run_poe(task, *cli, cwd=module_script_project)
+    assert result.code == 0, result.capture + result.stderr
+    assert f"argv: {expected_argv}" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("task", "cli", "expected_argv"),
+    [
+        # default = false: flag absent → omit; flag present → emit
+        ("bool_default_false", (), "[]"),
+        ("bool_default_false", ("--flag",), "['--flag']"),
+        # default = true: flag absent → omit; flag present (toggles to false) → emit
+        ("bool_default_true", (), "[]"),
+        ("bool_default_true", ("--flag",), "['--flag']"),
+    ],
+)
+def test_module_script_boolean_argv(
+    task, cli, expected_argv, module_script_project, run_poe
+):
+    """
+    Boolean flags are emitted into argv iff the resolved value differs from
+    the declared default — which corresponds to "the user provided the flag
+    on the CLI" regardless of whether the default is true or false.
+    """
+    result = run_poe(task, *cli, cwd=module_script_project)
+    assert result.code == 0, result.capture + result.stderr
+    assert f"argv: {expected_argv}" in result.stdout
+
+
+def test_module_script_task_finds_src_layout_modules(temp_pyproject, run_poe):
+    """
+    Module-style script tasks should be able to import modules from a src/
+    layout, matching the callable-script path which adds 'src' to sys.path.
+    """
+    project_path = temp_pyproject(
+        """
+        [tool.poe.tasks.run]
+        script = "srcmod"
+        """
+    )
+    src_module = project_path / "src" / "srcmod"
+    src_module.mkdir(parents=True)
+    (src_module / "__init__.py").touch()
+    (src_module / "__main__.py").write_text("print('hello from src layout')\n")
+
+    result = run_poe("run", cwd=project_path)
+    assert result.code == 0, result.capture + result.stderr
+    assert "hello from src layout" in result.stdout

--- a/tests/test_script_tasks.py
+++ b/tests/test_script_tasks.py
@@ -436,7 +436,7 @@ def test_script_boolean_flag_default_value(run_poe):
     result = run_poe("booleans", project="scripts", env=no_venv)
     assert result.capture == "Poe => booleans\n"
     assert result.stdout == (
-        "args ()\n" "kwargs {'non': False, 'tru': True, 'fal': False, 'txt': 'text'}\n"
+        "args ()\n" "kwargs {'non': False, 'tru': True, 'fal': False, 'txt': True}\n"
     )
 
 

--- a/tests/test_script_tasks.py
+++ b/tests/test_script_tasks.py
@@ -585,9 +585,7 @@ def test_module_script_boolean_argv(
     assert f"argv: {expected_argv}" in result.stdout
 
 
-def test_module_script_task_no_args_forwards_extras_verbatim(
-    temp_pyproject, run_poe
-):
+def test_module_script_task_no_args_forwards_extras_verbatim(temp_pyproject, run_poe):
     """
     A module-style task with no declared args forwards CLI tokens to the
     module verbatim. Specifically, literal `${...}` references are NOT

--- a/tests/test_script_tasks.py
+++ b/tests/test_script_tasks.py
@@ -585,6 +585,35 @@ def test_module_script_boolean_argv(
     assert f"argv: {expected_argv}" in result.stdout
 
 
+def test_module_script_task_no_args_forwards_extras_verbatim(
+    temp_pyproject, run_poe
+):
+    """
+    A module-style task with no declared args forwards CLI tokens to the
+    module verbatim. Specifically, literal `${...}` references are NOT
+    template-expanded into argv — matching the `cmd` task precedent
+    (`cmd.py:113`). The `${MAYBE}` token below would have been expanded
+    by the previous behavior because `MAYBE` is set on the task env.
+    """
+    project_path = temp_pyproject(
+        """
+        [tool.poe.tasks.run]
+        script = "mymod"
+        env = { MAYBE = "expanded" }
+        """
+    )
+    module_dir = project_path / "mymod"
+    module_dir.mkdir()
+    (module_dir / "__init__.py").touch()
+    (module_dir / "__main__.py").write_text(
+        "import sys\nprint('argv:', sys.argv[1:])\n"
+    )
+
+    result = run_poe("run", "--foo", "cheese", "${MAYBE}", cwd=project_path)
+    assert result.code == 0, result.capture + result.stderr
+    assert "argv: ['--foo', 'cheese', '${MAYBE}']" in result.stdout
+
+
 def test_module_script_task_finds_src_layout_modules(temp_pyproject, run_poe):
     """
     Module-style script tasks should be able to import modules from a src/

--- a/tests/test_sequence_tasks.py
+++ b/tests/test_sequence_tasks.py
@@ -97,77 +97,46 @@ def test_subtasks_inherit_cwd_option_as_default(run_poe, is_windows):
     assert result.stderr == ""
 
 
-def test_sequences_boolean_flag(run_poe):
-    result = run_poe(
-        "booleans",
-        "--non",
-        "--tru",
-        "--fal",
-        "--txt",
-        project="sequences",
-    )
-    assert result.capture == (
-        r"""Poe => poe_test_echo '
-${non}=True' '${non:+plus}=plus' '${non:-minus}=True
-${fal}=True' '${fal:+plus}=plus' '${fal:-minus}=True
-${tru}=' '${tru:+plus}=' '${tru:-minus}=minus
-${txt}=' '${txt:+plus}=' '${txt:-minus}=minus'
-"""
-        r"Poe => poe_test_echo "
-        r"""\${non}=${non} \${non:+plus}=${non:+plus} \${non:-minus}=${non:-minus}
-poe_test_echo \${fal}=${fal} \${fal:+plus}=${fal:+plus} \${fal:-minus}=${fal:-minus}
-poe_test_echo \${tru}=${tru} \${tru:+plus}=${tru:+plus} \${tru:-minus}=${tru:-minus}
-poe_test_echo \${txt}=${txt} \${txt:+plus}=${txt:+plus} \${txt:-minus}=${txt:-minus}
-"""
-        "Poe => {'non':non, 'tru':tru, 'fal':fal, 'txt':txt}\n"
-    )
-    # Verify cmd and shell subtasks see boolean values via env vars
-    assert result.stdout.endswith(
-        """
-${non}=True ${non:+plus}=plus ${non:-minus}=True
+@pytest.mark.parametrize(
+    ("cli_args", "cmd_shell_lines", "expr_dict"),
+    [
+        pytest.param(
+            (),
+            """${non}= ${non:+plus}= ${non:-minus}=minus
+${fal}= ${fal:+plus}= ${fal:-minus}=minus
+${tru}=True ${tru:+plus}=plus ${tru:-minus}=True
+${txt}=True ${txt:+plus}=plus ${txt:-minus}=True
+""",
+            "{'non': False, 'tru': True, 'fal': False, 'txt': True}",
+            id="defaults",
+        ),
+        pytest.param(
+            ("--non", "--tru", "--fal", "--txt"),
+            """${non}=True ${non:+plus}=plus ${non:-minus}=True
 ${fal}=True ${fal:+plus}=plus ${fal:-minus}=True
 ${tru}= ${tru:+plus}= ${tru:-minus}=minus
 ${txt}= ${txt:+plus}= ${txt:-minus}=minus
-${non}=True ${non:+plus}=plus ${non:-minus}=True
-${fal}=True ${fal:+plus}=plus ${fal:-minus}=True
-${tru}= ${tru:+plus}= ${tru:-minus}=minus
-${txt}= ${txt:+plus}= ${txt:-minus}=minus
-{'non': True, 'tru': False, 'fal': True, 'txt': False}
-""".lstrip()
-    )
-
-
-def test_sequences_boolean_flag_default_value(run_poe):
-    result = run_poe("booleans", project="sequences")
-    assert result.capture == (
-        r"""Poe => poe_test_echo '
-${non}=' '${non:+plus}=' '${non:-minus}=minus
-${fal}=' '${fal:+plus}=' '${fal:-minus}=minus
-${tru}=True' '${tru:+plus}=plus' '${tru:-minus}=True
-${txt}=text' '${txt:+plus}=plus' '${txt:-minus}=text'
-"""
-        r"Poe => poe_test_echo "
-        r"""\${non}=${non} \${non:+plus}=${non:+plus} \${non:-minus}=${non:-minus}
-poe_test_echo \${fal}=${fal} \${fal:+plus}=${fal:+plus} \${fal:-minus}=${fal:-minus}
-poe_test_echo \${tru}=${tru} \${tru:+plus}=${tru:+plus} \${tru:-minus}=${tru:-minus}
-poe_test_echo \${txt}=${txt} \${txt:+plus}=${txt:+plus} \${txt:-minus}=${txt:-minus}
-"""
-        "Poe => {'non':non, 'tru':tru, 'fal':fal, 'txt':txt}\n"
-    )
-    # Verify cmd and shell subtasks see boolean values via env vars
-    assert result.stdout.endswith(
-        """
-${non}= ${non:+plus}= ${non:-minus}=minus
-${fal}= ${fal:+plus}= ${fal:-minus}=minus
-${tru}=True ${tru:+plus}=plus ${tru:-minus}=True
-${txt}=text ${txt:+plus}=plus ${txt:-minus}=text
-${non}= ${non:+plus}= ${non:-minus}=minus
-${fal}= ${fal:+plus}= ${fal:-minus}=minus
-${tru}=True ${tru:+plus}=plus ${tru:-minus}=True
-${txt}=text ${txt:+plus}=plus ${txt:-minus}=text
-{'non': False, 'tru': True, 'fal': False, 'txt': 'text'}
-""".lstrip()
-    )
+""",
+            "{'non': True, 'tru': False, 'fal': True, 'txt': False}",
+            id="all_toggled",
+        ),
+    ],
+)
+def test_sequences_boolean_flag(
+    run_poe,
+    cli_args: tuple[str, ...],
+    cmd_shell_lines: str,
+    expr_dict: str,
+) -> None:
+    """
+    Boolean args propagate consistently through a sequence's cmd + shell +
+    expr subtasks: the cmd and shell subtasks both see the resolved values
+    via env vars (``"True"``/unset), and the expr subtask sees them as real
+    Python bools.
+    """
+    result = run_poe("booleans", *cli_args, project="sequences")
+    expected_tail = f"{cmd_shell_lines}{cmd_shell_lines}{expr_dict}\n"
+    assert result.stdout.endswith(expected_tail)
 
 
 def test_private_env_inherited_and_filtered(run_poe, is_windows):

--- a/tests/test_shell_task.py
+++ b/tests/test_shell_task.py
@@ -149,65 +149,48 @@ done
     assert result.stderr == ""
 
 
-def test_shell_boolean_flag(run_poe):
-    result = run_poe(
-        "booleans",
-        "--non",
-        "--tru",
-        "--fal",
-        "--txt",
-        project="shells",
-    )
-    assert result.capture == (
-        r"Poe => poe_test_echo "
-        r"""\${non}=${non} \${non:+plus}=${non:+plus} \${non:-minus}=${non:-minus}
-poe_test_echo \${fal}=${fal} \${fal:+plus}=${fal:+plus} \${fal:-minus}=${fal:-minus}
-poe_test_echo \${tru}=${tru} \${tru:+plus}=${tru:+plus} \${tru:-minus}=${tru:-minus}
-poe_test_echo \${txt}=${txt} \${txt:+plus}=${txt:+plus} \${txt:-minus}=${txt:-minus}
-"""
-    )
-    assert result.stdout.endswith(
-        """${non}=True ${non:+plus}=plus ${non:-minus}=True
+@pytest.mark.parametrize(
+    ("cli_args", "expected_env_lines"),
+    [
+        pytest.param(
+            (),
+            """${non}= ${non:+plus}= ${non:-minus}=minus
+${fal}= ${fal:+plus}= ${fal:-minus}=minus
+${tru}=True ${tru:+plus}=plus ${tru:-minus}=True
+${txt}=True ${txt:+plus}=plus ${txt:-minus}=True
+""",
+            id="defaults",
+        ),
+        pytest.param(
+            ("--non", "--tru", "--fal", "--txt"),
+            """${non}=True ${non:+plus}=plus ${non:-minus}=True
 ${fal}=True ${fal:+plus}=plus ${fal:-minus}=True
 ${tru}= ${tru:+plus}= ${tru:-minus}=minus
 ${txt}= ${txt:+plus}= ${txt:-minus}=minus
-""".lstrip()
-    )
-
-
-def test_shell_boolean_flag_default_value(run_poe):
-    result = run_poe("booleans", project="shells")
-    assert result.capture == (
-        r"Poe => poe_test_echo "
-        r"""\${non}=${non} \${non:+plus}=${non:+plus} \${non:-minus}=${non:-minus}
-poe_test_echo \${fal}=${fal} \${fal:+plus}=${fal:+plus} \${fal:-minus}=${fal:-minus}
-poe_test_echo \${tru}=${tru} \${tru:+plus}=${tru:+plus} \${tru:-minus}=${tru:-minus}
-poe_test_echo \${txt}=${txt} \${txt:+plus}=${txt:+plus} \${txt:-minus}=${txt:-minus}
-"""
-    )
-    assert result.stdout.endswith(
-        """${non}= ${non:+plus}= ${non:-minus}=minus
-${fal}= ${fal:+plus}= ${fal:-minus}=minus
-${tru}=True ${tru:+plus}=plus ${tru:-minus}=True
-${txt}=text ${txt:+plus}=plus ${txt:-minus}=text
-""".lstrip()
-    )
-
-
-def test_shell_boolean_flag_partial_negate_true(run_poe):
-    """Only --tru passed: negates default=true to False (unset), others keep defaults"""
-    result = run_poe(
-        "booleans",
-        "--tru",
-        project="shells",
-    )
-    assert result.stdout.endswith(
-        """${non}= ${non:+plus}= ${non:-minus}=minus
+""",
+            id="all_toggled",
+        ),
+        pytest.param(
+            ("--tru",),
+            """${non}= ${non:+plus}= ${non:-minus}=minus
 ${fal}= ${fal:+plus}= ${fal:-minus}=minus
 ${tru}= ${tru:+plus}= ${tru:-minus}=minus
-${txt}=text ${txt:+plus}=plus ${txt:-minus}=text
-""".lstrip()
-    )
+${txt}=True ${txt:+plus}=plus ${txt:-minus}=True
+""",
+            id="negate_tru",
+        ),
+    ],
+)
+def test_shell_boolean_flag(
+    run_poe, cli_args: tuple[str, ...], expected_env_lines: str
+) -> None:
+    """
+    Same invariant as the cmd suite, exercised against a shell task.
+    Boolean args toggle to/from the truthy bool default; the resolved bool
+    propagates to env vars as ``"True"`` (truthy) or unset (falsy).
+    """
+    result = run_poe("booleans", *cli_args, project="shells")
+    assert result.stdout.endswith(expected_env_lines)
 
 
 def test_shell_bool_env_collision_flag_set(run_poe):

--- a/tests/test_switch_task.py
+++ b/tests/test_switch_task.py
@@ -1,5 +1,7 @@
 import sys
 
+import pytest
+
 
 def test_switch_on_platform(run_poe):
     common_prefix = "Poe <= override or sys.platform\n"
@@ -134,67 +136,57 @@ def test_switch_capture_out(run_poe, projects):
         output_path.unlink()
 
 
-def test_switch_boolean_flag(run_poe):
-    result = run_poe(
-        "booleans-cmd", "--non", "--tru", "--fal", "--txt", project="switch"
-    )
-    assert (
-        result.capture == "Poe <= poe_test_echo minus\n"
-        "Poe => {'non':non, 'tru':tru, 'fal':fal, 'txt':txt}\n"
-    )
-    assert result.stdout == "{'non': True, 'tru': False, 'fal': True, 'txt': False}\n"
-
-    result = run_poe(
-        "booleans-expr", "--non", "--tru", "--fal", "--txt", project="switch"
-    )
-    assert result.capture == (
-        "Poe <= tru\n"
-        r"""Poe => poe_test_echo '
-${non}=True' '${non:+plus}=plus' '${non:-minus}=True
-${fal}=True' '${fal:+plus}=plus' '${fal:-minus}=True
-${tru}=' '${tru:+plus}=' '${tru:-minus}=minus
-${txt}=' '${txt:+plus}=' '${txt:-minus}=minus'
-"""
-    )
-    assert result.stdout.endswith(
-        """
-${non}=True ${non:+plus}=plus ${non:-minus}=True
-${fal}=True ${fal:+plus}=plus ${fal:-minus}=True
-${tru}= ${tru:+plus}= ${tru:-minus}=minus
-${txt}= ${txt:+plus}= ${txt:-minus}=minus
-""".lstrip()
-    )
-
-
-def test_switch_boolean_flag_default_value(run_poe):
-    result = run_poe("booleans-cmd", project="switch")
-    assert result.capture == (
-        "Poe <= poe_test_echo text\n"
-        r"""Poe => poe_test_echo 'case=text
-${non}=' '${non:+plus}=' '${non:-minus}=minus
-${fal}=' '${fal:+plus}=' '${fal:-minus}=minus
-${tru}=True' '${tru:+plus}=plus' '${tru:-minus}=True
-${txt}=text' '${txt:+plus}=plus' '${txt:-minus}=text'
-"""
-    )
-    assert result.stdout.endswith(
-        """case=text
+@pytest.mark.parametrize(
+    ("task", "cli_args", "expected_stdout_tail"),
+    [
+        pytest.param(
+            "booleans-cmd",
+            (),
+            """case=True
 ${non}= ${non:+plus}= ${non:-minus}=minus
 ${fal}= ${fal:+plus}= ${fal:-minus}=minus
 ${tru}=True ${tru:+plus}=plus ${tru:-minus}=True
-${txt}=text ${txt:+plus}=plus ${txt:-minus}=text
-""".lstrip()
-    )
-
-    result = run_poe("booleans-expr", project="switch")
-    assert (
-        result.capture == "Poe <= tru\n"
-        "Poe => {'case': True,'non':non, 'tru':tru, 'fal':fal, 'txt':txt}\n"
-    )
-    assert (
-        result.stdout
-        == "{'case': True, 'non': False, 'tru': True, 'fal': False, 'txt': 'text'}\n"
-    )
+${txt}=True ${txt:+plus}=plus ${txt:-minus}=True
+""",
+            id="cmd_defaults_match_True_arm",
+        ),
+        pytest.param(
+            "booleans-cmd",
+            ("--non", "--tru", "--fal", "--txt"),
+            "{'non': True, 'tru': False, 'fal': True, 'txt': False}\n",
+            id="cmd_toggled_falls_through_to_default_expr_arm",
+        ),
+        pytest.param(
+            "booleans-expr",
+            (),
+            "{'case': True, 'non': False, 'tru': True, 'fal': False, 'txt': True}\n",
+            id="expr_defaults_match_True_arm",
+        ),
+        pytest.param(
+            "booleans-expr",
+            ("--non", "--tru", "--fal", "--txt"),
+            """${non}=True ${non:+plus}=plus ${non:-minus}=True
+${fal}=True ${fal:+plus}=plus ${fal:-minus}=True
+${tru}= ${tru:+plus}= ${tru:-minus}=minus
+${txt}= ${txt:+plus}= ${txt:-minus}=minus
+""",
+            id="expr_toggled_falls_through_to_default_cmd_arm",
+        ),
+    ],
+)
+def test_switch_boolean_flag(
+    run_poe, task: str, cli_args: tuple[str, ...], expected_stdout_tail: str
+) -> None:
+    """
+    Switch task control: the control task's resolved value selects which
+    branch runs. For booleans-cmd the control is a cmd echoing ${txt:-minus}
+    (matches the "True" arm when txt's truthy default is preserved, else
+    falls through). For booleans-expr the control evaluates the tru var
+    (same pattern via the True/False bool stringified to "True"/"False").
+    Each case asserts the tail of stdout from the selected branch.
+    """
+    result = run_poe(task, *cli_args, project="switch")
+    assert result.stdout.endswith(expected_stdout_tail)
 
 
 def test_switch_task_forwards_extra_args_via_poe_extra_args(run_poe):


### PR DESCRIPTION
## Summary

- Module-style script tasks (`script = "some_module"`) can now declare named `args`. Parsed values (with defaults applied) are re-emitted onto the module's `sys.argv` so the module's own argument parser picks them up.
- Documented conventions: positionals in declared order; options as `<first-declared-name> value`; multi-value space-separated; boolean flags emitted iff the user provided them on the CLI; extras after `--` appended verbatim.
- `print_result` rejected on module-style tasks at config validation and in the JSON schema — the runtime check, schema constraint, and parity corpus fixture all land together.
- Boolean arg defaults rejected unless TOML `bool`, a recognised case-insensitive literal (`t`/`true`/`1`/`f`/`false`/`0`/`""`), or a `${VAR}` template — runtime check, schema constraint, and corpus fixture land together. Was a silent leak through `format_argv` that broke the "emit flag iff user toggled it" invariant.
- CLAUDE.md now documents the runtime/schema parity invariant: prefer declarative `Annotated[T, Metadata(...)]`, fall back to `__schema_fragment__` + invalid-corpus fixture.
- Bonus: extended the schema parity corpus to run the full load+validate pipeline (previously only parse), and added a corpus fixture for the pre-existing `use_exec`/`capture_stdout` constraint.

## Notable behavior changes

- `_run_module` no longer template-fills user-passed extras. This brings it in line with `cmd`/`shell` (the canonical pattern); the previous behavior was inherited from the callable script/expr paths and was inconsistent with the rest of the codebase.
- `PYTHONPATH` is now extended with an absolute `<project_dir>/src` (appended, not prepended) for module-style tasks, matching the intent of `sys.path.append('src')` in the callable path. A latent cwd-override bug affecting both paths is filed as #395.