### PR TITLE
fix(args): restore default for absent multiple positional args

### DIFF
--- a/poethepoet/task/args.py
+++ b/poethepoet/task/args.py
@@ -521,7 +521,7 @@ class PoeTaskArgs:
             # and the first entry of `options` for positionals (argparse default).
             key = arg.options[0] if arg.positional else arg.name
             value = parsed_args.get(key)
-            if value is None:
+            if value is None or (arg.positional and value == []):
                 continue
             if len(value) != multi:
                 parser.error(
@@ -535,12 +535,6 @@ class PoeTaskArgs:
         """
         Surface every ``multiple`` arg as a list, applying its configured
         default when the arg was absent.
-
-        argparse leaves an absent ``multiple`` arg as ``None`` (its default is
-        kept empty so ``action="extend"`` doesn't prepend onto supplied
-        values). Here ``None`` becomes the configured default wrapped in a list,
-        or ``[]`` when no default is set — so scripts always receive a list and
-        env-var exposure stays consistent.
         """
         for arg in self._args:
             if not arg.multiple:
@@ -548,7 +542,9 @@ class PoeTaskArgs:
             # dest is `arg.name` for option args and `arg.options[0]` for
             # positionals, matching `_validate_exact_count`.
             key = arg.options[0] if arg.positional else arg.name
-            if parsed_args.get(key) is not None:
+            value = parsed_args.get(key)
+            if value is not None and not (arg.positional and value == []):
+                # Position arg with multiple=True arrives as []
                 continue
             default = arg.get("default")
             if default is None:

--- a/poethepoet/task/args.py
+++ b/poethepoet/task/args.py
@@ -544,7 +544,8 @@ class PoeTaskArgs:
             key = arg.options[0] if arg.positional else arg.name
             value = parsed_args.get(key)
             if value is not None and not (arg.positional and value == []):
-                # Position arg with multiple=True arrives as []
+                # Omitted option arg with multiple=True arrives as None
+                # Omitted positional arg with multiple=True arrives as []
                 continue
             default = arg.get("default")
             if default is None:

--- a/tests/fixtures/cmds_project/pyproject.toml
+++ b/tests/fixtures/cmds_project/pyproject.toml
@@ -43,6 +43,23 @@ positional = true
 multiple = true
 type = "integer"
 
+[tool.poe.tasks.multiple-positional-default]
+cmd = "poe_test_echo $files"
+
+[[tool.poe.tasks.multiple-positional-default.args]]
+name = "files"
+positional = true
+multiple = true
+default = "src tests"
+
+[tool.poe.tasks.multiple-pair-positional]
+cmd = "poe_test_echo coords $coords"
+
+[[tool.poe.tasks.multiple-pair-positional.args]]
+name = "coords"
+positional = true
+multiple = 2
+
 [tool.poe.tasks.meeseeks]
 cmd = """poe_test_echo "I'm Mr. Meeseeks! Look at me!" """
 capture_stdout = "${POE_PWD}/message.txt"

--- a/tests/fixtures/scripts_project/pyproject.toml
+++ b/tests/fixtures/scripts_project/pyproject.toml
@@ -149,6 +149,15 @@ default = "base"
 name = "pair"
 multiple = 2
 
+[tool.poe.tasks.multiple-positional-default]
+script = "pkg:echo_script(files=files)"
+
+[[tool.poe.tasks.multiple-positional-default.args]]
+name = "files"
+positional = true
+multiple = true
+default = "src tests"
+
 [tool.poe.tasks.multiple-lines-help]
 script = "pkg:echo_script(first, second, widgets=widgets, engines=engines)"
 help = """

--- a/tests/schema/test_smoke.py
+++ b/tests/schema/test_smoke.py
@@ -203,7 +203,7 @@ def test_build_schema_script_module_forbids_print_result() -> None:
     variant = schema["definitions"]["script_task"]
     expected_clause = {
         "if": {
-            "properties": {"script": {"pattern": "^[^:]*$"}},
+            "properties": {"script": {"pattern": "^[^:]*$", "type": "string"}},
             "required": ["script"],
         },
         "then": {"properties": {"print_result": False}},

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,6 +224,8 @@ def test_documentation_of_task_named_args(run_poe):
         r"    --plain               \s+\n"
         r"    --defaulted           \s+\[default: base\]\n"
         r"    --pair                \s+\n"
+        r"  multiple-positional-default\s+\n"
+        r"    files                 \s+\[default: src tests\]\n"
         r"  multiple-lines-help     \s+Multilines\n"
         r"                            \s+Creating multi-line documentation for greater"
         " detail and inclusion of examples\n"

--- a/tests/test_cmd_tasks.py
+++ b/tests/test_cmd_tasks.py
@@ -63,6 +63,33 @@ def test_cmd_task_with_multiple_value_arg(run_poe):
     assert result.stderr == ""
 
 
+def test_cmd_multiple_positional_default_reaches_command_line(run_poe):
+    # End-to-end mirror of the 0.47.0 break: an absent `multiple` positional
+    # with a default must still reach the command line. The default "src tests"
+    # is exposed as an env var and word-split into two `$files` tokens.
+    result = run_poe("multiple-positional-default", project="cmds")
+    assert result.capture == "Poe => poe_test_echo src tests\n"
+    assert result.stdout == "src tests\n"
+    assert result.stderr == ""
+
+
+def test_cmd_multiple_positional_default_is_overridden(run_poe):
+    # Supplied values replace the default rather than extending it.
+    result = run_poe("multiple-positional-default", "a", "b", project="cmds")
+    assert result.capture == "Poe => poe_test_echo a b\n"
+    assert result.stdout == "a b\n"
+    assert result.stderr == ""
+
+
+def test_cmd_multiple_n_positional_absent_is_empty_not_error(run_poe):
+    # An absent (not required) `multiple = N` positional resolves to empty
+    # rather than tripping the "expected N values, got 0" exact-count check.
+    result = run_poe("multiple-pair-positional", project="cmds")
+    assert result.capture == "Poe => poe_test_echo coords\n"
+    assert result.stdout == "coords\n"
+    assert result.stderr == ""
+
+
 def test_cmd_task_with_cwd_option(run_poe, poe_project_path):
     result = run_poe("cwd", project="cwd")
     assert result.capture == "Poe => poe_test_pwd\n"

--- a/tests/test_script_tasks.py
+++ b/tests/test_script_tasks.py
@@ -528,6 +528,32 @@ def test_multiple_arg_scalar_default_is_overridden_not_extended(run_poe):
     assert result.stderr == ""
 
 
+def test_multiple_positional_arg_applies_scalar_default(run_poe):
+    # Regression (0.47.0): an absent `multiple` positional surfaces as [] from
+    # argparse, not None like options, so its configured default was dropped.
+    # The default must still apply -> ['src tests'].
+    result = run_poe(
+        "multiple-positional-default",
+        project="scripts",
+        env=no_venv,
+    )
+    assert result.stdout == "args ()\nkwargs {'files': ['src tests']}\n"
+    assert result.stderr == ""
+
+
+def test_multiple_positional_arg_default_is_overridden(run_poe):
+    # Supplied positional values must replace the default, not extend it.
+    result = run_poe(
+        "multiple-positional-default",
+        "a",
+        "b",
+        project="scripts",
+        env=no_venv,
+    )
+    assert result.stdout == "args ()\nkwargs {'files': ['a', 'b']}\n"
+    assert result.stderr == ""
+
+
 def test_async_script_task(run_poe, projects):
     result = run_poe(
         "async-task",


### PR DESCRIPTION
## What

- An absent positional arg declared with `multiple` no longer drops its configured `default`.

## Why

- 0.47.0's multi-value arg rework applies defaults only when argparse yields `None`.
- argparse collapses an absent `nargs="*"` **positional** to `[]`, not `None`, so its default was silently skipped.
- e.g. `cmd = "mypy $files"` with `default = "src tests"` expanded to `mypy` with no target.

## Fix

- Treat a positional's `[]` as absent (a positional can't be given an explicit empty), restoring the default.
- Leave an explicitly-emptied option's `[]` intact.
- Guard `_validate_exact_count` so an absent `multiple = N` positional doesn't trip a spurious "expected N values, got 0".

## Tests

- New scripts fixture: positional `multiple` arg with a default; covers default-applied and explicit-override cases.
- New cmd-task coverage mirroring the reported break end-to-end (default resolves through env-var exposure and `$files` word-splitting): default reaches the command line, supplied values override, absent `multiple = N` resolves to empty rather than erroring.

## Unrelated

- Aligns a stale `print_result` schema-clause assertion with the generator output (`"type": "string"` added in `d2f9c11`), which was already failing on `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)