### PR TITLE
docs(skill): improve coverage of expr/switch config semantics and edge cases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,17 @@ Reference tests/README.md for instructions on how to write, run, and debug tests
 | Change config parsing             | `config/config.py`                 |
 | Add environment variable handling | `env/manager.py`                   |
 | Fix shell completion              | `completion/`                      |
+| Edit the bundled Agent Skill      | `poethepoet/skills/poethepoet/`    |
+
+## Bundled Agent Skill
+
+This project ships an Agent Skill at `poethepoet/skills/poethepoet/` that teaches AI coding assistants how to use poe. End-users install it via `poe _install_skill`, which copies the tree into a detected `.claude/skills/`, `.codex/skills/`, etc. (see `poethepoet/skills/install.py`).
+
+- **Skill content**: `SKILL.md` + `references/*.md` (task-types, task-options, args-reference, creating-tasks, task-packages).
+- **Pinned version**: `poethepoet/skills/poethepoet/version.txt` — kept in step with poe's user-facing surface. Bump it when skill content changes meaningfully.
+- **Evals**: `tests/skills/evals.json` (corpus) and `tests/skills/run_evals.py` (runner). The runner copies the skill into a fixture project's `.claude/skills/` and shells out to `claude -p`, so it exercises the real discovery path. Run via `poe eval-skill`.
+
+When you change poe's behaviour, syntax, or user-facing semantics, check whether the skill's reference docs still describe it correctly — drift here causes downstream agents to hedge or generate broken configs. If you spot a gap while working on the skill, the canonical answer is in the installed source (`poethepoet/task/*.py`) and the published docs (https://poethepoet.natn.io); verify before paraphrasing.
 
 ## Test Fixtures
 

--- a/poethepoet/skills/poethepoet/SKILL.md
+++ b/poethepoet/skills/poethepoet/SKILL.md
@@ -11,6 +11,16 @@ Poe recognizes uv and poetry projects, or the presence of venv in the project, a
 
 **This skill targets poe 0.46.0.** Full documentation: https://poethepoet.natn.io
 
+## When poe behaviour is unclear
+
+Don't speculate or hedge — poe's behaviour is cheaply verifiable:
+
+- Official docs: https://poethepoet.natn.io
+- Installed source: `python -c "import poethepoet, os; print(os.path.dirname(poethepoet.__file__))"` — then read `task/*.py` for the relevant task type.
+- A 30-second behavioural probe in a throwaway `poe_tasks.toml` settles most questions.
+
+Verify, then state the answer plainly. Don't attach "I'll need to check this" caveats to behaviour you can simply check.
+
 ## Step 0: Orient yourself (do this first)
 
 Run these to understand the environment before doing anything else:
@@ -78,6 +88,10 @@ If `poe` output doesn't give enough detail (e.g. you need to understand a task's
 | `switch`   | Conditional branching             | `task.switch = [...]`         |
 
 See `references/task-types.md` for full details, syntax, and examples for each type.
+
+**Referencing args inside `expr`, a parens-form `script` call (`"module:fn(arg1)"`), or `switch.control.expr`**: use the **bare variable name**, not `${name}`. `expr = "AWS_REGION"` is correct; `expr = "${AWS_REGION}"` routes through the environment and silently fails for private `_`-prefixed args. The `${VAR}` form is for env vars (in any task type), not for args inside Python-evaluating tasks. (For the no-parens form `script = "module:fn"`, args are auto-passed as kwargs — you never write the arg name into the call expression.) See `references/task-types.md` for the mechanism.
+
+**Referencing env vars inside `expr`**: write `${VAR}` and **never quote it**. `expr = "${STAGE}"` is correct — it resolves to the string value (internally `${VAR}` is rewritten to `__env.VAR`, an attribute reference on an injected class, not a textual paste). `expr = "'${STAGE}'"` is **broken**: the inner quotes turn it into the literal string `"__env.STAGE"`, not the value of `STAGE`. To call a method, do it directly: `expr = "${STAGE}.upper()"` (not `"'${STAGE}'.upper()"`).
 
 ## Common task patterns
 

--- a/poethepoet/skills/poethepoet/references/task-types.md
+++ b/poethepoet/skills/poethepoet/references/task-types.md
@@ -58,6 +58,8 @@ script = "my_pkg.deploy:run(env, dry_run=True)"  # with inline args
 script = "http.server"                           # runs module's __main__
 ```
 
+When the call expression names a **module** (no `:` or `()`), poe runs `python -m <module>` and any declared args are re-emitted on `sys.argv` (with defaults applied) — useful for delegating to existing CLI modules. With a callable form, declared args are passed as kwargs (no parens) or by reference in the call (with parens). See `args-reference.md` for the full table.
+
 **With task args** (passed as keyword args when no parentheses):
 
 ```toml
@@ -90,6 +92,8 @@ args = [
 ## shell — Shell Script
 
 Runs a full shell script via the configured interpreter. Task args are accessible as environment variables.
+
+Note: only **public** args reach a shell task. Private `_`-prefixed args are deliberately not exported to the environment, so a shell task can't see them — use a `script` or `expr` task if you need to consume a private arg.
 
 Use when: you need shell features — pipes, conditionals, loops, process substitution. Otherwise, prefer `cmd`.
 
@@ -249,7 +253,9 @@ control.expr = "sys.platform"
 
 ```toml
 [tool.poe.tasks.deploy]
-control.expr = "${STAGE}"
+# ✅ Reference the arg by bare variable name. Do NOT write `${STAGE}` here —
+#    that routes through the environment and silently breaks for private args.
+control.expr = "STAGE"
 args = [{ name = "STAGE", positional = true, choices = ["staging", "production"] }]
 
   [[tool.poe.tasks.deploy.switch]]
@@ -263,6 +269,29 @@ args = [{ name = "STAGE", positional = true, choices = ["staging", "production"]
 
 **default option**: `"pass"` (succeed silently with no match) or `"fail"` (fail if no case matched). Default is `"fail"`.
 
+**Constraints**:
+
+- Control task type must be `expr`, `cmd`, or `script`.
+- Matching is by string comparison: the control output is `str()`-ed and compared against each `case` value (also `str()`-ed).
+- `args` declared on the switch task propagate automatically to the control task **and** every case task. Cases may **not** redeclare `args`, `uses`, or `deps`.
+
+**Branching on a private (`_`-prefixed) arg**: in an `expr` control, reference it by **bare variable name**, never `${...}`. Private args aren't exported as env vars, so `control.expr = "${_target}"` silently resolves to an empty string and the switch falls through to `default`. Use the bare-variable form:
+
+```toml
+[tool.poe.tasks.deploy]
+control.expr = "_target"          # ✅ bare variable — works for both public and private args
+# control.expr = "${_target}"     # ❌ broken: ${_target} routes through env, silent empty for private args
+args = [{ name = "_target", positional = true, choices = ["dev", "prod"] }]
+
+  [[tool.poe.tasks.deploy.switch]]
+  case = "dev"
+  cmd = "deploy --env dev"
+
+  [[tool.poe.tasks.deploy.switch]]
+  case = "prod"
+  cmd = "deploy --env prod"
+```
+
 ---
 
 ## expr — Python Expression
@@ -270,6 +299,19 @@ args = [{ name = "STAGE", positional = true, choices = ["staging", "production"]
 Evaluates a Python expression and prints the result to stdout.
 
 Use when: outputting computed values, platform checks, file counts, or lightweight validation.
+
+> **Common misconception — `${VAR}` is NOT textual substitution.** It is tempting to assume `${STAGE}` gets pasted into the Python source so that `expr = "${STAGE}"` becomes the bare name `staging` and raises `NameError` (so you'd need to "quote it" as `expr = "'${STAGE}'"`). **This is wrong.** `${VAR}` is rewritten to an *attribute reference* on an injected class — internally `${STAGE}` becomes `__env.STAGE`, which evaluates to the string value at runtime. Compare:
+>
+> - ✅ `expr = "${STAGE}"` → Python source becomes `__env.STAGE` → yields the string value (e.g. `"staging"`).
+> - ❌ `expr = "'${STAGE}'"` → Python source becomes `'__env.STAGE'` → yields the **literal string** `"__env.STAGE"` (NOT the value of `STAGE`). The "defensive" outer quotes actively break the expression.
+>
+> To call a method on the value, do **not** wrap it: `expr = "${STAGE}.upper()"` → `__env.STAGE.upper()` → yields `"STAGING"`. (Writing `"'${STAGE}'.upper()"` would call `.upper()` on the literal string `"__env.STAGE"` and return `"__ENV.STAGE"` — broken.)
+
+**Referencing declared args.** A declared arg is in scope as a **bare Python variable** under its declared name. The canonical form is `expr = "AWS_REGION"`, not `expr = "${AWS_REGION}"`.
+
+> The `${AWS_REGION}` form routes through the *environment* (not the args namespace). For a **public** arg this coincides because public args are also exported to env — but for a **private `_`-prefixed arg it silently breaks**: private args are deliberately not exported, so `${_target}` resolves to an empty/missing env var rather than the arg's value. Always use the bare-variable form when an `expr` references an arg.
+
+See `args-reference.md` for the full per-task-type table.
 
 ```toml
 [tool.poe.tasks.platform]

--- a/tests/skills/evals.json
+++ b/tests/skills/evals.json
@@ -61,6 +61,28 @@
         "Response includes a help = line for the task",
         "Response sets PYTHONPATH or otherwise makes the scripts module importable"
       ]
+    },
+    {
+      "id": 6,
+      "fixture": "poe_project",
+      "prompt": "In a poe `expr` task, do I need to quote `${STAGE}` so the expression doesn't fail with a NameError? Like `expr = \"'${STAGE}'\"` versus `expr = \"${STAGE}\"`.",
+      "expected_output": "Agent explains that ${VAR} inside an expr is NOT a textual substitution — it resolves to a string-valued attribute on an injected class (__env.STAGE under the hood). So expr = \"${STAGE}\" is safe and no extra quoting is required. May also note that if STAGE is a declared arg, the canonical form is the bare-variable form `expr = \"STAGE\"`.",
+      "expectations": [
+        "Response explains that ${VAR} in expr resolves to a string value (not source-text substitution)",
+        "Response confirms `expr = \"${STAGE}\"` works without extra quoting",
+        "Response does not recommend wrapping the reference in single or double quotes as a fix"
+      ]
+    },
+    {
+      "id": 7,
+      "fixture": "poe_project",
+      "prompt": "I'm building a `switch` task whose control branches on a private arg called `_target` (positional, choices: 'dev' or 'prod'). What should `control` look like, and where do the args go?",
+      "expected_output": "Agent uses the bare-variable form on the control expr (e.g. control.expr = \"_target\"), NOT ${_target} — because private `_`-prefixed args are deliberately not exported as environment variables and the ${...} env-route silently fails for them. Declares args on the switch task (not on individual cases), since args on a switch propagate automatically to the control task and every case task, and cases may not redeclare args.",
+      "expectations": [
+        "Response uses the bare-variable form for the control (e.g. expr = \"_target\"), not ${_target}",
+        "Response declares args on the switch task, not on individual case tasks",
+        "Response does not place args on case tasks"
+      ]
     }
   ]
 }

--- a/tests/skills/run_evals.py
+++ b/tests/skills/run_evals.py
@@ -80,6 +80,12 @@ def run_claude(prompt: str, cwd: Path, model: str | None = None) -> dict[str, An
         "json",
         "--permission-mode",
         "bypassPermissions",
+        # Skip user-level settings so the eval runs against a clean baseline
+        # (otherwise the caller's output style, hooks, env, etc. leak into the
+        # subprocess and confound results). Project + local sources still apply
+        # so the skill installed at the fixture's .claude/skills/ is discovered.
+        "--setting-sources",
+        "project,local",
     ]
     if model:
         cmd.extend(["--model", model])
@@ -140,11 +146,54 @@ def grade(response_text: str, expectations: list[str]) -> list[dict[str, Any]]:
     return [_check(response_text, exp) for exp in expectations]
 
 
+_COUNTER_EXAMPLE_MARKERS = (
+    "wrong",
+    "broken",
+    "❌",
+    "don't",
+    "do not",
+    "avoid",
+    "incorrect",
+    "fails silently",
+    "not recommended",
+)
+
+
+def _is_labeled_counter_example(text: str, search: str) -> bool:
+    """
+    Return True if every occurrence of *search* in *text* sits on a line that
+    also contains a counter-example marker (e.g. "wrong", "broken", "❌"). Used
+    by negate-mode heuristics to avoid penalising responses that show the
+    forbidden pattern as an explicit ❌-labelled contrast rather than as a
+    recommendation.
+
+    Conservative: a single un-labelled occurrence means False (recommendation).
+    """
+    needle = search.lstrip("\n")
+    idx = 0
+    found_any = False
+    while True:
+        pos = text.find(needle, idx)
+        if pos == -1:
+            break
+        found_any = True
+        line_start = text.rfind("\n", 0, pos) + 1
+        line_end = text.find("\n", pos)
+        line = text[line_start : line_end if line_end != -1 else len(text)].lower()
+        if not any(marker in line for marker in _COUNTER_EXAMPLE_MARKERS):
+            return False
+        idx = pos + len(needle)
+    return found_any
+
+
 def _check(text: str, expectation: str) -> dict[str, Any]:
     exp_lower = expectation.lower()
 
-    # Ordered list of (trigger phrase, search term, description)
-    heuristics: list[tuple[str, str]] = [
+    # Each entry is (trigger, search) — passes when `search` is found in `text`,
+    # or (trigger, search, "negate") — passes when `search` is NOT found
+    # (catches "Response does not X" style expectations by detecting the
+    # forbidden pattern). First matching trigger wins.
+    heuristics: list[tuple] = [
         ("$poe_extra_args", "$POE_EXTRA_ARGS"),
         ("parallel", "parallel"),
         ("sequence", "sequence"),
@@ -165,16 +214,55 @@ def _check(text: str, expectation: str) -> dict[str, Any]:
         ("defines a types task", "[tool.poe.tasks.types]"),
         ("defines a format task", "[tool.poe.tasks.format]"),
         ("defines a check task", "[tool.poe.tasks.check]"),
+        # Negative heuristics — pass when the forbidden pattern is NOT present.
+        # The leading "\n" requires the pattern to be on its own line (typical
+        # of an agent's recommended TOML block) so inline prose discussions of
+        # the wrong form (e.g. "don't write `control.expr = \"${_target}\"`")
+        # don't false-fail correct responses.
+        #
+        # Eval 6: agent must not recommend wrapping ${VAR} in quotes inside an expr.
+        ("without extra quoting", "\nexpr = \"'${STAGE}'\"", "negate"),
+        ("does not recommend wrapping", "\nexpr = \"'${STAGE}'\"", "negate"),
+        # Eval 7: control.expr on a private arg must use the bare variable form,
+        # not the ${...} env-route (which silently fails for private args).
+        ("bare-variable form", '\ncontrol.expr = "${_target}"', "negate"),
     ]
 
-    for trigger, search in heuristics:
+    for entry in heuristics:
+        trigger, search = entry[0], entry[1]
+        negate = len(entry) > 2 and entry[2] == "negate"
         if trigger in exp_lower:
             found = search in text
-            status = "Found" if found else "Not found"
+            if negate and found and _is_labeled_counter_example(text, search):
+                # The forbidden pattern appears as an explicit ❌/broken/wrong
+                # counter-example (often shown next to the ✅ form to teach the
+                # contrast). That's the gold-standard didactic answer, not a
+                # genuine recommendation — pass.
+                return {
+                    "text": expectation,
+                    "passed": True,
+                    "evidence": (
+                        f"Forbidden pattern {search!r} present but labeled "
+                        f"as a counter-example (wrong/broken/❌/don't)"
+                    ),
+                }
+            passed = (not found) if negate else found
+            if negate:
+                status = (
+                    f"Forbidden pattern {search!r} not in response"
+                    if not found
+                    else f"Forbidden pattern {search!r} found in response"
+                )
+            else:
+                status = (
+                    f"Found {search!r} in response"
+                    if found
+                    else f"Not found {search!r} in response"
+                )
             return {
                 "text": expectation,
-                "passed": found,
-                "evidence": f"{status} {search!r} in response",
+                "passed": passed,
+                "evidence": status,
             }
 
     return {


### PR DESCRIPTION
## Summary

Closes #399.

The bundled Agent Skill underspecified how `${VAR}` resolves inside an `expr` task and how args reach a `switch` control task — enough that a real agent session formed a wrong mental model and had to drop into source to recover. The diagnosis: canonical info ("How args are available by task type") lives in `args-reference.md` but worked examples live in `task-types.md`, so a reader anchored on the example never sees the table.

Closes every gap from the issue body + follow-up comment, plus surfaces the same cross-cutting facts in `script` and `shell` sections (so the silo doesn't reappear for those task types).

- **`expr` section**: explicit rebuttal of the "${VAR} is textual substitution" misconception with ✅/❌ contrast; bare-variable rule for declared args including silent-failure note for private `_`-prefixed args.
- **`switch` section**: canonical arg example switched to bare-variable form; new Constraints subsection; inline private-arg example with ✅/❌ comments.
- **`script` / `shell` sections**: parity cross-links into args-reference (call-form vs no-parens-form; private args invisible to shell).
- **SKILL.md**: new "When poe behaviour is unclear" anti-hedging note (the issue's meta-lesson) + cross-cutting bare-variable and no-quote-`${VAR}` hints in the quick-reference table.
- **CLAUDE.md**: new "Bundled Agent Skill" section so future agents working in this repo are aware of the skill and can keep its references in step with runtime behaviour.

Locked in with two regression evals in `tests/skills/evals.json` (IDs 6 and 7) targeting the exact misconceptions: recommending `expr = "'${STAGE}'"` and writing `control.expr = "${_target}"` for a private arg.

A second commit improves the eval harness (separate concern, lands together for convenience):
- `_check` now supports negation (`(trigger, search, "negate")`) with a newline-prefix requirement and a labelled-counter-example escape hatch, so "Response does not X" expectations stop auto-passing.
- `run_claude` passes `--setting-sources project,local` so eval responses run against a clean baseline rather than inheriting the caller's user-level settings.

## Test plan

- [x] `poe lint` — clean
- [x] `poe eval-skill --eval 6 --replicas 3 --no-baseline` — 9/9, all 3 replicas use the right form, several explicitly explain why the wrong form is wrong
- [x] `poe eval-skill --eval 7 --replicas 3 --no-baseline` — 9/9, same
- [x] Heuristic discrimination verified end-to-end: synthetic wrong-form recommendation fails; correct response that explains the wrong form inline passes; gold-standard ✅/❌-labelled response passes
- [x] Technical claims in the new doc text independently verified by a second agent pass against `task/expr.py`, `task/switch.py`, `task/script.py`, `env/task_env.py`, `helpers/python.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)