### PR TITLE
feat: respect the FORCE_COLOR environment variable

### DIFF
--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -65,5 +65,6 @@ External Environment variables
 The following environment variables can be set to modify Poe the Poet's behavior.
 
 - ``POE_PROJECT_DIR``: used as the default value for the ``--directory`` global argument.
-- ``NO_COLOR``: disables ansi colors in output (unless the --ansi argument is provided).
+- ``NO_COLOR``: disables ansi colors in output (unless the ``--ansi`` argument is provided).
+- ``FORCE_COLOR``: forces ansi colors in output when set to a non-zero value (overridden by ``NO_COLOR`` or the ``--no-ansi`` argument).
 - ``POE_DEBUG``: can be set to ``1`` to enable printing debug messages to stdout.

--- a/docs/tasks/task_types/parallel.rst
+++ b/docs/tasks/task_types/parallel.rst
@@ -22,11 +22,12 @@ Subtask outputs are streamed to the console as they arrive with a prefix identif
 
     [tool.poe.tasks.check]
     parallel = [
-      { cmd = "ruff check", env = { FORCE_COLOR = "1" } },
+      { cmd = "ruff check" },
       { cmd = "mypy" },
     ]
+    env = { FORCE_COLOR = "1" }
 
-  Alternatively, set ``FORCE_COLOR`` at the global or project level if all subtasks should use it.
+  Alternatively, set ``FORCE_COLOR`` at the global or project level if all tasks should use it.
 
 
 Available task options

--- a/docs/tasks/task_types/parallel.rst
+++ b/docs/tasks/task_types/parallel.rst
@@ -12,6 +12,22 @@ By default the contents of the array are interpreted as references to other task
 
 Subtask outputs are streamed to the console as they arrive with a prefix identifying the task.
 
+.. note::
+
+  Because subtask output is captured via a pipe rather than written directly to the terminal, tools that detect terminal support by calling ``isatty()`` (such as Ruff, Behave, and others) will disable colored output when run as parallel subtasks.
+
+  The standard workaround is to set the ``FORCE_COLOR`` environment variable on the affected subtask, which tells tools to force colored output regardless of TTY detection. Poe also respects this variable for its own output:
+
+  .. code-block:: toml
+
+    [tool.poe.tasks.check]
+    parallel = [
+      { cmd = "ruff check", env = { FORCE_COLOR = "1" } },
+      { cmd = "mypy" },
+    ]
+
+  Alternatively, set ``FORCE_COLOR`` at the global or project level if all subtasks should use it.
+
 
 Available task options
 ----------------------

--- a/poethepoet/io.py
+++ b/poethepoet/io.py
@@ -15,6 +15,10 @@ def guess_ansi_support(file) -> bool:
         # https://no-color.org/
         return False
 
+    if os.environ.get("FORCE_COLOR", "0")[0] != "0":
+        # https://force-color.org/
+        return True
+
     if (
         os.environ.get("GITHUB_ACTIONS", "false") == "true"
         and "PYTEST_CURRENT_TEST" not in os.environ


### PR DESCRIPTION
## Description of changes

This PR adds support for the `FORCE_COLOR` environment variable to enable colored output in parallel subtasks and other scenarios where TTY detection fails.

### Motivation

When running tasks in parallel, subtask output is captured via pipes rather than written directly to the terminal. Many tools (Ruff, Behave, etc.) detect terminal support using `isatty()` and disable colored output when this check fails. This results in loss of colored output even when the parent terminal supports it.

The `FORCE_COLOR` environment variable is a standard convention (https://force-color.org/) that tells tools to force colored output regardless of TTY detection. This PR:

1. **Implements `FORCE_COLOR` support in Poe** (`poethepoet/io.py`): Modified `guess_ansi_support()` to check for `FORCE_COLOR` and enable ANSI colors when it's set to a non-zero value. This respects the standard precedence where `NO_COLOR` and `--no-ansi` still take priority.

2. **Documents the feature** (`docs/tasks/task_types/parallel.rst`): Added a note explaining the TTY detection issue in parallel tasks and provides a practical example showing how to use `FORCE_COLOR` to restore colored output.

3. **Updates environment variable documentation** (`docs/env_vars.rst`): Added `FORCE_COLOR` to the list of supported external environment variables with a description of its behavior.

### Changes

- `poethepoet/io.py`: Added check for `FORCE_COLOR` environment variable in `guess_ansi_support()`
- `docs/tasks/task_types/parallel.rst`: Added note with explanation and example of using `FORCE_COLOR`
- `docs/env_vars.rst`: Documented `FORCE_COLOR` variable and fixed formatting of `--ansi` reference

## Pre-merge Checklist

- [x] New features are documented (added to parallel task docs and env vars docs)
- [x] This PR targets the *development* branch for code changes

https://claude.ai/code/session_01JxdfwkqYaEp4gsfZ5VFFbY