### PR TITLE
fix(evals): detect counter-example labels on preceding lines

### DIFF
--- a/tests/skills/run_evals.py
+++ b/tests/skills/run_evals.py
@@ -158,18 +158,29 @@ _COUNTER_EXAMPLE_MARKERS = (
     "not recommended",
 )
 
+# How many preceding lines to scan (in addition to the matched line) when
+# looking for a counter-example marker. A label like ``# Wrong`` or ``❌ broken``
+# is usually a comment or prose line *above* the offending value rather than on
+# the same line — e.g. a ``# Wrong`` comment sitting above a
+# ``[tool.poe.tasks.x]`` header which in turn sits above the value.
+_COUNTER_EXAMPLE_LOOKBACK = 3
+
 
 def _is_labeled_counter_example(text: str, search: str) -> bool:
     """
-    Return True if every occurrence of *search* in *text* sits on a line that
-    also contains a counter-example marker (e.g. "wrong", "broken", "❌"). Used
-    by negate-mode heuristics to avoid penalising responses that show the
-    forbidden pattern as an explicit ❌-labelled contrast rather than as a
-    recommendation.
+    Return True if every occurrence of *search* in *text* falls within a window
+    (the matched line plus the few preceding lines) that contains a
+    counter-example marker (e.g. "wrong", "broken", "❌"). Used by negate-mode
+    heuristics to avoid penalising responses that present the forbidden pattern
+    as an explicit ❌-labelled contrast rather than as a recommendation.
+
+    The window reaches back over preceding lines because the label is commonly
+    above the code, not on the same line (see ``_COUNTER_EXAMPLE_LOOKBACK``).
 
     Conservative: a single un-labelled occurrence means False (recommendation).
     """
     needle = search.lstrip("\n")
+    lines = text.splitlines()
     idx = 0
     found_any = False
     while True:
@@ -177,10 +188,11 @@ def _is_labeled_counter_example(text: str, search: str) -> bool:
         if pos == -1:
             break
         found_any = True
-        line_start = text.rfind("\n", 0, pos) + 1
-        line_end = text.find("\n", pos)
-        line = text[line_start : line_end if line_end != -1 else len(text)].lower()
-        if not any(marker in line for marker in _COUNTER_EXAMPLE_MARKERS):
+        line_no = text.count("\n", 0, pos)
+        window = "\n".join(
+            lines[max(0, line_no - _COUNTER_EXAMPLE_LOOKBACK) : line_no + 1]
+        ).lower()
+        if not any(marker in window for marker in _COUNTER_EXAMPLE_MARKERS):
             return False
         idx = pos + len(needle)
     return found_any

--- a/tests/skills/test_grading.py
+++ b/tests/skills/test_grading.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for the eval-runner grading heuristics in ``run_evals.py``.
+
+These guard the counter-example detection used by negate-mode assertions: a
+correct didactic answer that shows a forbidden pattern as a labelled
+``# Wrong`` contrast must not be penalised, while a genuine recommendation of
+the forbidden pattern must still fail.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from run_evals import _check, _is_labeled_counter_example  # noqa: E402
+
+# The forbidden pattern used by eval-6's negate assertions (on its own line).
+FORBIDDEN = "\nexpr = \"'${STAGE}'\""
+
+
+def test_label_on_preceding_line_is_exempt():
+    """
+    A ``# Wrong`` label two lines above the value (with a table header in
+    between) is the real ✅/❌ contrast shape, and must count as labelled.
+
+    This is the eval-6 regression: the old same-line-only check false-failed it.
+    """
+    text = (
+        "```toml\n"
+        "# Correct\n"
+        "[tool.poe.tasks.show]\n"
+        'expr = "${STAGE}"\n'
+        "\n"
+        "# Wrong — yields the literal string\n"
+        "[tool.poe.tasks.show]\n"
+        "expr = \"'${STAGE}'\"\n"
+        "```\n"
+    )
+    assert _is_labeled_counter_example(text, FORBIDDEN) is True
+
+
+def test_same_line_label_is_exempt():
+    text = "expr = \"'${STAGE}'\"  # ❌ broken\n"
+    assert _is_labeled_counter_example(text, FORBIDDEN) is True
+
+
+def test_unlabelled_recommendation_is_not_exempt():
+    text = "Use this:\n```toml\nexpr = \"'${STAGE}'\"\n```\n"
+    assert _is_labeled_counter_example(text, FORBIDDEN) is False
+
+
+def test_marker_too_far_above_is_not_exempt():
+    """A marker beyond the lookback window must not exempt the occurrence."""
+    text = (
+        "# Wrong\n"
+        "filler one\n"
+        "filler two\n"
+        "filler three\n"
+        "expr = \"'${STAGE}'\"\n"
+    )
+    assert _is_labeled_counter_example(text, FORBIDDEN) is False
+
+
+def test_negate_assertion_passes_for_labelled_didactic_answer():
+    """End-to-end via ``_check``: mirrors eval-6's correct with-skill answer."""
+    response = (
+        "No — use `expr = \"${STAGE}\"` (unquoted).\n\n"
+        "```toml\n"
+        "# Correct\n"
+        'expr = "${STAGE}"\n'
+        "# Wrong — yields the literal string \"__env.STAGE\"\n"
+        "expr = \"'${STAGE}'\"\n"
+        "```\n"
+    )
+    result = _check(
+        response,
+        "Response does not recommend wrapping the reference in quotes as a fix",
+    )
+    assert result["passed"] is True


### PR DESCRIPTION
Fix a false-fail in the skill eval grader, surfaced by the latest eval run (eval-6 scored *below* the no-skill baseline despite a correct answer).

- Scan a small window of preceding lines for a counter-example marker, not just the matched line — labels like `# Wrong` typically sit a line or two *above* the offending value (the usual ✅/❌ contrast block)
- Leave the line-start `found` matching unchanged, so eval-7's negate assertion is unaffected
- Add regression tests for the grading heuristics (none existed)

Does not touch the skill or its content; this is eval-harness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)