### PR TITLE
docs(skill): improve and document SKILL.md based on feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
 
 - ✅ Also works fine as a [general purpose task runner](https://poethepoet.natn.io/guides/without_poetry.html)
 
+- ✅ Ships with an official [Agent Skill](https://poethepoet.natn.io/guides/ai_agents_guide.html) to help AI coding agents use poe effectively
+
 
 ## Quick start
 

--- a/docs/guides/ai_agents_guide.rst
+++ b/docs/guides/ai_agents_guide.rst
@@ -28,25 +28,29 @@ Include the following in your ``.claude/settings.json`` to grant your agent perm
 
 .. code-block:: json
 
-   "permissions": {
-     "allow": [
-       "Bash(poe *)"
-     ]
+   {
+     "permissions": {
+       "allow": [
+         "Bash(poe *)"
+       ]
+     }
    }
 
 If you have a lightweight poe task for code formatting, then you might want to configure your agent to run that task whenever it finishes making changes:
 
 .. code-block:: json
 
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "poe format"
-          }
-        ]
-      }
-    ]
-  },
+  {
+    "hooks": {
+      "Stop": [
+        {
+          "hooks": [
+            {
+              "type": "command",
+              "command": "poe format"
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/docs/guides/ai_agents_guide.rst
+++ b/docs/guides/ai_agents_guide.rst
@@ -1,0 +1,52 @@
+Using poethepoet with AI Agents
+===============================
+
+Poe the Poet is a good fit with agentic coding workflows, as a way to standardize allowed agent actions within a project. This page collects some tips to help get the most from poethepoet when working with coding agents.
+
+.. tip::
+
+  Add a section to your CLAUDE.md or AGENTS.md to instruct the agent to always check for and use available poe tasks when performing common actions like testing, linting, formatting, or whatever is relevant for your project.
+
+  This helps the agent avoid running with incorrect configuration or dependencies, and makes it easier to manage permissions for these actions.
+
+Agent Skill
+-----------
+
+The official poethepoet skill can help your AI Agent use poethepoet more effectively. It covers discovering and executing tasks, as well as more in-depth guidance on creating them.
+
+See the :ref:`full installation instructions<Install the poethepoet AI Agent skill>`, or simply run the interactive installer with:
+
+.. code-block:: sh
+
+    poe _install_skill
+
+
+Claude Code
+-----------
+
+Include the following in your ``.claude/settings.json`` to grant your agent permission to run any poe task, assuming you only define poe tasks for benign actions.
+
+.. code-block:: json
+
+   "permissions": {
+     "allow": [
+       "Bash(poe *)"
+     ]
+   }
+
+If you have a lightweight poe task for code formatting, then you might want to configure your agent to run that task whenever it finishes making changes:
+
+.. code-block:: json
+
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "poe format"
+          }
+        ]
+      }
+    ]
+  },

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -15,5 +15,6 @@ This section contains guides for using the various features of Poe the Poet.
    global_tasks
    tox_replacement_guide
    without_poetry
+   ai_agents_guide
    library_guide
    migrations

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,6 +72,8 @@ Top features
 
 |V| Also works fine as a :doc:`general purpose task runner<./guides/without_poetry>`
 
+|V| Ships with an official :doc:`Agent Skill<./guides/ai_agents_guide>` to help AI coding agents use poe effectively
+
 
 Quick start
 ===========

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -194,6 +194,37 @@ Powershell completion includes:
 
   You'll need to start a new shell for the new completion script to be loaded. Alternatively, you can invoke ``. $PROFILE`` to reload your profile.
 
+
+Install the poethepoet AI Agent skill
+-------------------------------------
+
+The official poethepoet skill can help your AI Agent use poethepoet more effectively. It covers discovering and executing tasks, as well as more in-depth guidance on creating them.
+
+Install via the built in ``_install_skill`` task
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Poe ships with a task to install the skill (similar to how shell completions are installed):
+
+.. code-block:: sh
+
+    poe _install_skill                         # auto-detects .claude/.codex/.pi/.agents and prompts
+    poe _install_skill ~/.claude/skills        # explicit path (substitute your agent's dir)
+    poe _install_skill <skills-dir> --upgrade  # non-interactive upgrade (skips if same/newer)
+
+Install from GitHub
+~~~~~~~~~~~~~~~~~~~
+
+You can also install the skill directly from github, such as by using |vercel_skills_link|:
+
+.. code-block:: sh
+
+   npx skills add https://github.com/nat-n/poethepoet/tree/v0.46.0/poethepoet/skills/poethepoet
+
+.. note::
+
+  The skill is versioned in step with poe. After upgrading poe, re-run the install task with ``--upgrade`` (shown above) to refresh the installed copy — it skips the copy if the installed version is already current.
+
+
 Supported python versions
 -------------------------
 
@@ -221,3 +252,6 @@ macOS, linux and windows.
 
    <a href="https://python-poetry.org/docs/main/plugins/#using-plugins" target="_blank">poetry docs</a>
 
+.. |vercel_skills_link| raw:: html
+
+    <a href="https://vercel.com/docs/agent-resources/skills" target="_blank">Vercel Agent Skills</a>

--- a/poethepoet/skills/poethepoet/SKILL.md
+++ b/poethepoet/skills/poethepoet/SKILL.md
@@ -1,109 +1,91 @@
 ---
 name: poethepoet
-description: Use when working in a Python project with poethepoet (poe) as a task runner, or when asked to run, create, or configure poe tasks. Also use when: setting up development workflows (testing, linting, formatting) in any Python project; encountering pyproject.toml with [tool.poe] sections or poe_tasks.toml/yaml files; needing to invoke poe commands; adding task arguments or environment variables; composing tasks with sequences or parallel execution; bootstrapping common tasks in a new project. If there's any chance the project uses poe, load this skill and check before exploring manually.
+description: Use when about to run or manage a common Python dev task — tests, linting, formatting, type-checking, building, or any repeated project command — to first check whether poethepoet (poe) already defines it; poe is the idiomatic way to run these. Also use when asked to run, create, or configure poe tasks, or when you see [tool.poe] in pyproject.toml or a poe_tasks.toml/yaml/json file.
 ---
 
 # Poethepoet (poe)
 
-Poethepoet is a Python project task runner. It lets teams define, document, and run development tasks (test, lint, build, deploy, etc.) from `pyproject.toml` or standalone config files — with no Makefiles or shell scripts required. Tasks self-document with help text and are invoked via `poe <task>`.
+Poethepoet (poe) is a Python task runner: teams define, document, and run dev tasks (test, lint, build, deploy…) from `pyproject.toml` or a standalone config file — no Makefiles or shell scripts. Tasks self-document via `help` text and run as `poe <task>`. Poe detects uv/poetry projects (or a local venv) and runs each task in the right environment automatically — no need to remember `poetry run` vs `uv run`.
 
-Poe recognizes uv and poetry projects, or the presence of venv in the project, and automatically invokes tasks in the right environment so that project dependencies and tools are available without having to remember whether to run `poetry run poe` or `uv run poe`.
-
-**This skill targets poe 0.46.0.** Full documentation: https://poethepoet.natn.io
+**Targets poe 0.46.0.** Full docs: https://poethepoet.natn.io
 
 ## When poe behaviour is unclear
 
-Don't speculate or hedge — poe's behaviour is cheaply verifiable:
+Don't speculate — poe's behaviour is cheaply verifiable:
 
-- Official docs: https://poethepoet.natn.io
-- Installed source: `python -c "import poethepoet, os; print(os.path.dirname(poethepoet.__file__))"` — then read `task/*.py` for the relevant task type.
-- A 30-second behavioural probe in a throwaway `poe_tasks.toml` settles most questions.
+- Docs: https://poethepoet.natn.io
+- Source: `python -c "import poethepoet, os; print(os.path.dirname(poethepoet.__file__))"`, then read `task/*.py` for the relevant type.
+- A 30-second probe in a throwaway `poe_tasks.toml` settles most questions.
 
-Verify, then state the answer plainly. Don't attach "I'll need to check this" caveats to behaviour you can simply check.
+Verify, then state the answer plainly — no "I'll need to check" caveats on behaviour you can simply check.
+
+**If the skill (or poe itself) let you down, offer to report it so it can be fixed.** The most valuable case is when this skill *failed to give you guidance you needed* — a gap, a missing case, advice that didn't fit your situation; also worth reporting is something the skill stated that was not right, or a clear bug in poethepoet. Use judgement — skip it if the cause was your own misread, an unrelated environment issue, or something you can't actually pin down. **Ask the user first and post only if they agree; nothing is sent automatically.** A good issue (repo `nat-n/poethepoet`, e.g. via `gh issue create`) says what you were trying to do, what was missing or wrong (or the bug), how you found the real answer, and a concrete suggestion for improving the skill.
 
 ## Step 0: Orient yourself (do this first)
 
-Run these to understand the environment before doing anything else:
+Run these before doing anything else:
 
 ```bash
-# 1. Find poe and check its version
-which poe 2>/dev/null && poe --version 2>/dev/null
-
-# 2. List all available tasks in this project
-poe 2>&1
-
-# 3. Identify config files
-ls pyproject.toml poe_tasks.toml poe_tasks.yaml poe_tasks.json 2>/dev/null
+which poe 2>/dev/null && poe --version 2>/dev/null        # find poe + version
+poe 2>&1                                                  # list all tasks
+ls pyproject.toml poe_tasks.toml poe_tasks.yaml poe_tasks.json 2>/dev/null  # find config
 ```
 
-The poe cli finds tasks defined in the current working directory and parent directories in one of the supported file formats, e.g. pyproject.toml.
+Poe finds tasks in a supported config file in the working directory or any parent.
 
-**If `poe` is not in PATH**, try these based on the project type:
+**If `poe` is not in PATH:**
 
-| Situation                                                 | Command                                                               |
-| --------------------------------------------------------- | --------------------------------------------------------------------- |
-| uv project (`uv.lock` or `[tool.uv]` present)             | `uv run poe`                                                          |
-| poetry project (`poetry.lock` or `[tool.poetry]` present) | `poetry run poe`                                                      |
-| poetry plugin installed                                   | `poetry poe`                                                          |
-| poe not installed                                         | Guide user: `pipx install poethepoet` or `uv tool install poethepoet` |
+| Situation | Command |
+| --- | --- |
+| uv project (`uv.lock` / `[tool.uv]`) | `uv run poe` |
+| poetry project (`poetry.lock` / `[tool.poetry]`) | `poetry run poe` |
+| poetry plugin installed | `poetry poe` |
+| not installed | `pipx install poethepoet` or `uv tool install poethepoet` |
 
-**Version check**: Compare `poe --version` output with `0.46.0` (this skill's target version). If significantly different, some features described here may not be available. The latest released version can be checked at:
-
-```
-https://raw.githubusercontent.com/nat-n/poethepoet/refs/heads/main/poethepoet/skills/poethepoet/version.txt
-```
-
-If troubleshooting version-related issues, this URL is useful for confirming whether an upgrade is available.
+**Version**: if `poe --version` differs much from 0.46.0, some features here may not exist. Latest: https://raw.githubusercontent.com/nat-n/poethepoet/refs/heads/main/poethepoet/skills/poethepoet/version.txt
 
 ## Using existing tasks
 
 ```bash
-poe                         # List all tasks with descriptions
-poe <task>                  # Run a task
-poe <task> -x --extra-flag  # Extra args auto-forwarded to cmd tasks
-poe <task> -- -x            # Explicit free-arg separator (any task type)
-poe <task> --named-arg val  # Named args (if task defines them)
-poe -d <task>               # Dry run: show command without executing
-poe -C /path/to/project <task>  # Run in a different directory
-poe -v <task>               # Verbose output
+poe                         # list all tasks with descriptions
+poe <task>                  # run a task
+poe <task> -x --extra-flag  # extra args auto-forwarded to cmd tasks
+poe <task> -- -x            # explicit free-arg separator (any task type)
+poe <task> --named-arg val  # named args (if the task defines them)
+poe -d <task>               # dry run: show the command without running it
+poe -C /path <task>         # run as if from another directory (handier than cd)
+poe -v <task>               # verbose
 ```
 
-**Tip**: using the -C option to run poe in a different directory is more convenient than cd-ing into it
+**Always prefer poe tasks over running tools directly.** Before running `pytest`, `ruff`, `mypy`, etc., check `poe` first — if a task exists, use it, so you inherit the project's flags, env, and conventions.
 
-If `poe` output doesn't give enough detail (e.g. you need to understand a task's implementation or args), read the config files directly: `pyproject.toml` (`[tool.poe.tasks]`), or `poe_tasks.toml`/`poe_tasks.yaml`/`poe_tasks.json` if present — and follow any `include` or `include_script` references to find tasks defined elsewhere.
-
-**Always prefer poe tasks over running tools directly.** Before running `pytest`, `ruff`, `mypy`, etc., check `poe` output first — if a task exists for the action, use it. This respects project-specific flags, env, and conventions.
+If `poe`'s output isn't enough (e.g. you need a task's implementation or args), read the config directly — `pyproject.toml` (`[tool.poe.tasks]`) or `poe_tasks.toml`/`.yaml`/`.json` — and follow any `include`/`include_script` references.
 
 ## Task types quick reference
 
-| Type       | When to use                       | Shorthand                     |
-| ---------- | --------------------------------- | ----------------------------- |
-| `cmd`      | Running any CLI command (default) | `task = "command"`            |
-| `script`   | Calling a Python function         | `task.script = "module:fn"`   |
-| `shell`    | Shell scripts (pipes, loops)      | `task.shell = "cmd1 \| cmd2"` |
-| `sequence` | Run tasks in order                | `task = ["a", "b"]`           |
-| `parallel` | Run tasks concurrently            | `task.parallel = ["a", "b"]`  |
-| `ref`      | Reference another task            | `task.ref = "other"`          |
-| `expr`     | Python expression output          | `task.expr = "sys.platform"`  |
-| `switch`   | Conditional branching             | `task.switch = [...]`         |
+| Type | When to use | Shorthand |
+| --- | --- | --- |
+| `cmd` | running any CLI command (default) | `task = "command"` |
+| `script` | calling a Python function | `task.script = "module:fn"` |
+| `shell` | shell scripts (pipes, loops) | `task.shell = "cmd1 \| cmd2"` |
+| `sequence` | run tasks in order | `task = ["a", "b"]` |
+| `parallel` | run tasks concurrently | `task.parallel = ["a", "b"]` |
+| `ref` | reference another task | `task.ref = "other"` |
+| `expr` | Python expression output | `task.expr = "sys.platform"` |
+| `switch` | conditional branching | `task.switch = [...]` |
 
-See `references/task-types.md` for full details, syntax, and examples for each type.
+Full syntax and examples per type: `references/task-types.md`.
 
-**Referencing args inside `expr`, a parens-form `script` call (`"module:fn(arg1)"`), or `switch.control.expr`**: use the **bare variable name**, not `${name}`. `expr = "AWS_REGION"` is correct; `expr = "${AWS_REGION}"` routes through the environment and silently fails for private `_`-prefixed args. The `${VAR}` form is for env vars (in any task type), not for args inside Python-evaluating tasks. (For the no-parens form `script = "module:fn"`, args are auto-passed as kwargs — you never write the arg name into the call expression.) See `references/task-types.md` for the mechanism.
+**Two silent-failure rules for `expr`, `switch.control.expr`, and parens-form `script` calls (`"mod:fn(arg)"`)** — get these wrong and the task fails quietly, not loudly:
 
-**Referencing env vars inside `expr`**: write `${VAR}` and **never quote it**. `expr = "${STAGE}"` is correct — it resolves to the string value (internally `${VAR}` is rewritten to `__env.VAR`, an attribute reference on an injected class, not a textual paste). `expr = "'${STAGE}'"` is **broken**: the inner quotes turn it into the literal string `"__env.STAGE"`, not the value of `STAGE`. To call a method, do it directly: `expr = "${STAGE}.upper()"` (not `"'${STAGE}'.upper()"`).
+- **Declared args → bare name**, never `${name}`. `expr = "AWS_REGION"` ✅; `expr = "${AWS_REGION}"` ❌ routes through the environment and is silently empty for private `_`-args. (No-parens `script = "mod:fn"` auto-passes args as kwargs — never name them in the call.)
+- **Env vars → unquoted `${VAR}`**. `${VAR}` compiles to the attribute reference `__env.VAR` (not textual paste), so `expr = "${STAGE}"` ✅ yields the value, but `expr = "'${STAGE}'"` ❌ yields the literal string `"__env.STAGE"`. Call methods directly: `"${STAGE}.upper()"`.
+
+Mechanism and more cases: `references/task-types.md`.
 
 ## Common task patterns
 
-**Simplest task with help**:
-
-```toml
-[tool.poe.tasks.test]
-cmd = "pytest"
-help = "Run the test suite"
-```
-
-**With named arguments**:
+**Named arguments**:
 
 ```toml
 [tool.poe.tasks.test]
@@ -112,23 +94,7 @@ help = "Run the test suite"
 args = [{ name = "markers", options = ["-m"], default = "", help = "pytest marker expression" }]
 ```
 
-**Sequence** (run A then B):
-
-```toml
-[tool.poe.tasks.check]
-sequence = ["lint", "types", "test"]
-help = "Run all quality checks"
-```
-
-**Parallel** (run A and B simultaneously):
-
-```toml
-[tool.poe.tasks.check]
-parallel = ["lint", "types"]
-help = "Run quality checks in parallel"
-```
-
-**Extra args forwarded through a sequence**:
+**Extra args forwarded through a sequence** (only subtasks that name `$POE_EXTRA_ARGS` receive them):
 
 ```toml
 [tool.poe.tasks.check]
@@ -144,42 +110,45 @@ script = "scripts.codegen:main()"
 help = "Run code generation"
 ```
 
-This tasks expects the `scripts.codegen` package to be available in the project's environment, and calls the `main()` function.
+Calls `main()` from the `scripts.codegen` module in the project environment.
+
+For more types (sequence, parallel, switch, …) and options, see the references below.
+
+## The `_` prefix means "internal"
+
+A leading underscore marks something as not part of the public surface:
+
+- **`_task`** — composition-only: hidden from the `poe` listing **and not runnable directly** (`poe _task` errors). Use it via `deps`, `uses`, `ref`, or a sequence/parallel.
+- **`_arg`** — not exported to the environment; its CLI flag drops the underscore (`--arg`).
+- **`_env` / `uses` var** — usable in config expansion but not exported to subprocesses.
 
 ## Creating and modifying tasks
 
-Before creating tasks, read `references/creating-tasks.md` — it covers:
+Read `references/creating-tasks.md` before creating tasks — it covers project-type detection, choosing a task type, bootstrapping the standard set (test/lint/types/format/check), groups, private tasks, and includes. When a tool choice isn't clear from the project (e.g. mypy vs ty, which test runner), ask the user rather than guessing. A few principles matter most:
 
-- Detecting project type (uv vs poetry) and where to add tasks
-- Choosing the right task type
-- Bootstrapping common tasks (test, lint, types, format, check)
-- How to add dependencies correctly (never edit pyproject.toml dependencies directly)
-- How to prompt the user when tool choice is unclear
-- Organizing tasks with groups and private tasks
-- Always run `poe --help task` after creating/modifying a task to confirm it's set up correctly and the help text looks good.
+- **Never hand-edit dependency arrays** in `pyproject.toml` (`[project]`, `[tool.uv]`, `[dependency-groups]`, `[tool.poetry.group.*]`). Use `uv add --dev <pkg>` / `poetry add --group dev <pkg>` so the lockfile stays in sync — this applies to poe itself too.
+- **Don't add `#` comments to task config** unless asked. Task docs belong in `help`, which surfaces in `poe` and `poe --help <task>`; config comments surface nowhere. If a task needs a comment to explain it, rename it, refine its `help`, or split it.
+- **Compose, don't recurse.** To run one task from another, use `deps`, `uses`, `ref`, or a `sequence`/`parallel` — never `cmd = "poe other-task"`. Shelling out spawns a second poe process and hides the dependency from poe (no ordering, dedup, or dry-run visibility), and it can't invoke private `_`-tasks at all.
+- **Leave a clean set.** Delete throwaway tasks you created while developing or debugging before finishing. Aim for a small, intentional set where every task pulls its weight and a newcomer can see why each exists and how they're organized — not a pile of overlapping one-offs.
 
-**Never hand-edit dependency arrays** in `pyproject.toml` (including `[tool.uv].dev-dependencies`, `[dependency-groups]`, and `[tool.poetry.group.*.dependencies]`). Always use `uv add --dev <pkg>` or `poetry add --group dev <pkg>` so the lockfile stays in sync. This applies to poethepoet itself too.
-
-**Don't add comments to task config (TOML/YAML/JSON) unless the user asks.** Task documentation belongs in the `help` field — that's what surfaces in `poe` listing and `poe --help <task>`; config-file `#` comments don't appear anywhere a user looks and just add noise to the config. If a task can't be described in a one-line `help`, simplify or split it rather than reaching for a comment.
+After creating or changing a task, run `poe --help <task>` to confirm it parses and the help text reads well.
 
 ## Key task options
 
-| Option     | Purpose                                                       |
-| ---------- | ------------------------------------------------------------- |
-| `help`     | One-line description shown in `poe` listing — always add this |
-| `args`     | CLI arguments the task accepts                                |
-| `env`      | Environment variables for the task                            |
-| `deps`     | Tasks to run before this one                                  |
-| `uses`     | Capture another task's stdout as a variable                   |
-| `cwd`      | Working directory (relative to project root)                  |
-| `executor` | Override executor: `uv`, `poetry`, `virtualenv`, `simple`     |
+| Option | Purpose |
+| --- | --- |
+| `help` | one-line description shown in `poe` listing — always add this |
+| `args` | CLI arguments the task accepts |
+| `env` | environment variables for the task |
+| `deps` | tasks to run before this one |
+| `uses` | capture another task's stdout as a variable |
+| `cwd` | working directory (relative to project root) |
+| `executor` | override executor: `uv`, `poetry`, `virtualenv`, `simple` |
 
-See `references/task-options.md` for complete options reference.
-See `references/args-reference.md` for the complete args configuration reference.
-See `references/task-packages.md` for using `poethepoet-tasks` and defining reusable task packages with `TaskCollection` and `@tasks.script`.
+- Complete options: `references/task-options.md`
+- Complete args config: `references/args-reference.md`
+- Reusable task packages (`poethepoet-tasks`, `TaskCollection`, `@tasks.script`, composing collections with `.include()`): `references/task-packages.md`
 
 ## IMPORTANT BEST PRACTICE
 
-**This point is very important and you should remember it.** Always check for an existing poe task before running a tool directly, and prefer using poe tasks when available. This ensures you benefit from any project-specific configuration, environment variables, or conventions that the tasks encapsulate — reducing friction and avoiding mistakes.
-
-If a task you need often does not yet exist, consider offering to create it (see `references/creating-tasks.md`) or asking the team to create it rather than running the tool directly.
+**Important — remember this.** Always check for an existing poe task before running a tool directly, and prefer poe tasks when available: you inherit the project's configuration, env, and conventions, avoiding friction and mistakes. If a task you need often doesn't exist yet, offer to create it (see `references/creating-tasks.md`) rather than reaching for the tool directly.

--- a/poethepoet/skills/poethepoet/references/args-reference.md
+++ b/poethepoet/skills/poethepoet/references/args-reference.md
@@ -177,12 +177,14 @@ If no args are declared then all cli arguments are captured as "free args", so a
 ## Defaults from environment variables
 
 ```toml
-args = [{ name = "AWS_REGION", options = ["--region", "-r"] default = "${AWS_DEFAULT_REGION:-us-east-1}" }]
+args = [{ name = "AWS_REGION", options = ["--region", "-r"], default = "${AWS_DEFAULT_REGION:-us-east-1}" }]
 ```
 
 The fact that args are normally exposed as environment variables can be useful when the task explicitly needed, for example calling an arg `"AWS_REGION"` will set that environment variable for all subprocesses of the task.
 
-## If provided the default value will be appended in the help messages automatically.
+If provided, the default value is appended to the help message automatically.
+
+---
 
 ## Constrained choices
 

--- a/poethepoet/skills/poethepoet/references/creating-tasks.md
+++ b/poethepoet/skills/poethepoet/references/creating-tasks.md
@@ -310,7 +310,7 @@ Make the module importable by ensuring `scripts/__init__.py` exists or configuri
 
 ## Private tasks
 
-Prefix task names with `_` to hide them from `poe` listing while keeping them usable for composition:
+Prefix a task name with `_` to make it **composition-only**: it's hidden from the `poe` listing **and cannot be run directly** (`poe _get-bucket-name` errors with "Tasks prefixed with `_` cannot be executed directly"). It exists purely to be referenced by other tasks via `deps`, `uses`, `ref`, or a sequence/parallel.
 
 ```toml
 [tool.poe.tasks._get-bucket-name]
@@ -321,6 +321,37 @@ cmd = "aws s3 sync ./build s3://${_bucket}"
 uses = { _bucket = "_get-bucket-name" }
 help = "Deploy to S3"
 ```
+
+The `_` prefix is the same "internal, not public" convention used by [private args](args-reference.md) (kept out of the environment) and private env/`uses` vars (not exported to subprocesses).
+
+---
+
+## Compose tasks; don't call poe recursively
+
+When a task needs to run another task, compose them with `deps`, `uses`, `ref`, or a `sequence`/`parallel` block. **Don't** invoke poe from inside a task body:
+
+```toml
+# ❌ Don't: shell out to a second poe process
+[tool.poe.tasks.release]
+shell = "poe test && poe build"
+
+# ✅ Do: let poe orchestrate
+[tool.poe.tasks.release]
+sequence = ["test", "build"]
+help = "Test then build"
+```
+
+Invoking poe from inside a task body starts a fresh poe process that re-reads config and re-resolves the executor/venv, and the dependency is invisible to poe's own graph — so you lose dependency dedup, ordering guarantees, dry-run visibility (`poe -d`), and completion. It also can't reach a private `_`-task at all, since those refuse direct invocation.
+
+---
+
+## Keep the task set clean
+
+The finished task set is something a teammate reads to understand the project's workflow, so curate it:
+
+- **Remove scaffolding.** If you created throwaway tasks to experiment or debug while building the real ones, delete them before you finish.
+- **Every task should pull its weight.** Prefer a small set of clearly-purposed tasks over many tiny, overlapping, or one-off ones. If two tasks do nearly the same thing, merge or parameterize them with `args`.
+- **Make the organizing principle legible.** A newcomer skimming `poe` should be able to tell why each task exists and how they group together (use `help` text and, when the list is long, `groups`).
 
 ---
 
@@ -360,10 +391,17 @@ Tasks without a group appear first under an implicit heading.
 
 For large projects with many tasks, you can organize tasks across multiple files and include them. This is useful in monorepo contexts to reuse tasks across multiple python .projects.
 
+The `include` key takes either a single path or a list of paths:
+
 ```toml
-# pyproject.toml
+# pyproject.toml — single file
 [tool.poe]
 include = "tasks/common.toml"
+```
+
+```toml
+# pyproject.toml — multiple files
+[tool.poe]
 include = ["tasks/backend.toml", "tasks/frontend.toml"]
 ```
 

--- a/poethepoet/skills/poethepoet/references/task-packages.md
+++ b/poethepoet/skills/poethepoet/references/task-packages.md
@@ -156,26 +156,50 @@ Useful for composite tasks (like `check`) that should automatically drop exclude
 
 ---
 
-## Mixing task collections
+## Composing collections with `.include()`
 
-Extend or modify an existing `TaskCollection` before including it:
+`TaskCollection.include(other)` merges another collection into this one and returns `self`, so calls chain. Use it to build on a third-party collection **and** to combine several of your own into one.
+
+**There are two ways to combine collections — choose by the flexibility you need:**
+
+- **Multiple `include_script` (or `include`) entries** keep each source independent and configured *in TOML at the consumer*: each entry can carry its own tag filter and args (via the function-ref string), `cwd`, or `executor`. This is the more flexible, declarative option — natural when the sources are independent (different packages/teams) or a monorepo subproject needs its own working directory. The cost: poe spawns a separate Python subprocess per entry, on every invocation including tab completion (noticeable, especially under poetry).
+
+- **Python `.include()` into one collection** merges everything behind a single entry point and a single subprocess. Reach for it when you control the collections and want them merged uniformly, or when startup cost matters — accepting that per-entry TOML knobs (tags, args, `cwd`, `executor`) are no longer available unless you re-express them in code.
+
+The composed form:
 
 ```python
-from poethepoet_tasks import TaskCollection, tasks as base_tasks
+# src/my_tasks/__init__.py
+from poethepoet_tasks import TaskCollection
+from . import backend_tasks, frontend_tasks  # each module exposes a TaskCollection
 
-# Remove a task and replace it:
+tasks = (
+    TaskCollection()
+    .include(backend_tasks.tasks)
+    .include(frontend_tasks.tasks)
+)
+```
+
+```toml
+[tool.poe]
+include_script = "my_tasks:tasks"  # one subprocess, not several
+```
+
+**Precedence is first-registered-wins, per task name.** A task already in the collection outranks one added later by `.include()` (or a later `add`) — `include()` appends the other's tasks below what's already there. So to override a task from an included collection, register your version *first*, or `.remove()` then `.add()` on the imported collection:
+
+```python
+from poethepoet_tasks import tasks as base_tasks
+
+# Override `check` from the base collection before exposing it:
 base_tasks.remove("check")
 base_tasks.add(
     task_name="check",
     task_config={"help": "Lint and types only", "sequence": ["lint", "types"]},
     tags=["lint", "types"],
 )
-
-# Or compose into your own collection (your tasks take precedence):
-my_tasks = TaskCollection()
-my_tasks.add(task_name="build", ...)
-my_tasks.include(base_tasks)  # appended with lower precedence
 ```
+
+`.include()` also merges `env` (existing keys win on conflict), `envfile` (appended, de-duplicated), and any task generators.
 
 ---
 
@@ -193,10 +217,6 @@ tasks.envfile.append(".secrets")
 ```
 
 ---
-
-## Performance note
-
-Each `include_script` entry spawns a Python subprocess to evaluate (even for tab completion). If you're using multiple task packages, merge them into one `TaskCollection` via `.include()` and expose a single entry point rather than listing multiple `include_script` values.
 
 ## Stylistic preferences
 

--- a/tests/skills/run_evals.py
+++ b/tests/skills/run_evals.py
@@ -158,18 +158,29 @@ _COUNTER_EXAMPLE_MARKERS = (
     "not recommended",
 )
 
+# How many preceding lines to scan (in addition to the matched line) when
+# looking for a counter-example marker. A label like ``# Wrong`` or ``❌ broken``
+# is usually a comment or prose line *above* the offending value rather than on
+# the same line — e.g. a ``# Wrong`` comment sitting above a
+# ``[tool.poe.tasks.x]`` header which in turn sits above the value.
+_COUNTER_EXAMPLE_LOOKBACK = 3
+
 
 def _is_labeled_counter_example(text: str, search: str) -> bool:
     """
-    Return True if every occurrence of *search* in *text* sits on a line that
-    also contains a counter-example marker (e.g. "wrong", "broken", "❌"). Used
-    by negate-mode heuristics to avoid penalising responses that show the
-    forbidden pattern as an explicit ❌-labelled contrast rather than as a
-    recommendation.
+    Return True if every occurrence of *search* in *text* falls within a window
+    (the matched line plus the few preceding lines) that contains a
+    counter-example marker (e.g. "wrong", "broken", "❌"). Used by negate-mode
+    heuristics to avoid penalising responses that present the forbidden pattern
+    as an explicit ❌-labelled contrast rather than as a recommendation.
+
+    The window reaches back over preceding lines because the label is commonly
+    above the code, not on the same line (see ``_COUNTER_EXAMPLE_LOOKBACK``).
 
     Conservative: a single un-labelled occurrence means False (recommendation).
     """
     needle = search.lstrip("\n")
+    lines = text.splitlines()
     idx = 0
     found_any = False
     while True:
@@ -177,10 +188,11 @@ def _is_labeled_counter_example(text: str, search: str) -> bool:
         if pos == -1:
             break
         found_any = True
-        line_start = text.rfind("\n", 0, pos) + 1
-        line_end = text.find("\n", pos)
-        line = text[line_start : line_end if line_end != -1 else len(text)].lower()
-        if not any(marker in line for marker in _COUNTER_EXAMPLE_MARKERS):
+        line_no = text.count("\n", 0, pos)
+        window = "\n".join(
+            lines[max(0, line_no - _COUNTER_EXAMPLE_LOOKBACK) : line_no + 1]
+        ).lower()
+        if not any(marker in window for marker in _COUNTER_EXAMPLE_MARKERS):
             return False
         idx = pos + len(needle)
     return found_any

--- a/tests/skills/test_grading.py
+++ b/tests/skills/test_grading.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from run_evals import _check, _is_labeled_counter_example  # noqa: E402
+from run_evals import _check, _is_labeled_counter_example
 
 # The forbidden pattern used by eval-6's negate assertions (on its own line).
 FORBIDDEN = "\nexpr = \"'${STAGE}'\""

--- a/tests/skills/test_grading.py
+++ b/tests/skills/test_grading.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for the eval-runner grading heuristics in ``run_evals.py``.
+
+These guard the counter-example detection used by negate-mode assertions: a
+correct didactic answer that shows a forbidden pattern as a labelled
+``# Wrong`` contrast must not be penalised, while a genuine recommendation of
+the forbidden pattern must still fail.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from run_evals import _check, _is_labeled_counter_example  # noqa: E402
+
+# The forbidden pattern used by eval-6's negate assertions (on its own line).
+FORBIDDEN = "\nexpr = \"'${STAGE}'\""
+
+
+def test_label_on_preceding_line_is_exempt():
+    """
+    A ``# Wrong`` label two lines above the value (with a table header in
+    between) is the real ✅/❌ contrast shape, and must count as labelled.
+
+    This is the eval-6 regression: the old same-line-only check false-failed it.
+    """
+    text = (
+        "```toml\n"
+        "# Correct\n"
+        "[tool.poe.tasks.show]\n"
+        'expr = "${STAGE}"\n'
+        "\n"
+        "# Wrong — yields the literal string\n"
+        "[tool.poe.tasks.show]\n"
+        "expr = \"'${STAGE}'\"\n"
+        "```\n"
+    )
+    assert _is_labeled_counter_example(text, FORBIDDEN) is True
+
+
+def test_same_line_label_is_exempt():
+    text = "expr = \"'${STAGE}'\"  # ❌ broken\n"
+    assert _is_labeled_counter_example(text, FORBIDDEN) is True
+
+
+def test_unlabelled_recommendation_is_not_exempt():
+    text = "Use this:\n```toml\nexpr = \"'${STAGE}'\"\n```\n"
+    assert _is_labeled_counter_example(text, FORBIDDEN) is False
+
+
+def test_marker_too_far_above_is_not_exempt():
+    """A marker beyond the lookback window must not exempt the occurrence."""
+    text = (
+        "# Wrong\n"
+        "filler one\n"
+        "filler two\n"
+        "filler three\n"
+        "expr = \"'${STAGE}'\"\n"
+    )
+    assert _is_labeled_counter_example(text, FORBIDDEN) is False
+
+
+def test_negate_assertion_passes_for_labelled_didactic_answer():
+    """End-to-end via ``_check``: mirrors eval-6's correct with-skill answer."""
+    response = (
+        'No — use `expr = "${STAGE}"` (unquoted).\n\n'
+        "```toml\n"
+        "# Correct\n"
+        'expr = "${STAGE}"\n'
+        '# Wrong — yields the literal string "__env.STAGE"\n'
+        "expr = \"'${STAGE}'\"\n"
+        "```\n"
+    )
+    result = _check(
+        response,
+        "Response does not recommend wrapping the reference in quotes as a fix",
+    )
+    assert result["passed"] is True


### PR DESCRIPTION
Improve the bundled poethepoet Agent Skill, document it for end users, and fix an eval-grader false-fail surfaced while validating the change. All added behaviour is probe- or source-verified.

**Skill**
- Trim `SKILL.md` (~2640 → ~2380 tokens), dropping tutorial bloat duplicated by the reference files
- Reframe the skill `description` to trigger on the action of running a common dev task, not on passively noticing poe config
- Fix three reference bugs: an arg example missing a comma, a stray heading, and an `include` example with duplicate TOML keys
- Consolidate the `_`-prefix convention (private tasks are composition-only and not runnable directly, alongside private args and env)
- Prefer task composition (deps/uses/ref/sequence) over invoking poe recursively from a task body
- Keep the task set curated — remove scratch/debug tasks before finishing
- Frame TaskCollection composition as a flexibility-vs-efficiency tradeoff between multiple `include_script` entries and Python `.include()`
- Offer (with the user's permission) to file an issue when the skill has a gap or surfaces a poe bug

**Docs**
- Add a "Using poethepoet with AI Agents" guide with Claude Code permission and format-on-stop hook examples
- Add an installation section for `poe _install_skill`, GitHub install, and upgrading the skill
- Link the guide from the guides index and list the Agent Skill under Top features (docs index + README)

**Evals**
- Fix a grader false-fail: detect counter-example labels (`# Wrong`, ❌) on lines *preceding* the offending value, not just the same line — a correct didactic answer was scoring below the no-skill baseline (eval-6)
- Add regression tests for the grading heuristics (none existed)

**Follow-ups (not in this PR)**
- Bump the skill `version.txt` (content changed materially)
- Add discovery-style evals (bare "run the tests" in a poe project) to actually exercise the `description` reframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)